### PR TITLE
[BE][BOM-93] feat: 다 읽음 API 로직에 읽은 개수 갱신 로직 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
@@ -43,8 +43,8 @@ public class ArticleController {
 
     @PatchMapping("/{id}/read")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateIsRead(@PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id) {
-        articleService.markAsRead(id);
+    public void updateIsRead(@PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id, @RequestParam Long memberId) {
+        articleService.markAsRead(id, memberId);
     }
 
     @GetMapping("/statistics/categories")

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -78,5 +79,9 @@ public class Article extends BaseEntity {
 
     public void markAsRead() {
         isRead = true;
+    }
+
+    public boolean isArrivedToday() {
+        return arrivedDateTime.toLocalDate().isEqual(LocalDate.now());
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MemberController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MemberController.java
@@ -27,11 +27,6 @@ public class MemberController {
         return memberService.updateWeeklyGoalCount(request);
     }
 
-    @PatchMapping("/me/reading/progress/week/count")
-    public WeeklyCurrentCountResponse updateWeeklyCurrentCount(@Valid @RequestBody UpdateWeeklyCurrentCountRequest request){
-        return memberService.updateWeeklyCurrentCount(request);
-    }
-
     @GetMapping("/me/reading")
     public ReadingInformationResponse getReadingInformation(@RequestParam Long memberId){
         return memberService.getReadingInformation(memberId);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/TodayReading.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/TodayReading.java
@@ -17,6 +17,8 @@ import me.bombom.api.v1.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TodayReading extends BaseEntity {
 
+    private static final int INCREASE_CURRENT_COUNT = 1;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -41,5 +43,9 @@ public class TodayReading extends BaseEntity {
         this.memberId = memberId;
         this.totalCount = totalCount;
         this.currentCount = currentCount;
+    }
+
+    public void increaseCurrentCount() {
+        this.currentCount += INCREASE_CURRENT_COUNT;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/WeeklyReading.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/WeeklyReading.java
@@ -17,7 +17,7 @@ import me.bombom.api.v1.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class WeeklyReading extends BaseEntity {
 
-    public static final int INCREASE_CURRENT_COUNT = 1;
+    private static final int INCREASE_CURRENT_COUNT = 1;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -49,7 +49,7 @@ public class WeeklyReading extends BaseEntity {
         this.goalCount = goalCount;
     }
 
-    public void increaseCurrentCount(int increaseCount) {
-        this.currentCount += increaseCount;
+    public void increaseCurrentCount() {
+        this.currentCount += INCREASE_CURRENT_COUNT;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -38,15 +38,6 @@ public class MemberService {
         return WeeklyGoalCountResponse.from(weeklyReading);
     }
 
-    public WeeklyCurrentCountResponse updateWeeklyCurrentCount(UpdateWeeklyCurrentCountRequest request) {
-        Member member = memberRepository.findById(request.memberId())
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
-        WeeklyReading weeklyReading = weeklyReadingRepository.findByMemberId(member.getId())
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
-        weeklyReading.increaseCurrentCount(WeeklyReading.INCREASE_CURRENT_COUNT);
-        return WeeklyCurrentCountResponse.from(weeklyReading);
-    }
-
     public ReadingInformationResponse getReadingInformation(Long memberId) {
         ContinueReading continueReading = continueReadingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/domain/ArticleTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/domain/ArticleTest.java
@@ -8,17 +8,41 @@ import org.junit.jupiter.api.Test;
 
 class ArticleTest {
 
-    private static final LocalDateTime baseTime = LocalDateTime.of(2025, 7, 15, 10, 0);
+    private static final LocalDateTime BASE_TIME = LocalDateTime.of(2025, 7, 15, 10, 0);
 
     @Test
     void 아티클의_읽기_상태를_true로_바꿀_수_있다() {
         //given
-        Article article = TestFixture.createArticle(1L, 1L, baseTime);
+        Article article = TestFixture.createArticle(1L, 1L, BASE_TIME);
 
         //when
         article.markAsRead();
 
         //then
         assertThat(article.isRead()).isTrue();
+    }
+
+    @Test
+    void 아티클이_오늘_도착했으면_true를_반환한다() {
+        // given
+        Article article = TestFixture.createArticle(1L, 1L, LocalDateTime.now());
+
+        // when
+        boolean result = article.isArrivedToday();
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void 아티클이_오늘_도착하지_않았으면_false를_반환한다() {
+        // given
+        Article article = TestFixture.createArticle(1L, 1L, BASE_TIME);
+
+        // when
+        boolean result = article.isArrivedToday();
+
+        // then
+        assertThat(result).isFalse();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MemberServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MemberServiceTest.java
@@ -9,10 +9,8 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.domain.WeeklyReading;
-import me.bombom.api.v1.member.dto.request.UpdateWeeklyCurrentCountRequest;
 import me.bombom.api.v1.member.dto.request.UpdateWeeklyGoalCountRequest;
 import me.bombom.api.v1.member.dto.response.ReadingInformationResponse;
-import me.bombom.api.v1.member.dto.response.WeeklyCurrentCountResponse;
 import me.bombom.api.v1.member.dto.response.WeeklyGoalCountResponse;
 import me.bombom.api.v1.member.repository.ContinueReadingRepository;
 import me.bombom.api.v1.member.repository.MemberRepository;
@@ -43,7 +41,7 @@ class MemberServiceTest {
     private TodayReadingRepository todayReadingRepository;
 
     @Test
-    void 주간_목표를_수정할_수_있다(){
+    void 주간_목표를_수정할_수_있다() {
         // given
         Member savedMember = memberRepository.save(TestFixture.normalMemberFixture());
 
@@ -89,57 +87,6 @@ class MemberServiceTest {
 
         // when & then
         assertThatThrownBy(() -> memberService.updateWeeklyGoalCount(request))
-                .isInstanceOf(CIllegalArgumentException.class)
-                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
-    }
-    
-    @Test
-    void 이번_주에_읽은_아티클_수를_갱신할_수_있다() {
-        // given
-        Member savedMember = memberRepository.save(TestFixture.normalMemberFixture());
-
-        WeeklyReading weeklyReading = WeeklyReading.builder()
-                .memberId(savedMember.getId())
-                .goalCount(0)
-                .currentCount(2)
-                .build();
-        weeklyReadingRepository.save(weeklyReading);
-
-        UpdateWeeklyCurrentCountRequest request = new UpdateWeeklyCurrentCountRequest(savedMember.getId());
-        
-        // when
-        WeeklyCurrentCountResponse result = memberService.updateWeeklyCurrentCount(request);
-
-        // then
-        assertThat(result.currentCount()).isEqualTo(3);
-    }
-
-    @Test
-    void 이번주_읽은_수_갱신에서_회원_정보가_존재하지_않을_경우_예외가_발생한다() {
-        // given
-        WeeklyReading weeklyReading = WeeklyReading.builder()
-                .memberId(0L)
-                .goalCount(0)
-                .currentCount(2)
-                .build();
-        weeklyReadingRepository.save(weeklyReading);
-
-        UpdateWeeklyCurrentCountRequest request = new UpdateWeeklyCurrentCountRequest(0L);
-
-        // when & then
-        assertThatThrownBy(() -> memberService.updateWeeklyCurrentCount(request))
-                .isInstanceOf(CIllegalArgumentException.class)
-                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
-    }
-
-    @Test
-    void 이번주_읽은_수_갱신에서_주간_목표_정보가_존재하지_않을_경우_예외가_발생한다() {
-        // given
-        Member savedMember = memberRepository.save(TestFixture.normalMemberFixture());
-        UpdateWeeklyCurrentCountRequest request = new UpdateWeeklyCurrentCountRequest(savedMember.getId());
-
-        // when & then
-        assertThatThrownBy(() -> memberService.updateWeeklyCurrentCount(request))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
     }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 다 읽음 API 내에서 오늘 읽은 개수와 이번주 읽은 개수를 갱신하는 로직을 추가합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 프론트측에서 이렇게 하나로 호출하는게 편하다 합니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 이번 주 읽은 개수 갱신 API를 삭제했습니다.
- 다 읽으면 해당 아티클이 도착한 날에 상관 없이 `이번 주 읽은 아티클 수`를 +1 합니다.
- 만약 타겟 아티클이 오늘 왔으면 `오늘 읽은 아티클 수`를 +1 합니다.
- 해당 아티클을 읽었다는 갱신을 시도하는 `memberId`에 대해 검증이 필요할 것 같아, 이를 쿼리 파라미터로 받고 검증하도록 추가합니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
