### PR TITLE
[FE][BOM-77] feat: select 컴포넌트 제작

### DIFF
--- a/frontend/.stylelintrc.cjs
+++ b/frontend/.stylelintrc.cjs
@@ -28,6 +28,7 @@ const groupMap = {
     'justify-content',
     'justify-items',
     'justify-self',
+    'gap',
   ],
   Box: [
     'width',

--- a/frontend/public/assets/chevron-down.svg
+++ b/frontend/public/assets/chevron-down.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 6L8 10L12 6" stroke="#94A3B8" stroke-width="1.33333" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -123,18 +123,18 @@ const SubTitle = styled.div`
 const Nav = styled.nav`
   display: flex;
   align-items: center;
+  gap: 8px;
 
   padding: 4px;
   border-radius: 14px;
 
   background: ${({ theme }) => theme.colors.white};
-
-  gap: 8px;
 `;
 
 const NavButton = styled.button<{ active?: boolean }>`
   display: flex;
   align-items: center;
+  gap: 4px;
 
   padding: 10px 12px;
   border-radius: 12px;
@@ -145,20 +145,17 @@ const NavButton = styled.button<{ active?: boolean }>`
   color: ${({ active, theme }) =>
     active ? theme.colors.white : theme.colors.black};
   font: ${({ theme }) => theme.fonts.body2};
-
-  gap: 4px;
 `;
 
 const ProfileBox = styled.div`
   display: flex;
   align-items: center;
+  gap: 8px;
 
   padding: 8px 12px;
   border-radius: 12px;
 
   background: ${({ theme }) => theme.colors.white};
-
-  gap: 8px;
 `;
 
 const ProfileImg = styled.img`
@@ -180,9 +177,9 @@ const ProfileName = styled.div``;
 const ProfileEmail = styled.div`
   display: flex;
   align-items: center;
+  gap: 4px;
 
   cursor: pointer;
-  gap: 4px;
 `;
 
 const EmailText = styled.div`

--- a/frontend/src/components/ImageInfoCard/ImageInfoCard.tsx
+++ b/frontend/src/components/ImageInfoCard/ImageInfoCard.tsx
@@ -24,11 +24,10 @@ const Container = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 8px;
 
   width: fit-content;
   padding: 12px 8px;
-
-  gap: 8px;
 `;
 
 const Image = styled.img`
@@ -45,10 +44,9 @@ const InfoBox = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
+  gap: 4px;
 
   height: 60px;
-
-  gap: 4px;
 `;
 
 const Title = styled.h3`

--- a/frontend/src/components/Select/Select.stories.tsx
+++ b/frontend/src/components/Select/Select.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import Select from './Select';
+import { useState } from 'react';
+
+const meta: Meta<typeof Select> = {
+  title: 'components/common/Select',
+  component: Select,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+const fruitOptions = [
+  { label: 'Apple', value: 'apple' },
+  { label: 'Banana', value: 'banana' },
+  { label: 'Grapes', value: 'grapes' },
+  { label: 'Orange', value: 'orange' },
+];
+
+export const Default: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<string | null>(null);
+
+    return (
+      <div style={{ padding: '40px' }}>
+        <Select
+          options={fruitOptions}
+          selectedValue={selected}
+          onSelectOption={(value) => setSelected(value)}
+          placeholder="과일"
+        />
+      </div>
+    );
+  },
+};
+
+export const LongPlaceholder: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<string | null>(null);
+
+    return (
+      <div style={{ padding: '40px' }}>
+        <Select
+          options={fruitOptions}
+          selectedValue={selected}
+          onSelectOption={(value) => setSelected(value)}
+          placeholder="과일을 선택해주세요."
+        />
+      </div>
+    );
+  },
+};
+
+export const WideWidth: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<string | null>(null);
+
+    return (
+      <div style={{ padding: '40px' }}>
+        <Select
+          options={fruitOptions}
+          selectedValue={selected}
+          onSelectOption={(value) => setSelected(value)}
+          width={240}
+          placeholder="과일을 선택해주세요."
+        />
+      </div>
+    );
+  },
+};

--- a/frontend/src/components/Select/Select.tsx
+++ b/frontend/src/components/Select/Select.tsx
@@ -1,0 +1,148 @@
+import styled from '@emotion/styled';
+import { ComponentProps, useState } from 'react';
+import { useClickOutsideRef } from '../../hooks/useClickOutsideRef';
+import ChevronIcon from '../icons/ChevronIcon';
+
+interface SelectProps<T extends { label: string; value: string }>
+  extends ComponentProps<'div'> {
+  options: T[];
+  selectedValue: string | null;
+  onSelectOption: (optionValue: string) => void;
+  width?: number;
+  placeholder?: string;
+}
+
+function Select<T extends { label: string; value: string }>({
+  options,
+  selectedValue,
+  onSelectOption,
+  width = 132,
+  placeholder,
+  ...props
+}: SelectProps<T>) {
+  const [open, setOpen] = useState(false);
+  const SelectRef = useClickOutsideRef<HTMLDivElement>(() => setOpen(false));
+
+  const toggle = () => setOpen((prev) => !prev);
+
+  const selectedLabel = options.find(
+    (option) => option.value === selectedValue,
+  )?.label;
+
+  const onOptionSelected = (value: string) => {
+    setOpen(false);
+    onSelectOption(value);
+  };
+
+  return (
+    <Container ref={SelectRef} {...props} width={width}>
+      <SelectToggle onClick={toggle}>
+        <SelectText selected={selectedValue !== null}>
+          {selectedLabel || (placeholder ?? '')}
+        </SelectText>
+        <ChevronIcon width={16} direction={open ? 'up' : 'down'} />
+      </SelectToggle>
+      <SelectMenu open={open}>
+        <SelectMenuWrapper>
+          {options.map((option) => (
+            <SelectMenuItem
+              key={option.value}
+              data-value={option.value}
+              onClick={() => onOptionSelected(option.value)}
+            >
+              {option.label}
+            </SelectMenuItem>
+          ))}
+        </SelectMenuWrapper>
+      </SelectMenu>
+    </Container>
+  );
+}
+
+const Container = styled.div<{ width: number }>`
+  position: relative;
+
+  width: ${({ width }) => `${width}px`};
+  height: 36px;
+`;
+
+const SelectToggle = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid ${({ theme }) => theme.colors.stroke};
+  border-radius: 6px;
+
+  background-color: white;
+
+  box-sizing: border-box;
+  cursor: pointer;
+  user-select: none;
+`;
+
+const SelectText = styled.p<{ selected: boolean }>`
+  overflow: hidden;
+
+  flex: 1;
+
+  color: ${({ theme, selected }) =>
+    selected ? theme.colors.textPrimary : theme.colors.textTertiary};
+  font: ${({ theme }) => theme.fonts.caption};
+  white-space: nowrap;
+
+  text-overflow: ellipsis;
+`;
+
+const SelectMenu = styled.div<{ open: boolean }>`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 10;
+
+  display: ${({ open }) => (open ? 'block' : 'none')};
+
+  width: 100%;
+  margin-top: 6px;
+  border: 1px solid ${({ theme }) => theme.colors.stroke};
+  border-radius: 6px;
+
+  /* box-shadow: 0 4px 6px 0 rgb(0 0 0 / 9%); */
+
+  background: white;
+
+  box-sizing: border-box;
+  list-style: none;
+`;
+
+const SelectMenuWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  align-self: stretch;
+
+  width: 100%;
+  padding: 0 4px;
+  border-radius: 6px;
+
+  background-color: ${({ theme }) => theme.colors.white};
+`;
+
+const SelectMenuItem = styled.li`
+  width: 100%;
+  padding: 6px 8px;
+  border-radius: 6px;
+
+  font-weight: 400;
+  font-size: 12px;
+
+  cursor: pointer;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.primaryLight};
+  }
+`;
+
+export default Select;

--- a/frontend/src/components/icons/ChevronIcon.tsx
+++ b/frontend/src/components/icons/ChevronIcon.tsx
@@ -1,0 +1,42 @@
+import styled from '@emotion/styled';
+import { SVGProps } from 'react';
+
+interface ChevronIconProps extends SVGProps<SVGSVGElement> {
+  direction: 'up' | 'down' | 'left' | 'right';
+}
+
+const directionRotationMap = {
+  up: 'rotate(180deg)',
+  down: 'rotate(0deg)',
+  left: 'rotate(90deg)',
+  right: 'rotate(-90deg)',
+};
+
+function ChevronIcon({ direction, ...props }: ChevronIconProps) {
+  return (
+    <StyledSVG
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      direction={direction}
+      {...props}
+    >
+      <path
+        d="M4 6L8 10L12 6"
+        stroke="#94A3B8"
+        strokeWidth="1.33333"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </StyledSVG>
+  );
+}
+
+export default ChevronIcon;
+
+const StyledSVG = styled.svg<{ direction: ChevronIconProps['direction'] }>`
+  transform: ${({ direction }) => directionRotationMap[direction]};
+  transition: transform 0.2s ease;
+`;

--- a/frontend/src/hooks/useClickOutsideRef.ts
+++ b/frontend/src/hooks/useClickOutsideRef.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+
+export function useClickOutsideRef<T extends HTMLElement = HTMLElement>(
+  callback: (() => void) | null,
+) {
+  const ref = useRef<T>(null);
+
+  useEffect(() => {
+    if (!callback) return;
+
+    const listener = (event: Event) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      callback();
+    };
+
+    document.addEventListener('click', listener, true);
+    return () => {
+      document.removeEventListener('click', listener, true);
+    };
+  }, [callback]);
+
+  return ref;
+}

--- a/frontend/src/pages/recommend/components/ReadingKingLeaderboard/ReadingKingLeaderboard.tsx
+++ b/frontend/src/pages/recommend/components/ReadingKingLeaderboard/ReadingKingLeaderboard.tsx
@@ -1,5 +1,4 @@
 import styled from '@emotion/styled';
-import BookIcon from '../../../../components/icons/BookIcon';
 import AvatarIcon from '../../../../components/icons/AvatarIcon';
 import TopRightArrowIcon from '../../../../components/icons/TopRightArrowIcon';
 
@@ -179,6 +178,7 @@ export default function ReadingKingLeaderboard({
 const Container = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 21px;
 
   width: 100%;
   max-width: 400px;
@@ -192,7 +192,6 @@ const Container = styled.div`
   background: rgb(255 255 255 / 80%);
 
   backdrop-filter: blur(10px);
