### PR TITLE
[BE][BOM-101] fix: 뉴스레터 이메일 길이 제한 증가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Newsletter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/domain/Newsletter.java
@@ -30,7 +30,7 @@ public class Newsletter extends BaseEntity {
     @Column(nullable = false, length = 512)
     private String imageUrl;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 60)
     private String email;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
뉴스레터 중에 발신 이메일 길이가 30자가 넘는 곳이 있습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
다 담아야 할 것 같아요

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- email length를 30 -> 60으로 넉넉하게 늘립니다.
- `ddl-auto` 설정이 `update`로 되어있지만, 현재 더미 데이터가 존재하므로 코드만 바꾼다고 테이블의 제약 조건 변경이 반영되진 않습니다.
- 따라서 RDS에서 직접 아래 쿼리도 실행했습니다.
```sql
ALTER TABLE newsletter
MODIFY COLUMN email VARCHAR(60) NOT NULL;
```

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
