### PR TITLE
[FE][BOM-152] test: 테스트가 깨지는 현상 수정

### DIFF
--- a/frontend/src/utils/date.test.ts
+++ b/frontend/src/utils/date.test.ts
@@ -2,7 +2,7 @@ import { formatDate } from './date';
 
 describe('formatDate', () => {
   it('Date 정보를 점(.)으로 구분된 문자열로 변환한다.', () => {
-    const date = new Date('2025-07-01T12:00:00Z');
+    const date = new Date('2025-07-01T12:00:00');
     expect(formatDate(date)).toBe('2025.07.01');
   });
 });

--- a/frontend/src/utils/math.test.ts
+++ b/frontend/src/utils/math.test.ts
@@ -7,9 +7,11 @@ describe('calculateRate', () => {
     expect(calculateRate(VALUE, TOTAL)).toBe(25);
   });
 
-  it('전체를 의미하는 total의 값이 0일 때 0을 반환한다.', () => {
+  it('전체를 의미하는 total의 값이 0일 때 에러를 던진다.', () => {
     const TOTAL = 0;
     const VALUE = 50;
-    expect(calculateRate(VALUE, TOTAL)).toBe(0);
+    expect(() => calculateRate(VALUE, TOTAL)).toThrow(
+      '나누어지는 수(total)은 0이 될 수 없습니다.',
+    );
   });
 });


### PR DESCRIPTION
## 📌 What
- 유틸 테스트 date, math에서 테스트가 깨지는 현상 발생

## ❓ Why
- date: 로컬이 아닌 UTC 타임존 기준으로 테스트를 실행함
- math: 함수 로직의 변경이 테스트 코드에 반영되지 않음

## 🔧 How
- date: 로컬 타임존 기준으로 날짜를 계산하도록 수정
- math: 함수 로직 변경 반영

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