-  gap: 21px;
 `;
 
 const Header = styled.div`
@@ -202,7 +201,6 @@ const Header = styled.div`
 const TitleContainer = styled.div`
   display: flex;
   align-items: center;
-
   gap: 10.5px;
 `;
 
@@ -240,7 +238,6 @@ const Title = styled.h3`
 const LeaderboardList = styled.div`
   display: flex;
   flex-direction: column;
-
   gap: 14px;
 `;
 
@@ -300,10 +297,9 @@ const UserInfo = styled.div`
 const NameContainer = styled.div`
   display: flex;
   align-items: center;
+  gap: 7px;
 
   margin-bottom: -1px;
-
-  gap: 7px;
 `;
 
 const UserName = styled.div<{ weight: 'normal' | 'medium' }>`
@@ -330,10 +326,9 @@ const Badge = styled.div`
 const StatsContainer = styled.div`
   display: flex;
   align-items: center;
+  gap: 7px;
 
   margin-bottom: -1px;
-
-  gap: 7px;
 `;
 
 const ReadCount = styled.div`
@@ -367,6 +362,7 @@ const MyRankContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 12px;
 
   margin-bottom: 10.5px;
   padding: 13px 14px 14px;
@@ -377,8 +373,6 @@ const MyRankContainer = styled.div`
     rgb(255 153 102 / 10%),
     rgb(255 237 212 / 50%)
   );
-
-  gap: 12px;
 `;
 
 const MyRankInfo = styled.div`
@@ -433,7 +427,6 @@ const MyReadValue = styled.div`
 const ProgressSection = styled.div`
   display: flex;
   flex-direction: column;
-
   gap: 3.5px;
 `;
 

