### PR TITLE
[BE][BOM-110] fix: 뉴스레터 목록 조회 반환 객체에 category 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/dto/NewsletterResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/dto/NewsletterResponse.java
@@ -5,6 +5,7 @@ public record NewsletterResponse(
         String name,
         String imageUrl,
         String description,
-        String mainPageUrl
+        String mainPageUrl,
+        String category
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/repository/NewsletterRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/repository/NewsletterRepository.java
@@ -9,11 +9,12 @@ import org.springframework.data.jpa.repository.Query;
 public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
 
     @Query("""
-        SELECT new me.bombom.api.v1.newsletter.dto.NewsletterResponse( 
-                n.id, n.name, n.imageUrl, n.description, d.mainPageUrl
+        SELECT new me.bombom.api.v1.newsletter.dto.NewsletterResponse(
+                n.id, n.name, n.imageUrl, n.description, d.mainPageUrl, c.name
             )
         FROM Newsletter n
         JOIN NewsletterDetail d ON n.detailId = d.id
+        JOIN Category c ON c.id = n.categoryId
         ORDER BY d.subscribeCount DESC, n.name ASC
     """)
     List<NewsletterResponse> findNewslettersInfo();

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -10,6 +10,7 @@ import me.bombom.api.v1.member.domain.WeeklyReading;
 import me.bombom.api.v1.member.enums.Gender;
 import me.bombom.api.v1.newsletter.domain.Category;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.domain.NewsletterDetail;
 
 public final class TestFixture {
 
@@ -68,6 +69,32 @@ public final class TestFixture {
                 .categoryId(categoryId)
                 .detailId(1L)
                 .build();
+    }
+
+    /**
+     * NewsletterDetail
+     */
+    public static List<NewsletterDetail> createNewsletterDetails() {
+        return List.of(
+                NewsletterDetail.builder()
+                        .mainPageUrl("https://news1.com")
+                        .subscribeUrl("https://news1.com/subscribe")
+                        .issueCycle("매일 발행")
+                        .subscribeCount(1000)
+                        .build(),
+                NewsletterDetail.builder()
+                        .mainPageUrl("https://ittimes.com")
+                        .subscribeUrl("https://ittimes.com/subscribe")
+                        .issueCycle("매주 월요일")
+                        .subscribeCount(850)
+                        .build(),
+                NewsletterDetail.builder()
+                        .mainPageUrl("https://biz.com")
+                        .subscribeUrl("https://biz.com/subscribe")
+                        .issueCycle("격주 화요일")
+                        .subscribeCount(600)
+                        .build()
+        );
     }
 
     /**

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/service/NewsletterServiceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.newsletter.domain.Category;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
-import me.bombom.api.v1.newsletter.domain.NewsletterDetail;
 import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
+import me.bombom.api.v1.newsletter.repository.CategoryRepository;
 import me.bombom.api.v1.newsletter.repository.NewsletterDetailRepository;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,57 +30,17 @@ class NewsletterServiceTest {
     @Autowired
     private NewsletterDetailRepository newsletterDetailRepository;
 
+    @Autowired
+    private CategoryRepository categoryRepository;
+
     private List<Newsletter> newsletters;
 
     @BeforeEach
     public void setup() {
-        List<NewsletterDetail> newsletterDetails = List.of(
-            NewsletterDetail.builder()
-                    .mainPageUrl("https://news1.com")
-                    .subscribeUrl("https://news1.com/subscribe")
-                    .issueCycle("매일")
-                    .subscribeCount(1000)
-                    .build(),
-            NewsletterDetail.builder()
-                    .mainPageUrl("https://ittimes.com")
-                    .subscribeUrl("https://ittimes.com/subscribe")
-                    .issueCycle("매주 월요일")
-                    .subscribeCount(850)
-                    .build(),
-            NewsletterDetail.builder()
-                    .mainPageUrl("https://biz.com")
-                    .subscribeUrl("https://biz.com/subscribe")
-                    .issueCycle("격주 화요일")
-                    .subscribeCount(600)
-                    .build()
-            );
-        newsletterDetailRepository.saveAll(newsletterDetails);
-        newsletters = List.of(
-            Newsletter.builder()
-                    .name("뉴스픽")
-                    .description("뉴스픽 요약 뉴스")
-                    .imageUrl("https://cdn.bombom.me/img1.png")
-                    .email("news@newspick.com")
-                    .categoryId(1L)
-                    .detailId(newsletterDetails.get(0).getId())
-                    .build(),
-            Newsletter.builder()
-                    .name("IT타임즈")
-                    .description("IT 업계 트렌드")
-                    .imageUrl("https://cdn.bombom.me/img2.png")
-                    .email("editor@ittimes.io")
-                    .categoryId(2L)
-                    .detailId(newsletterDetails.get(1).getId())
-                    .build(),
-            Newsletter.builder()
-                    .name("비즈레터")
-                    .description("비즈니스 뉴스 큐레이션")
-                    .imageUrl("https://cdn.bombom.me/img3.png")
-                    .email("biz@biz.com")
-                    .categoryId(3L)
-                    .detailId(newsletterDetails.get(2).getId())
-                    .build()
-        );
+        newsletterDetailRepository.saveAll(TestFixture.createNewsletterDetails());
+        List<Category> categories = TestFixture.createCategories();
+        categoryRepository.saveAll(categories);
+        newsletters = TestFixture.createNewsletters(categories);
         newsletterRepository.saveAll(newsletters);
     }
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
뉴스레터 목록 조회 반환 객체에 category를 추가하였습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
뉴스레터 목록 조회시에 카테코리를 보여주기 위해서

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
