### PR TITLE
[BE][BOM-22] feat: 아티클 세부 정보 조회 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
@@ -21,9 +21,9 @@ public class ArticleController {
 
     private final ArticleService articleService;
 
-    @GetMapping("/{memberId}")
+    @GetMapping
     public Page<ArticleResponse> getArticles(
-            @PathVariable Long memberId,
+            @RequestParam Long memberId,
             @RequestParam(required = false) LocalDate date,
             @RequestParam(required = false) String category,
             @RequestParam(required = false, name = "sorted", defaultValue = "DESC") SortOption sortOption,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.article.controller;
 
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.article.dto.ArticleDetailResponse;
 import me.bombom.api.v1.article.dto.ArticleResponse;
 import me.bombom.api.v1.article.enums.SortOption;
 import me.bombom.api.v1.article.service.ArticleService;
@@ -36,5 +37,10 @@ public class ArticleController {
                 sortOption,
                 pageable
         );
+    }
+
+    @GetMapping("/{id}")
+    public ArticleDetailResponse getArticleDetail(@PathVariable Long id, @RequestParam Long memberId) {
+        return articleService.getArticleDetail(id, memberId);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
@@ -56,7 +56,7 @@ public class Article extends BaseEntity {
             Long id,
             @NonNull String title,
             @NonNull String contents,
-            @NonNull String thumbnailUrl,
+            String thumbnailUrl,
             int expectedReadTime,
             @NonNull String contentsSummary,
             boolean isRead,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -25,8 +26,9 @@ public class Article extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false, length = 512)
-    private String articleUrl;
+    @Lob
+    @Column(nullable = false, length = 512, columnDefinition = "mediumtext")
+    private String contents;
 
     @Column(length = 512)
     private String thumbnailUrl;
@@ -53,7 +55,7 @@ public class Article extends BaseEntity {
     public Article(
             Long id,
             @NonNull String title,
-            @NonNull String articleUrl,
+            @NonNull String contents,
             @NonNull String thumbnailUrl,
             int expectedReadTime,
             @NonNull String contentsSummary,
@@ -64,7 +66,7 @@ public class Article extends BaseEntity {
     ) {
         this.id = id;
         this.title = title;
-        this.articleUrl = articleUrl;
+        this.contents = contents;
         this.thumbnailUrl = thumbnailUrl;
         this.expectedReadTime = expectedReadTime;
         this.contentsSummary = contentsSummary;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/dto/ArticleDetailResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/dto/ArticleDetailResponse.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.article.dto;
+
+import java.time.LocalDateTime;
+import me.bombom.api.v1.article.domain.Article;
+import me.bombom.api.v1.newsletter.domain.Category;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.dto.NewsletterBasicResponse;
+
+public record ArticleDetailResponse(
+        String title,
+        String contents,
+        LocalDateTime arrivedDateTime,
+        int expectedReadTime,
+        NewsletterBasicResponse newsletter
+) {
+
+    public static ArticleDetailResponse of(Article article, Newsletter newsletter, Category category) {
+        return new ArticleDetailResponse(
+                article.getTitle(),
+                article.getContents(),
+                article.getArrivedDateTime(),
+                article.getExpectedReadTime(),
+                NewsletterBasicResponse.of(newsletter, category)
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
@@ -2,6 +2,8 @@ package me.bombom.api.v1.article.service;
 
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.article.domain.Article;
+import me.bombom.api.v1.article.dto.ArticleDetailResponse;
 import me.bombom.api.v1.article.dto.ArticleResponse;
 import me.bombom.api.v1.article.dto.GetArticlesOptions;
 import me.bombom.api.v1.article.enums.SortOption;
@@ -10,7 +12,9 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.newsletter.domain.Category;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
 import me.bombom.api.v1.newsletter.repository.CategoryRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -24,6 +28,7 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     private final CategoryRepository categoryRepository;
     private final MemberRepository memberRepository;
+    private final NewsletterRepository newsletterRepository;
 
     public Page<ArticleResponse> getArticles(
             Long memberId,
@@ -38,6 +43,17 @@ public class ArticleService {
                 GetArticlesOptions.of(date, getCategoryIdByName(categoryName), sortOption),
                 pageable
         );
+    }
+
+    public ArticleDetailResponse getArticleDetail(Long id, Long memberId) {
+        validateMemberExists(memberId);
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        Newsletter newsletter = newsletterRepository.findById(article.getNewsletterId())
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        Category category = categoryRepository.findById(newsletter.getCategoryId())
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        return ArticleDetailResponse.of(article, newsletter, category);
     }
 
     private void validateMemberExists(Long memberId) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/dto/NewsletterBasicResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/dto/NewsletterBasicResponse.java
@@ -1,0 +1,21 @@
+package me.bombom.api.v1.newsletter.dto;
+
+import me.bombom.api.v1.newsletter.domain.Category;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+
+public record NewsletterBasicResponse(
+        String name,
+        String email,
+        String imageUrl,
+        String category
+) {
+
+    public static NewsletterBasicResponse of(Newsletter newsletter, Category category) {
+        return new NewsletterBasicResponse(
+                newsletter.getName(),
+                newsletter.getEmail(),
+                newsletter.getImageUrl(),
+                category.getName()
+        );
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/service/ArticleServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/service/ArticleServiceTest.java
@@ -7,6 +7,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.article.domain.Article;
+import me.bombom.api.v1.article.dto.ArticleDetailResponse;
 import me.bombom.api.v1.article.dto.ArticleResponse;
 import me.bombom.api.v1.article.enums.SortOption;
 import me.bombom.api.v1.article.repository.ArticleRepository;
@@ -99,7 +100,7 @@ class ArticleServiceTest {
         articles = List.of(
                 Article.builder()
                         .title("개발자 생산성을 높이는 도구들")
-                        .articleUrl("https://example.com/articles/dev-tools")
+                        .contents("<h1>개발자 생산성을 높이는 도구들</h1>")
                         .thumbnailUrl("https://example.com/images/dev-tools.png")
                         .expectedReadTime(5)
                         .contentsSummary("생산성을 높이는 다양한 개발 도구들을 소개합니다.")
@@ -110,7 +111,7 @@ class ArticleServiceTest {
                         .build(),
                 Article.builder()
                         .title("AI가 바꾸는 일상의 풍경")
-                        .articleUrl("https://example.com/articles/ai-life")
+                        .contents("<h1>AI가 바꾸는 일상의 풍경</h1>")
                         .thumbnailUrl("https://example.com/images/ai-life.png")
                         .expectedReadTime(7)
                         .contentsSummary("AI 기술이 우리의 일상생활에 어떤 변화를 가져왔는지 정리했습니다.")
@@ -121,7 +122,7 @@ class ArticleServiceTest {
                         .build(),
                 Article.builder()
                         .title("2025년 IT 트렌드 미리보기")
-                        .articleUrl("https://example.com/articles/it-trend-2025")
+                        .contents("<h1>2025년 IT 트렌드 미리보기</h1>")
                         .thumbnailUrl("https://example.com/images/it-trend.png")
                         .expectedReadTime(4)
                         .contentsSummary("다가오는 IT 트렌드를 전망하고 주요 기술을 짚어봅니다.")
@@ -130,9 +131,9 @@ class ArticleServiceTest {
                         .newsletterId(newsletters.get(2).getId())
                         .arrivedDateTime(baseTime.minusMinutes(20))
                         .build(),
-                Article.builder() //하루 전 아티클
+                Article.builder() // 하루 전 아티클
                         .title("2025년 패션 트렌드 미리보기")
-                        .articleUrl("https://example.com/articles/fashion-trend-2025")
+                        .contents("<h1>2025년 패션 트렌드 미리보기</h1>")
                         .thumbnailUrl("https://example.com/images/it-trend.png")
                         .expectedReadTime(8)
                         .contentsSummary("다가오는 패션 트렌드를 전망하고 주요 기술을 짚어봅니다.")
@@ -373,5 +374,93 @@ class ArticleServiceTest {
             softly.assertThat(result.getContent().get(0).arrivedDateTime())
                     .isBefore(result.getContent().get(1).arrivedDateTime());
         });
+    }
+
+    @Test
+    void 아티클_상세_조회_성공_테스트() {
+        // given
+        Article article = articles.getFirst();
+        Newsletter newsletter = newsletters.getFirst();
+
+        // when
+        ArticleDetailResponse result = articleService.getArticleDetail(article.getId(), member.getId());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.title()).isEqualTo(article.getTitle());
+            softly.assertThat(result.newsletter().name()).isEqualTo(newsletter.getName());
+        });
+    }
+
+    @Test
+    void 아티클_상세_조회_아티클이_존재하지_않으면_예외() {
+        // when & then
+        assertThatThrownBy(() -> articleService.getArticleDetail(0L, member.getId()))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 아티클_상세_조회_멤버가_존재하지_않으면_예외() {
+        // given
+        Article article = articles.getFirst();
+
+        // when & then
+        assertThatThrownBy(() -> articleService.getArticleDetail(article.getId(), 0L))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 아티클_상세_조회_뉴스레터가_존재하지_않으면_예외() {
+        // given
+        Article article = Article.builder()
+                .title("테스트 아티클")
+                .contents("<p>테스트 내용</p>")
+                .thumbnailUrl("https://example.com/test.png")
+                .expectedReadTime(3)
+                .contentsSummary("테스트 요약")
+                .isRead(false)
+                .memberId(member.getId())
+                .newsletterId(0L) // 존재하지 않는 뉴스레터 ID
+                .arrivedDateTime(baseTime)
+                .build();
+        articleRepository.save(article);
+
+        // when & then
+        assertThatThrownBy(() -> articleService.getArticleDetail(article.getId(), member.getId()))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 아티클_상세_조회_카테고리가_존재하지_않으면_예외() {
+        // given
+        Newsletter newsletter = Newsletter.builder()
+                .name("테스트 뉴스레터")
+                .description("테스트 설명")
+                .imageUrl("https://example.com/test.png")
+                .email("test@example.com")
+                .categoryId(0L) // 존재하지 않는 카테고리 ID
+                .detailId(0L)
+                .build();
+        newsletterRepository.save(newsletter);
+        Article article = Article.builder()
+                .title("테스트 아티클")
+                .contents("<p>테스트 내용</p>")
+                .thumbnailUrl("https://example.com/test.png")
+                .expectedReadTime(3)
+                .contentsSummary("테스트 요약")
+                .isRead(false)
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .arrivedDateTime(baseTime)
+                .build();
+        articleRepository.save(article);
+
+        // when & then
+        assertThatThrownBy(() -> articleService.getArticleDetail(article.getId(), member.getId()))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
아티클 세부 정보 조회 API 구현과 테스트를 작성했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
아티클 읽기 페이지에서 사용되는 API입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
이전에 구현한 아티클 목록 조회 API의 반환형인 ArticleResponse 내부에 `NewsletterSummaryResponse`가 있었습니다.
NewsletterSummaryResponse 내부에는 **name, imageUrl, category**가 있습니다.

이번에 구현한 API의 반환 중 Newsletter의 필드는 **name, imageUrl, category에 email이 추가**로 필요합니다. 그래서 해당 dto의 이름을 `NewsletterBasicResponse`라고 지었습니다.

이후에 계획된 페이지에서 뉴스레터 상세 페이지는 `NewsletterDetailResponse`라고 이름 지을 계획인데 괜찮을까용??

Summary > Basic > Detail 순으로 하려합니다! 
어떤 페이지에서 사용되는 dto인지 이름으로 나타내면 명확하겠지만, 너무 종속되는거 같아서 피하려합니다.