--- a/frontend/src/pages/today/components/ArticleCard.tsx
+++ b/frontend/src/pages/today/components/ArticleCard.tsx
@@ -47,6 +47,7 @@ export default ArticleCard;
 const Container = styled.div<{ isRead: boolean }>`
   display: flex;
   align-items: center;
+  gap: 12px;
 
   padding: 20px;
   border-bottom: ${({ theme, isRead }) =>
@@ -55,17 +56,15 @@ const Container = styled.div<{ isRead: boolean }>`
   box-shadow: 0 20px 25px -5px rgb(0 0 0 / 10%);
 
   box-sizing: border-box;
-  gap: 12px;
   opacity: ${({ isRead }) => (isRead ? 0.5 : 1)};
 `;
 
 const InfoWrapper = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 12px;
 
   width: 100%;
-
-  gap: 12px;
 `;
 
 const Title = styled.h2`
@@ -88,7 +87,6 @@ const Description = styled.p`
 const MetaInfoRow = styled.div`
   display: flex;
   align-items: center;
-
   gap: 8px;
 `;
 
@@ -114,7 +112,6 @@ const MetaInfoText = styled.span`
 const ReadTimeBox = styled.div`
   display: flex;
   align-items: center;
-
   gap: 4px;
 `;
 

--- a/frontend/src/pages/today/components/ReadingStatusCard.tsx
+++ b/frontend/src/pages/today/components/ReadingStatusCard.tsx
@@ -103,10 +103,9 @@ export default ReadingStatusCard;
 const ProgressContainer = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 14px;
 
   width: 100%;
-
-  gap: 14px;
 `;
 
 const ProgressInfo = styled.div`
@@ -138,6 +137,7 @@ const Container = styled.section`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 26px;
 
   width: 310px;
   padding: 34px 30px;
