### PR TITLE
[FE][BOM-160] fix: 디바운싱 타임 수정

### DIFF
--- a/frontend/src/routes/storage.tsx
+++ b/frontend/src/routes/storage.tsx
@@ -39,7 +39,7 @@ function Storage() {
 
   const debouncedSearch = useDebounce(() => {
     refetchArticles();
-  }, 300);
+  }, 500);
 
   if (!articles || !categoryCounts) return null;
 


### PR DESCRIPTION
## 📌 What
검색 api 요청에 걸려있는 디바운싱 타임 수정

## ❓ Why
- 검색어가 변경될 때 실시간으로 요청을 보내면서, 과도한 요청이 오고 있다는 백엔드 측의 피드백을 받음

## 🔧 How
- 디바운스 시간을 300ms 에서 500ms로 변경

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
