### PR TITLE
[BE][BOM-15] feat: 주간 목표 수정 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.common.exception;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -11,5 +12,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(CIllegalArgumentException e){
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getErrorDetail()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e){
+        return ResponseEntity.status(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION.getStatus())
+                .body(ErrorResponse.from(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION));
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MemberController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MemberController.java
@@ -1,0 +1,27 @@
+package me.bombom.api.v1.member.controller;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.member.dto.request.UpdateWeeklyGoalRequest;
+import me.bombom.api.v1.member.dto.response.WeeklyGoalResponse;
+import me.bombom.api.v1.member.service.MemberService;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.Errors;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    private final MemberService memberService;
+
+    @PatchMapping("/me/reading/progress/week/goal")
+    public WeeklyGoalResponse updateWeeklyGoal(@Valid @RequestBody UpdateWeeklyGoalRequest request){
+        return memberService.updateWeeklyGoal(request);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
@@ -13,14 +13,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import me.bombom.api.v1.common.BaseEntity;
 import me.bombom.api.v1.member.enums.Gender;
 import org.hibernate.validator.constraints.UniqueElements;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends BaseEntity {
 
@@ -31,7 +30,6 @@ public class Member extends BaseEntity {
     @Column(nullable = false, length = 30)
     private String email;
 
-    @UniqueElements
     @Column(unique = true, nullable = false)
     private String nickname;
 
@@ -46,4 +44,23 @@ public class Member extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
     private Long roleId = 0L;
+
+    @Builder
+    public Member(
+            Long id,
+            @NonNull String email,
+            @NonNull String nickname,
+            String profileImageUrl,
+            LocalDateTime birthDate,
+            @NonNull Gender gender,
+            @NonNull Long roleId
+    ) {
+        this.id = id;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.roleId = roleId;
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/WeeklyGoal.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/WeeklyGoal.java
@@ -5,18 +5,18 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import me.bombom.api.v1.common.BaseEntity;
 import org.hibernate.validator.constraints.UniqueElements;
 
 @Entity
 @Getter
-@Builder
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeeklyGoal extends BaseEntity {
 
@@ -24,7 +24,6 @@ public class WeeklyGoal extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @UniqueElements
     @Column(unique = true, nullable = false)
     private Long memberId;
 
@@ -33,4 +32,21 @@ public class WeeklyGoal extends BaseEntity {
 
     @Column(columnDefinition = "TINYINT DEFAULT 0", nullable = false)
     private int currentCount;
+
+    @Builder
+    public WeeklyGoal(
+            Long id,
+            @NonNull Long memberId,
+            int weeklyGoalCount,
+            int currentCount
+    ) {
+        this.id = id;
+        this.memberId = memberId;
+        this.weeklyGoalCount = weeklyGoalCount;
+        this.currentCount = currentCount;
+    }
+
+    public void updateWeeklyGoalCount(Integer goalCount) {
+        this.weeklyGoalCount = goalCount;
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/request/UpdateWeeklyGoalRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/request/UpdateWeeklyGoalRequest.java
@@ -1,0 +1,9 @@
+package me.bombom.api.v1.member.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateWeeklyGoalRequest(
+        @NotNull(message = "회원 아이디는 필수 입력 값입니다.") Long memberId,
+        @NotNull(message = "주간 목표 개수는 필수 입력 값입니다.") Integer weeklyGoalCount
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/WeeklyGoalResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/WeeklyGoalResponse.java
@@ -1,0 +1,13 @@
+package me.bombom.api.v1.member.dto.response;
+
+import me.bombom.api.v1.member.domain.WeeklyGoal;
+
+public record WeeklyGoalResponse(
+        Long weeklyGoalId,
+        int weeklyGoalCount
+) {
+
+    public static WeeklyGoalResponse from(WeeklyGoal weeklyGoal) {
+        return new WeeklyGoalResponse(weeklyGoal.getId(), weeklyGoal.getWeeklyGoalCount());
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.member.repository;
+
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/WeeklyGoalRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/WeeklyGoalRepository.java
@@ -1,0 +1,11 @@
+package me.bombom.api.v1.member.repository;
+
+import java.util.Optional;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.domain.WeeklyGoal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WeeklyGoalRepository extends JpaRepository<WeeklyGoal, Long> {
+
+    Optional<WeeklyGoal> findByMemberId(Long memberId);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -1,0 +1,32 @@
+package me.bombom.api.v1.member.service;
+
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.domain.WeeklyGoal;
+import me.bombom.api.v1.member.dto.request.UpdateWeeklyGoalRequest;
+import me.bombom.api.v1.member.dto.response.WeeklyGoalResponse;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.member.repository.WeeklyGoalRepository;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+    private final WeeklyGoalRepository weeklyGoalRepository;
+
+    public WeeklyGoalResponse updateWeeklyGoal(UpdateWeeklyGoalRequest request) {
+        Member member = memberRepository.findById(request.memberId())
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        WeeklyGoal weeklyGoal = weeklyGoalRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        weeklyGoal.updateWeeklyGoalCount(request.weeklyGoalCount());
+        return WeeklyGoalResponse.from(weeklyGoal);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MemberServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MemberServiceTest.java
@@ -1,0 +1,96 @@
+package me.bombom.api.v1.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.domain.WeeklyGoal;
+import me.bombom.api.v1.member.dto.request.UpdateWeeklyGoalRequest;
+import me.bombom.api.v1.member.dto.response.WeeklyGoalResponse;
+import me.bombom.api.v1.member.enums.Gender;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.member.repository.WeeklyGoalRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(MemberService.class)
+class MemberServiceTest {
+
+    @Autowired
+    private MemberService memberService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private WeeklyGoalRepository weeklyGoalRepository;
+
+    @Test
+    void 주간_목표를_수정할_수_있다(){
+        // given
+        Member member = Member.builder()
+                .email("email")
+                .nickname("nickname")
+                .gender(Gender.FEMALE)
+                .roleId(1L)
+                .build();
+        memberRepository.save(member);
+
+        WeeklyGoal weeklyGoal = WeeklyGoal.builder()
+                .memberId(member.getId())
+                .weeklyGoalCount(0)
+                .currentCount(2)
+                .build();
+        weeklyGoalRepository.save(weeklyGoal);
+
+        UpdateWeeklyGoalRequest request = new UpdateWeeklyGoalRequest(member.getId(), 3);
+
+        // when
+        WeeklyGoalResponse result = memberService.updateWeeklyGoal(request);
+
+        // then
+        assertThat(result.weeklyGoalCount()).isEqualTo(3);
+    }
+
+    @Test
+    void 회원_정보가_존재하지_않을_경우_예외가_발생한다() {
+        // given
+        WeeklyGoal weeklyGoal = WeeklyGoal.builder()
+                .memberId(0L)
+                .weeklyGoalCount(0)
+                .currentCount(2)
+                .build();
+        weeklyGoalRepository.save(weeklyGoal);
+
+        UpdateWeeklyGoalRequest request = new UpdateWeeklyGoalRequest(0L, 3);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateWeeklyGoal(request))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 주간_목표_정보가_존재하지_않을_경우_예외가_발생한다() {
+        // given
+        Member member = Member.builder()
+                .email("email")
+                .nickname("nickname")
+                .gender(Gender.FEMALE)
+                .roleId(1L)
+                .build();
+        memberRepository.save(member);
+
+        UpdateWeeklyGoalRequest request = new UpdateWeeklyGoalRequest(member.getId(), 3);
+
+        // when & then
+        assertThatThrownBy(() -> memberService.updateWeeklyGoal(request))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 주간 목표 수정 API를 구현합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 주간 목표 값을 default로 3 설정 후, 사용자가 원하는 값으로 변경할 수 있게 하기 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- `Member` 및 `WeeklyGoal`의 생성자 파라미터에 `@NonNull` 제약을 추가합니다. 
- dirty checking 사용해서 `weeklyGoal` 값을 업데이트 하도록 구현했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