@@ -146,17 +146,14 @@ const Container = styled.section`
   box-shadow: 0 25px 50px -12px rgb(0 0 0 / 15%);
 
   background-color: ${({ theme }) => theme.colors.white};
-
-  gap: 26px;
 `;
 
 const TitleWrapper = styled.div`
   display: flex;
   align-items: center;
+  gap: 10px;
 
   width: 100%;
-
-  gap: 10px;
 `;
 
 const StatusIconWrapper = styled.div`
@@ -189,7 +186,6 @@ const StreakWrapper = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
-
   gap: 10px;
 `;
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- Select 컴포넌트를 제작한다.
<img width="155" height="173" alt="image" src="https://github.com/user-attachments/assets/11db934d-2fbf-4104-b246-0e42d1c13adf" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- useClickOutsideRef 훅을 제작하여 바깥을 클릭하면 자동으로 닫히게 구현하였습니다.
- value 타입을 제네릭으로 구현하였습니다.
<img width="801" height="382" alt="image" src="https://github.com/user-attachments/assets/ffaed83c-8217-4149-9325-cc0aed03b391" />


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 디자인 고민 사항
<img width="164" height="166" alt="image" src="https://github.com/user-attachments/assets/61802617-88f4-4a5c-8fbc-1c5875bdec0f" />
<img width="157" height="177" alt="image" src="https://github.com/user-attachments/assets/01627728-e9da-4222-a176-85f621a622ad" />

- 현재 shadcn에서 가져온 Select 컴포넌트의 디자인에서는 menu에서 위아래 패딩이 존재하지 않습니다(1번 사진). 근데 뭔가 조금 어색해서 좌우 패딩과 똑같이 위아래 패딩을 추가해보았는데요(2번 사진). 제 눈에는 뭐가 더 괜찮은지 모르겠네요.. 어느 것이 더 나은지 의견 주시면 감사하겠습니다!

