### PR TITLE
[BE][BOM-87] feat: 카테고리 별 아티클 개수 조회 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.article.dto.ArticleDetailResponse;
 import me.bombom.api.v1.article.dto.ArticleResponse;
+import me.bombom.api.v1.article.dto.GetArticleCategoryStatisticsResponse;
 import me.bombom.api.v1.article.dto.GetArticlesOptions;
 import me.bombom.api.v1.article.service.ArticleService;
 import org.springframework.data.domain.Page;
@@ -44,5 +45,10 @@ public class ArticleController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateIsRead(@PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id) {
         articleService.markAsRead(id);
+    }
+
+    @GetMapping("/statistics/categories")
+    public GetArticleCategoryStatisticsResponse getArticleCategoryStatistics(@RequestParam Long memberId){
+        return articleService.getArticleCategoryStatistics(memberId);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/dto/GetArticleCategoryStatisticsResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/dto/GetArticleCategoryStatisticsResponse.java
@@ -1,0 +1,16 @@
+package me.bombom.api.v1.article.dto;
+
+import java.util.List;
+
+public record GetArticleCategoryStatisticsResponse(
+        int totalCount,
+        List<GetArticleCountPerCategoryResponse> categories
+) {
+
+    public static GetArticleCategoryStatisticsResponse of(
+            int totalCount,
+            List<GetArticleCountPerCategoryResponse> countResponse
+    ) {
+        return new GetArticleCategoryStatisticsResponse(totalCount, countResponse);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/dto/GetArticleCountPerCategoryResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/dto/GetArticleCountPerCategoryResponse.java
@@ -1,0 +1,13 @@
+package me.bombom.api.v1.article.dto;
+
+import me.bombom.api.v1.newsletter.domain.Category;
+
+public record GetArticleCountPerCategoryResponse(
+        String category,
+        long count
+) {
+
+    public static GetArticleCountPerCategoryResponse of(Category category, long count) {
+        return new GetArticleCountPerCategoryResponse(category.getName(), count);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepository.java
@@ -16,6 +16,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, CustomA
         INNER JOIN Newsletter AS n 
         ON a.newsletterId = n.id 
         WHERE n.categoryId = :categoryId 
+            AND a.memberId = :memberId 
     """)
-    int countAllByCategoryId(Long categoryId);
+    int countAllByCategoryIdAndMemberId(Long categoryId, Long memberId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepository.java
@@ -1,7 +1,21 @@
 package me.bombom.api.v1.article.repository;
 
+import java.util.List;
 import me.bombom.api.v1.article.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface ArticleRepository extends JpaRepository<Article, Long>, CustomArticleRepository {
+
+    List<Article> findAllByMemberId(Long memberId);
+    int countAllByMemberId(Long memberId);
+
+    @Query("""
+        SELECT count(*) 
+        FROM Article AS a 
+        INNER JOIN Newsletter AS n 
+        ON a.newsletterId = n.id 
+        WHERE n.categoryId = :categoryId 
+    """)
+    int countAllByCategoryId(Long categoryId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
@@ -1,10 +1,13 @@
 package me.bombom.api.v1.article.service;
 
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.dto.ArticleDetailResponse;
 import me.bombom.api.v1.article.dto.ArticleResponse;
+import me.bombom.api.v1.article.dto.GetArticleCategoryStatisticsResponse;
+import me.bombom.api.v1.article.dto.GetArticleCountPerCategoryResponse;
 import me.bombom.api.v1.article.dto.GetArticlesOptions;
 import me.bombom.api.v1.article.repository.ArticleRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
@@ -51,6 +54,19 @@ public class ArticleService {
         Article article = articleRepository.findById(id)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
         article.markAsRead();
+    }
+
+    public GetArticleCategoryStatisticsResponse getArticleCategoryStatistics(Long memberId) {
+        validateMemberExists(memberId);
+        int totalCount = articleRepository.countAllByMemberId(memberId);
+        List<GetArticleCountPerCategoryResponse> countResponse = categoryRepository.findAll()
+                .stream()
+                .map(category -> {
+                    int count = articleRepository.countAllByCategoryId(category.getId());
+                    return GetArticleCountPerCategoryResponse.of(category, count);
+                })
+                .toList();
+        return GetArticleCategoryStatisticsResponse.of(totalCount, countResponse);
     }
 
     private void validateMemberExists(Long memberId) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
@@ -62,7 +62,7 @@ public class ArticleService {
         List<GetArticleCountPerCategoryResponse> countResponse = categoryRepository.findAll()
                 .stream()
                 .map(category -> {
-                    int count = articleRepository.countAllByCategoryId(category.getId());
+                    int count = articleRepository.countAllByCategoryIdAndMemberId(category.getId(), memberId);
                     return GetArticleCountPerCategoryResponse.of(category, count);
                 })
                 .toList();

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/service/ArticleServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/service/ArticleServiceTest.java
@@ -10,6 +10,7 @@ import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.dto.ArticleDetailResponse;
 import me.bombom.api.v1.article.dto.ArticleResponse;
+import me.bombom.api.v1.article.dto.GetArticleCategoryStatisticsResponse;
 import me.bombom.api.v1.article.dto.GetArticlesOptions;
 import me.bombom.api.v1.article.enums.SortOption;
 import me.bombom.api.v1.article.repository.ArticleRepository;
@@ -73,7 +74,7 @@ class ArticleServiceTest {
     void 아티클_목록_조회_DESC_정렬_테스트() {
         // given
         Pageable pageable = PageRequest.of(0, 10); // 충분한 크기로 전체 조회
-        
+
         // when
         Page<ArticleResponse> result = articleService.getArticles(
                 member.getId(),
@@ -95,7 +96,7 @@ class ArticleServiceTest {
     void 아티클_목록_조회_ASC_정렬_테스트() {
         // given
         Pageable pageable = PageRequest.of(0, 10);
-        
+
         // when
         Page<ArticleResponse> result = articleService.getArticles(
                 member.getId(),
@@ -141,7 +142,7 @@ class ArticleServiceTest {
     void 아티클_목록_조회_날짜_필터링_테스트() {
         // given
         Pageable pageable = PageRequest.of(0, 10);
-        
+
         // when
         Page<ArticleResponse> result = articleService.getArticles(
                 member.getId(),
@@ -174,7 +175,7 @@ class ArticleServiceTest {
     void 아티클_목록_조회_카테고리가_존재하지_않으면_예외() {
         // given
         Pageable pageable = PageRequest.of(0, 10);
-        
+
         // when & then
         assertThatThrownBy(() -> articleService.getArticles(
                 member.getId(),
@@ -188,7 +189,7 @@ class ArticleServiceTest {
     void 아티클_목록_조회_페이징_첫번째_페이지_테스트() {
         // given
         Pageable firstPage = PageRequest.of(0, 2);
-        
+
         // when
         Page<ArticleResponse> result = articleService.getArticles(
                 member.getId(),
@@ -214,7 +215,7 @@ class ArticleServiceTest {
     void 아티클_목록_조회_페이징_두번째_페이지_테스트() {
         // given
         Pageable secondPage = PageRequest.of(1, 2);
-        
+
         // when
         Page<ArticleResponse> result = articleService.getArticles(
                 member.getId(),
@@ -240,7 +241,7 @@ class ArticleServiceTest {
     void 아티클_목록_조회_페이징_DESC_정렬_테스트() {
         // given
         Pageable pageable = PageRequest.of(0, 2);
-        
+
         // when
         Page<ArticleResponse> result = articleService.getArticles(
                 member.getId(),
@@ -262,7 +263,7 @@ class ArticleServiceTest {
     void 아티클_목록_조회_페이징_ASC_정렬_테스트() {
         // given
         Pageable pageable = PageRequest.of(0, 2);
-        
+
         // when
         Page<ArticleResponse> result = articleService.getArticles(
                 member.getId(),
@@ -387,6 +388,30 @@ class ArticleServiceTest {
     void 다_읽음_갱신_아티클이_존재하지_않으면_예외() {
         // when & then
         assertThatThrownBy(() -> articleService.markAsRead(0L))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 카테고리_별_아티클_개수를_조회한다() {
+        // when
+        GetArticleCategoryStatisticsResponse result = articleService.getArticleCategoryStatistics(member.getId());
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.totalCount()).isEqualTo(4);
+            softly.assertThat(result.categories()).hasSize(3);
+            softly.assertThat(result.categories().get(1).category()).isEqualTo("테크");
+            softly.assertThat(result.categories().get(1).count()).isEqualTo(1);
+            softly.assertThat(result.categories().get(2).category()).isEqualTo("푸드");
+            softly.assertThat(result.categories().get(2).count()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void 카테고리_별_아티클_개수_조회_시_회원이_존재하지_않을_경우_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> articleService.getArticleCategoryStatistics(2L))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
     }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 카테고리 별 아티클 개수를 조회하는 API를 구현합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
1. `memberId`가 유효한지 검증합니다.
2. 해당 회원의 전체 아티클 개수를 count 합니다.
3. 모든 `category`를 불러오고, 각 카테고리를 순회하며 아티클 개수를 조회해 dto에 담습니다.

- `articleRepository.countAllByCategoryIdAndMemberId(category.getId(), memberId)`를 JPQL로 작성했습니다.
- JPA method로만 구성할 경우,
  1. 모든 `category`를 조회합니다.
  2. 회원의 모든 `article`을 조회합니다.
  3. 각 카테고리를 순회하며, `article`들 중 `newsletter`의 `categoryId`가 현재 `categoryId()`와 같은 것들을 필터링 합니다. 
    -> 매 article 마다 newsletter 조회 query 발생
        : `(카테고리 개수 * 아티클 개수)`번의 추가 쿼리

- 따라서 JPQL로 개수 조회 쿼리를 작성하는 것이 더 효율적일 것이라고 판단했습니다. 

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 네이밍은 언제나 어렵네요.. 메서드나 클래스 네이밍 추천 있으면 부탁드립니다! (특히 controller, service 메서드 네이밍)
- 더 효율적인 로직 있다면 피드백 부탁드립니다-