### PR TITLE
[BE][BOM-23] feat: 뉴스레터 목록 조회 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
@@ -24,9 +24,10 @@ public class Article extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String title;
 
-    @Column(length = 512)
+    @Column(length = 512, nullable = false)
     private String articleUrl;
 
     @Column(length = 512)
@@ -35,13 +36,18 @@ public class Article extends BaseEntity {
     @Column(columnDefinition = "tinyint")
     private int expectedReadTime;
 
+    @Column(nullable = false)
     private String contentsSummary;
 
-    private boolean isRead;
+    @Column(columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean isRead = false;
 
+    @Column(nullable = false)
     private Long memberId;
 
+    @Column(nullable = false)
     private Long newsletterId;
 
+    @Column(nullable = false)
     private LocalDateTime arrivedDateTime;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/ContinueReading.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/ContinueReading.java
@@ -25,8 +25,9 @@ public class ContinueReading extends BaseEntity {
     private Long id;
 
     @UniqueElements
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private Long memberId;
 
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private int dayCount;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
@@ -32,16 +32,18 @@ public class Member extends BaseEntity {
     private String email;
 
     @UniqueElements
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private String nickname;
 
     @Column(length = 512)
-    private String profileUrl;
+    private String profileImageUrl;
 
     private LocalDateTime birthDate;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    private Long roleId;
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+    private Long roleId = 0L;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Role.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Role.java
@@ -22,6 +22,6 @@ public class Role {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 20)
+    @Column(length = 20, nullable = false)
     private String authority;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/WeeklyGoal.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/WeeklyGoal.java
@@ -25,12 +25,12 @@ public class WeeklyGoal extends BaseEntity {
     private Long id;
 
     @UniqueElements
-    @Column(unique = true)
+    @Column(unique = true, nullable = false)
     private Long memberId;
 
-    @Column(columnDefinition = "tinyint")
+    @Column(columnDefinition = "TINYINT", nullable = false)
     private int weeklyGoalCount;
 
-    @Column(columnDefinition = "tinyint")
+    @Column(columnDefinition = "TINYINT DEFAULT 0", nullable = false)
     private int currentCount;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/controller/NewsletterController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/controller/NewsletterController.java
@@ -1,0 +1,20 @@
+package me.bombom.api.v1.newsletter.controller;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
+import me.bombom.api.v1.newsletter.service.NewsletterService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class NewsletterController {
+
+    private final NewsletterService newsletterService;
+
+    @GetMapping("/api/v1/newsletters")
+    public List<NewsletterResponse> getNewsletters() {
+        return newsletterService.getNewsletters();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/controller/NewsletterController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/controller/NewsletterController.java
@@ -5,15 +5,17 @@ import lombok.AllArgsConstructor;
 import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
 import me.bombom.api.v1.newsletter.service.NewsletterService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
+@RequestMapping("/api/v1/newsletters")
 public class NewsletterController {
 
     private final NewsletterService newsletterService;
 
-    @GetMapping("/api/v1/newsletters")
+    @GetMapping
     public List<NewsletterResponse> getNewsletters() {
         return newsletterService.getNewsletters();
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Category.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Category.java
@@ -22,6 +22,6 @@ public class Category {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 20)
+    @Column(length = 20, nullable = false)
     private String name;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Newsletter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Newsletter.java
@@ -6,16 +6,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import me.bombom.api.v1.common.BaseEntity;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Newsletter extends BaseEntity {
 
@@ -25,23 +23,34 @@ public class Newsletter extends BaseEntity {
 
     private String name;
 
+    private String description;
+
     @Column(length = 512)
     private String imageUrl;
 
     @Column(length = 30)
     private String email;
 
-    private String description;
-
-    @Column(length=512)
-    private String mainUrl;
-
-    @Column(length=512)
-    private String subscribeUrl;
-
-    private String issueCycle;
-
     private Long categoryId;
 
-    private int subscribeCount;
+    private Long detailId;
+
+    @Builder
+    public Newsletter(
+            Long id,
+            @NonNull String name,
+            @NonNull String description,
+            @NonNull String imageUrl,
+            @NonNull String email,
+            @NonNull Long categoryId,
+            @NonNull Long detailId
+    ) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.email = email;
+        this.categoryId = categoryId;
+        this.detailId = detailId;
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Newsletter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Newsletter.java
@@ -17,7 +17,7 @@ import me.bombom.api.v1.common.BaseEntity;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class NewsLetter extends BaseEntity {
+public class Newsletter extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -42,4 +42,6 @@ public class NewsLetter extends BaseEntity {
     private String issueCycle;
 
     private Long categoryId;
+
+    private int subscribeCount;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Newsletter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Newsletter.java
@@ -20,19 +20,23 @@ public class Newsletter extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
+    
+    @Column(nullable = false)
     private String name;
 
+    @Column(nullable = false)
     private String description;
 
-    @Column(length = 512)
+    @Column(length = 512, nullable = false)
     private String imageUrl;
 
-    @Column(length = 30)
+    @Column(length = 30, nullable = false)
     private String email;
 
+    @Column(nullable = false)
     private Long categoryId;
 
+    @Column(nullable = false)
     private Long detailId;
 
     @Builder

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/NewsletterDetail.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/NewsletterDetail.java
@@ -20,14 +20,16 @@ public class NewsletterDetail {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length=512)
+    @Column(length=512, nullable = false)
     private String mainPageUrl;
 
-    @Column(length=512)
+    @Column(length=512, nullable = false)
     private String subscribeUrl;
 
+    @Column(nullable = false)
     private String issueCycle;
 
+    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private int subscribeCount;
 
     @Builder

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/NewsletterDetail.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/NewsletterDetail.java
@@ -1,0 +1,47 @@
+package me.bombom.api.v1.newsletter.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NewsletterDetail {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length=512)
+    private String mainPageUrl;
+
+    @Column(length=512)
+    private String subscribeUrl;
+
+    private String issueCycle;
+
+    private int subscribeCount;
+
+    @Builder
+    public NewsletterDetail(
+            Long id,
+            @NonNull String mainPageUrl,
+            @NonNull String subscribeUrl,
+            @NonNull String issueCycle,
+            int subscribeCount
+    ) {
+        this.id = id;
+        this.mainPageUrl = mainPageUrl;
+        this.subscribeUrl = subscribeUrl;
+        this.issueCycle = issueCycle;
+        this.subscribeCount = subscribeCount;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/dto/NewsletterResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/dto/NewsletterResponse.java
@@ -1,0 +1,24 @@
+package me.bombom.api.v1.newsletter.dto;
+
+import java.util.List;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+
+public record NewsletterResponse(
+        Long newsletterId,
+        String name,
+        String imageUrl,
+        String description,
+        String mainUrl
+) {
+    public static List<NewsletterResponse> from(List<Newsletter> newsletters) {
+        return newsletters.stream()
+                .map(NewsletterResponse::from)
+                .toList();
+    }
+
+   public static NewsletterResponse from(Newsletter newsLetter) {
+       return new NewsletterResponse(newsLetter.getId(), newsLetter.getName(),
+               newsLetter.getImageUrl(), newsLetter.getDescription(),
+               newsLetter.getMainUrl());
+   }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/dto/NewsletterResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/dto/NewsletterResponse.java
@@ -1,24 +1,10 @@
 package me.bombom.api.v1.newsletter.dto;
 
-import java.util.List;
-import me.bombom.api.v1.newsletter.domain.Newsletter;
-
 public record NewsletterResponse(
         Long newsletterId,
         String name,
         String imageUrl,
         String description,
-        String mainUrl
+        String mainPageUrl
 ) {
-    public static List<NewsletterResponse> from(List<Newsletter> newsletters) {
-        return newsletters.stream()
-                .map(NewsletterResponse::from)
-                .toList();
-    }
-
-   public static NewsletterResponse from(Newsletter newsLetter) {
-       return new NewsletterResponse(newsLetter.getId(), newsLetter.getName(),
-               newsLetter.getImageUrl(), newsLetter.getDescription(),
-               newsLetter.getMainUrl());
-   }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/repository/NewsletterDetailRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/repository/NewsletterDetailRepository.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.newsletter.repository;
+
+import me.bombom.api.v1.newsletter.domain.NewsletterDetail;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsletterDetailRepository extends JpaRepository<NewsletterDetail, Long> {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/repository/NewsletterRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/repository/NewsletterRepository.java
@@ -1,0 +1,10 @@
+package me.bombom.api.v1.newsletter.repository;
+
+import java.util.List;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
+
+    List<Newsletter> findAllByOrderBySubscribeCountDescNameAsc();
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/repository/NewsletterRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/repository/NewsletterRepository.java
@@ -2,9 +2,19 @@ package me.bombom.api.v1.newsletter.repository;
 
 import java.util.List;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
 
-    List<Newsletter> findAllByOrderBySubscribeCountDescNameAsc();
+    @Query("""
+        SELECT new me.bombom.api.v1.newsletter.dto.NewsletterResponse( 
+                n.id, n.name, n.imageUrl, n.description, d.mainPageUrl
+            )
+        FROM Newsletter n
+        JOIN NewsletterDetail d ON n.detailId = d.id
+        ORDER BY d.subscribeCount DESC, n.name ASC
+    """)
+    List<NewsletterResponse> findNewslettersInfo();
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/service/NewsletterService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/service/NewsletterService.java
@@ -3,24 +3,23 @@ package me.bombom.api.v1.newsletter.service;
 import java.util.Collections;
 import java.util.List;
 import lombok.AllArgsConstructor;
-import me.bombom.api.v1.newsletter.domain.Newsletter;
 import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
 @AllArgsConstructor
+@Transactional(readOnly = true)
 public class NewsletterService {
 
     private final NewsletterRepository newsletterRepository;
 
     public List<NewsletterResponse> getNewsletters() {
-        List<Newsletter> newsletters = newsletterRepository.findAllByOrderBySubscribeCountDescNameAsc();
+        //임시로 repository 메서드 내부에 Detail 정보 가져오는 것이 불필요
+        List<NewsletterResponse> newsletters = newsletterRepository.findNewslettersInfo();
 
         Collections.shuffle(newsletters); //초기엔 셔플해서 랜덤 순서로 보여주기
-
-        return NewsletterResponse.from(newsletters);
+        return newsletters;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/service/NewsletterService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/service/NewsletterService.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.newsletter.service;
+
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
+import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@AllArgsConstructor
+public class NewsletterService {
+
+    private final NewsletterRepository newsletterRepository;
+
+    public List<NewsletterResponse> getNewsletters() {
+        List<Newsletter> newsletters = newsletterRepository.findAllByOrderBySubscribeCountDescNameAsc();
+
+        Collections.shuffle(newsletters); //초기엔 셔플해서 랜덤 순서로 보여주기
+
+        return NewsletterResponse.from(newsletters);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/service/NewsletterService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/service/NewsletterService.java
@@ -18,7 +18,6 @@ public class NewsletterService {
     public List<NewsletterResponse> getNewsletters() {
         //임시로 repository 메서드 내부에 Detail 정보 가져오는 것이 불필요
         List<NewsletterResponse> newsletters = newsletterRepository.findNewslettersInfo();
-
         Collections.shuffle(newsletters); //초기엔 셔플해서 랜덤 순서로 보여주기
         return newsletters;
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/Subscribe.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/Subscribe.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.subscribe.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -22,7 +23,9 @@ public class Subscribe extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private Long newsletterId;
 
+    @Column(nullable = false)
     private Long memberId;
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
@@ -1,0 +1,160 @@
+package me.bombom.api.v1.newsletter.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
+import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class NewsletterServiceTest {
+
+    @Autowired
+    private NewsletterService newsletterService;
+
+    @Autowired
+    private NewsletterRepository newsletterRepository;
+
+    List<Newsletter> newsletters;
+
+    @BeforeEach
+    public void setup() {
+        newsletters = List.of(
+                Newsletter.builder()
+                        .name("뉴스픽")
+                        .email("news@newspick.com")
+                        .imageUrl("https://cdn.bombom.me/images/news1.png")
+                        .description("하루 5분, 세상의 주요 뉴스를 요약해드립니다.")
+                        .mainUrl("https://newspick.com")
+                        .subscribeUrl("https://newspick.com/subscribe")
+                        .issueCycle("매일 아침")
+                        .categoryId(1L)
+                        .subscribeCount(950)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("IT타임즈")
+                        .email("editor@ittimes.io")
+                        .imageUrl("https://cdn.bombom.me/images/news2.png")
+                        .description("IT 이슈와 트렌드를 주간 단위로 전합니다.")
+                        .mainUrl("https://ittimes.io")
+                        .subscribeUrl("https://ittimes.io/subscribe")
+                        .issueCycle("매주 월요일")
+                        .categoryId(2L)
+                        .subscribeCount(770)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("비즈레터")
+                        .email("biz@bizletter.com")
+                        .imageUrl("https://cdn.bombom.me/images/news3.png")
+                        .description("비즈니스 인사이트를 쉽게 전달합니다.")
+                        .mainUrl("https://bizletter.com")
+                        .subscribeUrl("https://bizletter.com/subscribe")
+                        .issueCycle("격주 화요일")
+                        .categoryId(3L)
+                        .subscribeCount(620)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("헬스레터")
+                        .email("health@healthletter.kr")
+                        .imageUrl("https://cdn.bombom.me/images/news4.png")
+                        .description("건강 정보와 운동 팁을 소개합니다.")
+                        .mainUrl("https://healthletter.kr")
+                        .subscribeUrl("https://healthletter.kr/join")
+                        .issueCycle("매주 토요일")
+                        .categoryId(4L)
+                        .subscribeCount(540)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("브랜드다움")
+                        .email("brand@daum.com")
+                        .imageUrl("https://cdn.bombom.me/images/news5.png")
+                        .description("브랜딩과 마케팅 전략을 공유합니다.")
+                        .mainUrl("https://branddaum.com")
+                        .subscribeUrl("https://branddaum.com/join")
+                        .issueCycle("매주 금요일")
+                        .categoryId(3L)
+                        .subscribeCount(810)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("테크투데이")
+                        .email("tech@today.io")
+                        .imageUrl("https://cdn.bombom.me/images/news6.png")
+                        .description("최신 테크 소식을 큐레이션합니다.")
+                        .mainUrl("https://techtoday.io")
+                        .subscribeUrl("https://techtoday.io/subscribe")
+                        .issueCycle("매일")
+                        .categoryId(2L)
+                        .subscribeCount(880)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("UX Digest")
+                        .email("ux@digest.io")
+                        .imageUrl("https://cdn.bombom.me/images/news7.png")
+                        .description("UX 관련 아티클과 인사이트를 전달합니다.")
+                        .mainUrl("https://uxdigest.io")
+                        .subscribeUrl("https://uxdigest.io/join")
+                        .issueCycle("매주 목요일")
+                        .categoryId(5L)
+                        .subscribeCount(400)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("정치읽기")
+                        .email("info@readpolitics.org")
+                        .imageUrl("https://cdn.bombom.me/images/news8.png")
+                        .description("정치 이슈를 쉽게 설명해드립니다.")
+                        .mainUrl("https://readpolitics.org")
+                        .subscribeUrl("https://readpolitics.org/subscribe")
+                        .issueCycle("매주 일요일")
+                        .categoryId(5L)
+                        .subscribeCount(510)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("아트위클리")
+                        .email("art@weekly.net")
+                        .imageUrl("https://cdn.bombom.me/images/news9.png")
+                        .description("예술 전시와 뉴스를 큐레이션합니다.")
+                        .mainUrl("https://artweekly.net")
+                        .subscribeUrl("https://artweekly.net/subscribe")
+                        .issueCycle("격주 목요일")
+                        .categoryId(4L)
+                        .subscribeCount(350)
+                        .build(),
+
+                Newsletter.builder()
+                        .name("개발자 다이어리")
+                        .email("dev@diary.dev")
+                        .imageUrl("https://cdn.bombom.me/images/news10.png")
+                        .description("개발자가 직접 전하는 실무 팁")
+                        .mainUrl("https://diary.dev")
+                        .subscribeUrl("https://diary.dev/subscribe")
+                        .issueCycle("매주 수요일")
+                        .categoryId(1L)
+                        .subscribeCount(770)
+                        .build()
+        );
+
+        newsletterRepository.saveAll(newsletters);
+    }
+
+    @Test
+    void 뉴스레터를_모두_조회할_수_있다() {
+        //when
+        List<NewsletterResponse> result = newsletterService.getNewsletters();
+
+        //then
+        assertThat(result.size()).isEqualTo(newsletters.size());
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
@@ -11,9 +11,11 @@ import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 
-@SpringBootTest
+@DataJpaTest
+@Import(NewsletterService.class)
 class NewsletterServiceTest {
 
     @Autowired

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.domain.NewsletterDetail;
 import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
+import me.bombom.api.v1.newsletter.repository.NewsletterDetailRepository;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,130 +22,61 @@ class NewsletterServiceTest {
     @Autowired
     private NewsletterRepository newsletterRepository;
 
+    @Autowired
+    private NewsletterDetailRepository newsletterDetailRepository;
+
     List<Newsletter> newsletters;
 
     @BeforeEach
     public void setup() {
+        List<NewsletterDetail> newsletterDetails = List.of(
+            NewsletterDetail.builder()
+                    .mainPageUrl("https://news1.com")
+                    .subscribeUrl("https://news1.com/subscribe")
+                    .issueCycle("매일")
+                    .subscribeCount(1000)
+                    .build(),
+            NewsletterDetail.builder()
+                    .mainPageUrl("https://ittimes.com")
+                    .subscribeUrl("https://ittimes.com/subscribe")
+                    .issueCycle("매주 월요일")
+                    .subscribeCount(850)
+                    .build(),
+            NewsletterDetail.builder()
+                    .mainPageUrl("https://biz.com")
+                    .subscribeUrl("https://biz.com/subscribe")
+                    .issueCycle("격주 화요일")
+                    .subscribeCount(600)
+                    .build()
+            );
+
+        newsletterDetailRepository.saveAll(newsletterDetails);
+
         newsletters = List.of(
-                Newsletter.builder()
-                        .name("뉴스픽")
-                        .email("news@newspick.com")
-                        .imageUrl("https://cdn.bombom.me/images/news1.png")
-                        .description("하루 5분, 세상의 주요 뉴스를 요약해드립니다.")
-                        .mainUrl("https://newspick.com")
-                        .subscribeUrl("https://newspick.com/subscribe")
-                        .issueCycle("매일 아침")
-                        .categoryId(1L)
-                        .subscribeCount(950)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("IT타임즈")
-                        .email("editor@ittimes.io")
-                        .imageUrl("https://cdn.bombom.me/images/news2.png")
-                        .description("IT 이슈와 트렌드를 주간 단위로 전합니다.")
-                        .mainUrl("https://ittimes.io")
-                        .subscribeUrl("https://ittimes.io/subscribe")
-                        .issueCycle("매주 월요일")
-                        .categoryId(2L)
-                        .subscribeCount(770)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("비즈레터")
-                        .email("biz@bizletter.com")
-                        .imageUrl("https://cdn.bombom.me/images/news3.png")
-                        .description("비즈니스 인사이트를 쉽게 전달합니다.")
-                        .mainUrl("https://bizletter.com")
-                        .subscribeUrl("https://bizletter.com/subscribe")
-                        .issueCycle("격주 화요일")
-                        .categoryId(3L)
-                        .subscribeCount(620)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("헬스레터")
-                        .email("health@healthletter.kr")
-                        .imageUrl("https://cdn.bombom.me/images/news4.png")
-                        .description("건강 정보와 운동 팁을 소개합니다.")
-                        .mainUrl("https://healthletter.kr")
-                        .subscribeUrl("https://healthletter.kr/join")
-                        .issueCycle("매주 토요일")
-                        .categoryId(4L)
-                        .subscribeCount(540)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("브랜드다움")
-                        .email("brand@daum.com")
-                        .imageUrl("https://cdn.bombom.me/images/news5.png")
-                        .description("브랜딩과 마케팅 전략을 공유합니다.")
-                        .mainUrl("https://branddaum.com")
-                        .subscribeUrl("https://branddaum.com/join")
-                        .issueCycle("매주 금요일")
-                        .categoryId(3L)
-                        .subscribeCount(810)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("테크투데이")
-                        .email("tech@today.io")
-                        .imageUrl("https://cdn.bombom.me/images/news6.png")
-                        .description("최신 테크 소식을 큐레이션합니다.")
-                        .mainUrl("https://techtoday.io")
-                        .subscribeUrl("https://techtoday.io/subscribe")
-                        .issueCycle("매일")
-                        .categoryId(2L)
-                        .subscribeCount(880)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("UX Digest")
-                        .email("ux@digest.io")
-                        .imageUrl("https://cdn.bombom.me/images/news7.png")
-                        .description("UX 관련 아티클과 인사이트를 전달합니다.")
-                        .mainUrl("https://uxdigest.io")
-                        .subscribeUrl("https://uxdigest.io/join")
-                        .issueCycle("매주 목요일")
-                        .categoryId(5L)
-                        .subscribeCount(400)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("정치읽기")
-                        .email("info@readpolitics.org")
-                        .imageUrl("https://cdn.bombom.me/images/news8.png")
-                        .description("정치 이슈를 쉽게 설명해드립니다.")
-                        .mainUrl("https://readpolitics.org")
-                        .subscribeUrl("https://readpolitics.org/subscribe")
-                        .issueCycle("매주 일요일")
-                        .categoryId(5L)
-                        .subscribeCount(510)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("아트위클리")
-                        .email("art@weekly.net")
-                        .imageUrl("https://cdn.bombom.me/images/news9.png")
-                        .description("예술 전시와 뉴스를 큐레이션합니다.")
-                        .mainUrl("https://artweekly.net")
-                        .subscribeUrl("https://artweekly.net/subscribe")
-                        .issueCycle("격주 목요일")
-                        .categoryId(4L)
-                        .subscribeCount(350)
-                        .build(),
-
-                Newsletter.builder()
-                        .name("개발자 다이어리")
-                        .email("dev@diary.dev")
-                        .imageUrl("https://cdn.bombom.me/images/news10.png")
-                        .description("개발자가 직접 전하는 실무 팁")
-                        .mainUrl("https://diary.dev")
-                        .subscribeUrl("https://diary.dev/subscribe")
-                        .issueCycle("매주 수요일")
-                        .categoryId(1L)
-                        .subscribeCount(770)
-                        .build()
+            Newsletter.builder()
+                    .name("뉴스픽")
+                    .description("뉴스픽 요약 뉴스")
+                    .imageUrl("https://cdn.bombom.me/img1.png")
+                    .email("news@newspick.com")
+                    .categoryId(1L)
+                    .detailId(1L)
+                    .build(),
+            Newsletter.builder()
+                    .name("IT타임즈")
+                    .description("IT 업계 트렌드")
+                    .imageUrl("https://cdn.bombom.me/img2.png")
+                    .email("editor@ittimes.io")
+                    .categoryId(2L)
+                    .detailId(2L)
+                    .build(),
+            Newsletter.builder()
+                    .name("비즈레터")
+                    .description("비즈니스 뉴스 큐레이션")
+                    .imageUrl("https://cdn.bombom.me/img3.png")
+                    .email("biz@biz.com")
+                    .categoryId(3L)
+                    .detailId(3L)
+                    .build()
         );
 
         newsletterRepository.saveAll(newsletters);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.newsletter.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
@@ -27,7 +28,7 @@ class NewsletterServiceTest {
     @Autowired
     private NewsletterDetailRepository newsletterDetailRepository;
 
-    List<Newsletter> newsletters;
+    private List<Newsletter> newsletters;
 
     @BeforeEach
     public void setup() {
@@ -59,7 +60,7 @@ class NewsletterServiceTest {
                     .imageUrl("https://cdn.bombom.me/img1.png")
                     .email("news@newspick.com")
                     .categoryId(1L)
-                    .detailId(1L)
+                    .detailId(newsletterDetails.get(0).getId())
                     .build(),
             Newsletter.builder()
                     .name("IT타임즈")
@@ -67,7 +68,7 @@ class NewsletterServiceTest {
                     .imageUrl("https://cdn.bombom.me/img2.png")
                     .email("editor@ittimes.io")
                     .categoryId(2L)
-                    .detailId(2L)
+                    .detailId(newsletterDetails.get(1).getId())
                     .build(),
             Newsletter.builder()
                     .name("비즈레터")
@@ -75,7 +76,7 @@ class NewsletterServiceTest {
                     .imageUrl("https://cdn.bombom.me/img3.png")
                     .email("biz@biz.com")
                     .categoryId(3L)
-                    .detailId(3L)
+                    .detailId(newsletterDetails.get(2).getId())
                     .build()
         );
         newsletterRepository.saveAll(newsletters);
@@ -87,6 +88,15 @@ class NewsletterServiceTest {
         List<NewsletterResponse> result = newsletterService.getNewsletters();
 
         //then
-        assertThat(result.size()).isEqualTo(newsletters.size());
+        assertAll(
+                () -> assertThat(result.size()).isEqualTo(newsletters.size()),
+                () -> assertThat(result)
+                    .extracting("newsletterId")
+                    .containsExactlyInAnyOrder(
+                            newsletters.get(0).getId(),
+                            newsletters.get(1).getId(),
+                            newsletters.get(2).getId()
+                    )
+        );
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
@@ -51,9 +51,7 @@ class NewsletterServiceTest {
                     .subscribeCount(600)
                     .build()
             );
-
         newsletterDetailRepository.saveAll(newsletterDetails);
-
         newsletters = List.of(
             Newsletter.builder()
                     .name("뉴스픽")
@@ -80,7 +78,6 @@ class NewsletterServiceTest {
                     .detailId(3L)
                     .build()
         );
-
         newsletterRepository.saveAll(newsletters);
     }
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
전체 뉴스레터 목록 조회 API를 구현했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
뉴스레터 추천 페이지에서 필요합니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
JPA의 쿼리 메서드로 구독자 수 (desc), 이름(asc)로 정렬된 데이터를 받습니다.
그리고, 초기에는 셔플 후에 리턴하기로 정했기 때문에 셔플 후에 controller로 리턴하도록 했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
예외 발생 경우가 생각나지 않아 예외 처리를 하지 않았습니다.
테스트가 충분한지 검토해주시면 감사드리겠습니다.
