### PR TITLE
[BE][BOM-17] feat: 연속 읽기 & 오늘의 진행 현황 & 주간 목표 조회 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MemberController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MemberController.java
@@ -4,12 +4,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.member.dto.request.UpdateWeeklyCurrentCountRequest;
 import me.bombom.api.v1.member.dto.request.UpdateWeeklyGoalCountRequest;
+import me.bombom.api.v1.member.dto.response.ReadingInformationResponse;
 import me.bombom.api.v1.member.dto.response.WeeklyCurrentCountResponse;
 import me.bombom.api.v1.member.dto.response.WeeklyGoalCountResponse;
 import me.bombom.api.v1.member.service.MemberService;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,5 +30,10 @@ public class MemberController {
     @PatchMapping("/me/reading/progress/week/count")
     public WeeklyCurrentCountResponse updateWeeklyCurrentCount(@Valid @RequestBody UpdateWeeklyCurrentCountRequest request){
         return memberService.updateWeeklyCurrentCount(request);
+    }
+
+    @GetMapping("/me/reading")
+    public ReadingInformationResponse getReadingInformation(@RequestParam Long memberId){
+        return memberService.getReadingInformation(memberId);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/TodayReading.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/TodayReading.java
@@ -6,18 +6,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import me.bombom.api.v1.common.BaseEntity;
-import org.hibernate.validator.constraints.UniqueElements;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ContinueReading extends BaseEntity {
+public class TodayReading {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -26,17 +23,22 @@ public class ContinueReading extends BaseEntity {
     @Column(nullable = false, unique = true)
     private Long memberId;
 
-    @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
-    private int dayCount;
+    @Column(nullable = false, columnDefinition = "TINYINT")
+    private int totalCount;
+
+    @Column(nullable = false, columnDefinition = "TINYINT DEFAULT 0")
+    private int currentCount;
 
     @Builder
-    public ContinueReading(
+    public TodayReading(
             Long id,
             @NonNull Long memberId,
-            int dayCount
+            int totalCount,
+            int currentCount
     ) {
         this.id = id;
         this.memberId = memberId;
-        this.dayCount = dayCount;
+        this.totalCount = totalCount;
+        this.currentCount = currentCount;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/TodayReading.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/TodayReading.java
@@ -10,11 +10,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class TodayReading {
+public class TodayReading extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/ReadingInformationResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/ReadingInformationResponse.java
@@ -1,0 +1,24 @@
+package me.bombom.api.v1.member.dto.response;
+
+import me.bombom.api.v1.member.domain.ContinueReading;
+import me.bombom.api.v1.member.domain.TodayReading;
+import me.bombom.api.v1.member.domain.WeeklyReading;
+
+public record ReadingInformationResponse(
+        int streakReadDay,
+        TodayReadingResponse today,
+        WeeklyReadingResponse weekly
+) {
+
+    public static ReadingInformationResponse from(
+            ContinueReading continueReading,
+            TodayReading todayReading,
+            WeeklyReading weeklyReading
+    ) {
+        return new ReadingInformationResponse(
+                continueReading.getDayCount(),
+                TodayReadingResponse.from(todayReading),
+                WeeklyReadingResponse.from(weeklyReading)
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/ReadingInformationResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/ReadingInformationResponse.java
@@ -10,7 +10,7 @@ public record ReadingInformationResponse(
         WeeklyReadingResponse weekly
 ) {
 
-    public static ReadingInformationResponse from(
+    public static ReadingInformationResponse of(
             ContinueReading continueReading,
             TodayReading todayReading,
             WeeklyReading weeklyReading

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/TodayReadingResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/TodayReadingResponse.java
@@ -1,0 +1,13 @@
+package me.bombom.api.v1.member.dto.response;
+
+import me.bombom.api.v1.member.domain.TodayReading;
+
+public record TodayReadingResponse(
+        int readCount,
+        int totalCount
+) {
+
+    public static TodayReadingResponse from(TodayReading todayReading) {
+        return new TodayReadingResponse(todayReading.getCurrentCount(), todayReading.getTotalCount());
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/WeeklyReadingResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/WeeklyReadingResponse.java
@@ -1,0 +1,13 @@
+package me.bombom.api.v1.member.dto.response;
+
+import me.bombom.api.v1.member.domain.WeeklyReading;
+
+public record WeeklyReadingResponse(
+        int readCount,
+        int goalCount
+) {
+
+    public static WeeklyReadingResponse from(WeeklyReading weeklyReading) {
+        return new WeeklyReadingResponse(weeklyReading.getCurrentCount(), weeklyReading.getGoalCount());
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/ContinueReadingRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/ContinueReadingRepository.java
@@ -1,0 +1,11 @@
+package me.bombom.api.v1.member.repository;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
+import me.bombom.api.v1.member.domain.ContinueReading;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContinueReadingRepository extends JpaRepository<ContinueReading, Long> {
+
+    Optional<ContinueReading> findByMemberId(Long memberId);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/TodayReadingRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/TodayReadingRepository.java
@@ -1,0 +1,11 @@
+package me.bombom.api.v1.member.repository;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Optional;
+import me.bombom.api.v1.member.domain.TodayReading;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TodayReadingRepository extends JpaRepository<TodayReading, Long> {
+
+    Optional<TodayReading> findByMemberId(Long memberId);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -1,16 +1,23 @@
 package me.bombom.api.v1.member.service;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.member.domain.ContinueReading;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.domain.TodayReading;
 import me.bombom.api.v1.member.domain.WeeklyReading;
 import me.bombom.api.v1.member.dto.request.UpdateWeeklyCurrentCountRequest;
 import me.bombom.api.v1.member.dto.request.UpdateWeeklyGoalCountRequest;
+import me.bombom.api.v1.member.dto.response.ReadingInformationResponse;
 import me.bombom.api.v1.member.dto.response.WeeklyCurrentCountResponse;
 import me.bombom.api.v1.member.dto.response.WeeklyGoalCountResponse;
+import me.bombom.api.v1.member.repository.ContinueReadingRepository;
 import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.member.repository.TodayReadingRepository;
 import me.bombom.api.v1.member.repository.WeeklyReadingRepository;
+import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,6 +28,8 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final WeeklyReadingRepository weeklyReadingRepository;
+    private final ContinueReadingRepository continueReadingRepository;
+    private final TodayReadingRepository todayReadingRepository;
 
     public WeeklyGoalCountResponse updateWeeklyGoalCount(UpdateWeeklyGoalCountRequest request) {
         Member member = memberRepository.findById(request.memberId())
@@ -38,5 +47,15 @@ public class MemberService {
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
         weeklyReading.increaseCurrentCount(WeeklyReading.INCREASE_CURRENT_COUNT);
         return WeeklyCurrentCountResponse.from(weeklyReading);
+    }
+
+    public ReadingInformationResponse getReadingInformation(Long memberId) {
+        ContinueReading continueReading = continueReadingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        TodayReading todayReading = todayReadingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        WeeklyReading weeklyReading = weeklyReadingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        return ReadingInformationResponse.from(continueReading, todayReading, weeklyReading);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package me.bombom.api.v1.member.service;
 
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
@@ -17,7 +16,6 @@ import me.bombom.api.v1.member.repository.ContinueReadingRepository;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.member.repository.TodayReadingRepository;
 import me.bombom.api.v1.member.repository.WeeklyReadingRepository;
-import org.springframework.data.crossstore.ChangeSetPersister.NotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,6 +54,6 @@ public class MemberService {
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
         WeeklyReading weeklyReading = weeklyReadingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
-        return ReadingInformationResponse.from(continueReading, todayReading, weeklyReading);
+        return ReadingInformationResponse.of(continueReading, todayReading, weeklyReading);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -1,6 +1,9 @@
 package me.bombom.api.v1;
 
+import me.bombom.api.v1.member.domain.ContinueReading;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.domain.TodayReading;
+import me.bombom.api.v1.member.domain.WeeklyReading;
 import me.bombom.api.v1.member.enums.Gender;
 
 public final class TestFixture {
@@ -13,6 +16,29 @@ public final class TestFixture {
                 .nickname("nickname")
                 .gender(Gender.FEMALE)
                 .roleId(1L)
+                .build();
+    }
+
+    public static ContinueReading continueReadingFixture(Member member){
+        return ContinueReading.builder()
+                .memberId(member.getId())
+                .dayCount(10)
+                .build();
+    }
+
+    public static TodayReading todayReadingFixture(Member member){
+        return TodayReading.builder()
+                .memberId(member.getId())
+                .currentCount(1)
+                .totalCount(3)
+                .build();
+    }
+
+    public static WeeklyReading weeklyReadingFixture(Member member) {
+        return WeeklyReading.builder()
+                .memberId(member.getId())
+                .currentCount(3)
+                .goalCount(5)
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MemberServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MemberServiceTest.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.member.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
@@ -10,9 +11,12 @@ import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.domain.WeeklyReading;
 import me.bombom.api.v1.member.dto.request.UpdateWeeklyCurrentCountRequest;
 import me.bombom.api.v1.member.dto.request.UpdateWeeklyGoalCountRequest;
+import me.bombom.api.v1.member.dto.response.ReadingInformationResponse;
 import me.bombom.api.v1.member.dto.response.WeeklyCurrentCountResponse;
 import me.bombom.api.v1.member.dto.response.WeeklyGoalCountResponse;
+import me.bombom.api.v1.member.repository.ContinueReadingRepository;
 import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.member.repository.TodayReadingRepository;
 import me.bombom.api.v1.member.repository.WeeklyReadingRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +35,12 @@ class MemberServiceTest {
 
     @Autowired
     private WeeklyReadingRepository weeklyReadingRepository;
+
+    @Autowired
+    private ContinueReadingRepository continueReadingRepository;
+
+    @Autowired
+    private TodayReadingRepository todayReadingRepository;
 
     @Test
     void 주간_목표를_수정할_수_있다(){
@@ -130,6 +140,71 @@ class MemberServiceTest {
 
         // when & then
         assertThatThrownBy(() -> memberService.updateWeeklyCurrentCount(request))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 읽기_현황_종합_정보를_조회할_수_있다() {
+        // given
+        Member savedMember = memberRepository.save(TestFixture.normalMemberFixture());
+        continueReadingRepository.save(TestFixture.continueReadingFixture(savedMember));
+        todayReadingRepository.save(TestFixture.todayReadingFixture(savedMember));
+        weeklyReadingRepository.save(TestFixture.weeklyReadingFixture(savedMember));
+
+        // when
+        ReadingInformationResponse response = memberService.getReadingInformation(savedMember.getId());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streakReadDay()).isEqualTo(10);
+            softly.assertThat(response.today().readCount()).isEqualTo(1);
+            softly.assertThat(response.today().totalCount()).isEqualTo(3);
+            softly.assertThat(response.weekly().readCount()).isEqualTo(3);
+            softly.assertThat(response.weekly().goalCount()).isEqualTo(5);
+        });
+    }
+
+    @Test
+    void 읽기_현황_종합_정보_조회에서_회원_정보가_존재하지_않을_경우_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> memberService.getReadingInformation(1L))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 읽기_현황_종합_정보_조회에서_연속_읽기가_존재하지_않을_경우_예외가_발생한다() {
+        // given
+        Member savedMember = memberRepository.save(TestFixture.normalMemberFixture());
+
+        // when & then
+        assertThatThrownBy(() -> memberService.getReadingInformation(savedMember.getId()))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 읽기_현황_종합_정보_조회에서_일간_읽기_정보가_존재하지_않을_경우_예외가_발생한다() {
+        // given
+        Member savedMember = memberRepository.save(TestFixture.normalMemberFixture());
+        continueReadingRepository.save(TestFixture.continueReadingFixture(savedMember));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.getReadingInformation(savedMember.getId()))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 읽기_현황_종합_정보_조회에서_주간_목표_정보가_존재하지_않을_경우_예외가_발생한다() {
+        // given
+        Member savedMember = memberRepository.save(TestFixture.normalMemberFixture());
+        continueReadingRepository.save(TestFixture.continueReadingFixture(savedMember));
+        todayReadingRepository.save(TestFixture.todayReadingFixture(savedMember));
+
+        // when & then
+        assertThatThrownBy(() -> memberService.getReadingInformation(savedMember.getId()))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
     }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 연속 읽기, 오늘의 진행 현황, 주간 목표 조회를 조회하는 API를 구현합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- '오늘의 뉴스레터' 페이지에서 사용됩니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 오늘의 읽기 현황 저장을 위해 `TodayReading` 테이블이 추가되었습니다.
- 이후에는 `ContinueReading`, `TodayReading`, `WeeklyReading`을 조회해서 dto 가공만 하면 됐습니다.
- `@RequestParam`로 받는 `memberId`는 임시방편입니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
