### PR TITLE
[BE][BOM-164] feat: 회원가입 시 읽기 정보 초기화

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/controller/AuthController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/controller/AuthController.java
@@ -1,11 +1,9 @@
 package me.bombom.api.v1.auth.controller;
 
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
-import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.dto.PendingOAuth2Member;
@@ -33,31 +31,16 @@ public class AuthController {
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.CREATED)
     public void signup(@RequestBody MemberSignupRequest signupRequest, HttpServletRequest request) {
-        log.info("========== Signup Start ==========");
-        if (request.getCookies() != null) {
-            Arrays.stream(request.getCookies())
-                .forEach(cookie -> log.info("요청 쿠키: {}={}", cookie.getName(), cookie.getValue()));
-        } else {
-            log.warn("요청에 쿠키가 전혀 없습니다.");
-        }
-
         HttpSession session = request.getSession(false);
         if (session == null) {
-            log.error("세션을 찾을 수 없습니다. request.getSession(false)가 null을 반환했습니다.");
             throw new UnauthorizedException(ErrorDetail.MISSING_OAUTH_DATA);
         }
-
-        log.info("세션 ID: {}", session.getId());
         PendingOAuth2Member pendingMember = (PendingOAuth2Member) session.getAttribute("pendingMember");
         if (pendingMember == null) {
-            log.error("세션에서 'pendingMember'를 찾을 수 없습니다.");
             throw new UnauthorizedException(ErrorDetail.MISSING_OAUTH_DATA);
         }
-
-        log.info("성공적으로 pendingMember를 찾았습니다: {}", pendingMember);
         memberService.signup(pendingMember, signupRequest);
         session.removeAttribute("pendingMember");
-        log.info("========== Signup End ==========");
     }
 
     @GetMapping("/login/{provider}")

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -29,26 +29,18 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             NativeWebRequest webRequest,
             WebDataBinderFactory binderFactory
     ) {
-        log.info("========== LoginMemberArgumentResolver Start ==========");
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication == null ||  !authentication.isAuthenticated()) {
-            log.error("SecurityContextHolder에 인증 정보가 없거나, 인증되지 않은 사용자입니다.");
             throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
         }
-        log.info("Authentication 객체: {}", authentication);
         Object principal = authentication.getPrincipal();
-        log.info("Principal 객체: {}", principal);
         if (principal instanceof CustomOAuth2User) {
             Member member = ((CustomOAuth2User) principal).getMember();
             if (member == null) {
-                log.error("Principal 객체는 CustomOAuth2User이지만, 내부에 Member 객체가 null입니다.");
                 throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
             }
-            log.info("성공적으로 Member 객체를 찾았습니다: {}", member);
-            log.info("========== LoginMemberArgumentResolver End ==========");
             return member;
         }
-        log.error("Principal 객체가 CustomOAuth2User 타입이 아닙니다. 타입: {}", principal.getClass().getName());
         throw new  UnauthorizedException(ErrorDetail.INVALID_TOKEN);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/event/MemberSignupEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/event/MemberSignupEvent.java
@@ -1,0 +1,16 @@
+package me.bombom.api.v1.member.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class MemberSignupEvent extends ApplicationEvent {
+
+    private final Long memberId;
+
+    public MemberSignupEvent(Object source, Long memberId) {
+        super(source);
+        this.memberId = memberId;
+    }
+}
+

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/event/MemberSignupEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/event/MemberSignupEvent.java
@@ -1,15 +1,13 @@
 package me.bombom.api.v1.member.event;
 
 import lombok.Getter;
-import org.springframework.context.ApplicationEvent;
 
 @Getter
-public class MemberSignupEvent extends ApplicationEvent {
+public class MemberSignupEvent {
 
     private final Long memberId;
 
-    public MemberSignupEvent(Object source, Long memberId) {
-        super(source);
+    public MemberSignupEvent(Long memberId) {
         this.memberId = memberId;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/event/MemberSignupListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/event/MemberSignupListener.java
@@ -1,0 +1,23 @@
+package me.bombom.api.v1.member.event;
+
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.reading.service.ReadingService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class MemberSignupListener {
+
+    private final ReadingService readingService;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(MemberSignupEvent event) {
+        try {
+            readingService.initializeReadingInformation(event.getMemberId());
+        } catch (Exception e) {
+            // 로깅
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -29,7 +29,7 @@ public class MemberService {
                 .profileImageUrl(pendingMember.getProfileUrl())
                 .nickname(signupRequest.nickname())
                 .gender(signupRequest.gender())
-                .roleId(0L)
+                .roleId(1L)
                 .build();
         Member savedMember = memberRepository.save(newMember);
         readingService.initializeReadingInformation(savedMember.getId());

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
                 .roleId(1L)
                 .build();
         Member savedMember = memberRepository.save(newMember);
-        applicationEventPublisher.publishEvent(new MemberSignupEvent(this, savedMember.getId()));
+        applicationEventPublisher.publishEvent(new MemberSignupEvent(savedMember.getId()));
         return savedMember;
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -14,14 +14,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     // TODO : 회원가입 입력 정보 양식 반영
+    @Transactional
     public Member signup(PendingOAuth2Member pendingMember, MemberSignupRequest signupRequest) {
         Member newMember = Member.builder()
                 .provider(pendingMember.getProvider())

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberService {
 
+    private static final long MEMBER_ROLE_ID = 1L;
+
     private final MemberRepository memberRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -31,7 +33,7 @@ public class MemberService {
                 .profileImageUrl(pendingMember.getProfileUrl())
                 .nickname(signupRequest.nickname())
                 .gender(signupRequest.gender())
-                .roleId(1L)
+                .roleId(MEMBER_ROLE_ID)
                 .build();
         Member savedMember = memberRepository.save(newMember);
         applicationEventPublisher.publishEvent(new MemberSignupEvent(savedMember.getId()));

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package me.bombom.api.v1.member.service;
 
-import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.auth.dto.PendingOAuth2Member;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
@@ -9,6 +8,7 @@ import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.dto.request.MemberSignupRequest;
 import me.bombom.api.v1.member.dto.response.MemberProfileResponse;
 import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.reading.service.ReadingService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
+    private final ReadingService readingService;
     private final MemberRepository memberRepository;
 
     // TODO : 회원가입 입력 정보 양식 반영
@@ -30,7 +31,9 @@ public class MemberService {
                 .gender(signupRequest.gender())
                 .roleId(0L)
                 .build();
-        return memberRepository.save(newMember);
+        Member savedMember = memberRepository.save(newMember);
+        readingService.initializeReadingInformation(savedMember.getId());
+        return savedMember;
     }
 
     public MemberProfileResponse getProfile(Long id) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -7,8 +7,9 @@ import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.dto.request.MemberSignupRequest;
 import me.bombom.api.v1.member.dto.response.MemberProfileResponse;
+import me.bombom.api.v1.member.event.MemberSignupEvent;
 import me.bombom.api.v1.member.repository.MemberRepository;
-import me.bombom.api.v1.reading.service.ReadingService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final ReadingService readingService;
     private final MemberRepository memberRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     // TODO : 회원가입 입력 정보 양식 반영
     public Member signup(PendingOAuth2Member pendingMember, MemberSignupRequest signupRequest) {
@@ -32,7 +33,7 @@ public class MemberService {
                 .roleId(1L)
                 .build();
         Member savedMember = memberRepository.save(newMember);
-        readingService.initializeReadingInformation(savedMember.getId());
+        applicationEventPublisher.publishEvent(new MemberSignupEvent(this, savedMember.getId()));
         return savedMember;
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -23,10 +23,35 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ReadingService {
 
+    public static final int INITIAL_COUNT = 0;
+
     private final MemberRepository memberRepository;
     private final ContinueReadingRepository continueReadingRepository;
     private final TodayReadingRepository todayReadingRepository;
     private final WeeklyReadingRepository weeklyReadingRepository;
+
+    @Transactional
+    public void initializeReadingInformation(Long memberId) {
+        ContinueReading newContinueReading = ContinueReading.builder()
+                .memberId(memberId)
+                .dayCount(INITIAL_COUNT)
+                .build();
+        continueReadingRepository.save(newContinueReading);
+
+        TodayReading newTodayReading = TodayReading.builder()
+                .memberId(memberId)
+                .totalCount(INITIAL_COUNT)
+                .currentCount(INITIAL_COUNT)
+                .build();
+        todayReadingRepository.save(newTodayReading);
+
+        WeeklyReading newWeeklyReading = WeeklyReading.builder()
+                .memberId(memberId)
+                .goalCount(INITIAL_COUNT)
+                .currentCount(INITIAL_COUNT)
+                .build();
+        weeklyReadingRepository.save(newWeeklyReading);
+    }
 
     @Transactional
     public WeeklyGoalCountResponse updateWeeklyGoalCount(UpdateWeeklyGoalCountRequest request) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -23,7 +23,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ReadingService {
 
-    public static final int INITIAL_COUNT = 0;
+    private static final int INITIAL_COUNT = 0;
+    private static final int INITIAL_WEEKLY_GOAL_COUNT = 3;
 
     private final MemberRepository memberRepository;
     private final ContinueReadingRepository continueReadingRepository;
@@ -47,7 +48,7 @@ public class ReadingService {
 
         WeeklyReading newWeeklyReading = WeeklyReading.builder()
                 .memberId(memberId)
-                .goalCount(INITIAL_COUNT)
+                .goalCount(INITIAL_WEEKLY_GOAL_COUNT)
                 .currentCount(INITIAL_COUNT)
                 .build();
         weeklyReadingRepository.save(newWeeklyReading);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/event/MemberSignupListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/event/MemberSignupListenerTest.java
@@ -11,12 +11,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
 @SpringBootTest
+@ActiveProfiles("test")
 class MemberSignupListenerTest {
 
     @Autowired

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/event/MemberSignupListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/event/MemberSignupListenerTest.java
@@ -1,0 +1,44 @@
+package me.bombom.api.v1.member.event;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.reading.service.ReadingService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class MemberSignupListenerTest {
+
+    @Autowired
+    ApplicationEventPublisher publisher;
+
+    @Autowired
+    MemberRepository memberRepository;
+
+    @MockitoBean
+    ReadingService readingService;
+
+    @Test
+    void 회원가입_이벤트_발행_시_읽기정보_초기화_메서드가_호출된다() {
+        // given
+        Member member = memberRepository.save(TestFixture.normalMemberFixture());
+
+        // when
+        publisher.publishEvent(new MemberSignupEvent(this, member.getId()));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then
+        verify(readingService, times(1)).initializeReadingInformation(member.getId());
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/event/MemberSignupListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/event/MemberSignupListenerTest.java
@@ -34,7 +34,7 @@ class MemberSignupListenerTest {
         Member member = memberRepository.save(TestFixture.normalMemberFixture());
 
         // when
-        publisher.publishEvent(new MemberSignupEvent(this, member.getId()));
+        publisher.publishEvent(new MemberSignupEvent(member.getId()));
         TestTransaction.flagForCommit();
         TestTransaction.end();
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -156,4 +156,20 @@ class ReadingServiceTest {
                 .isInstanceOf(CIllegalArgumentException.class)
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
     }
+
+    @Test
+    void 읽기_정보를_초기화한다() {
+        // given
+        Member savedMember = memberRepository.save(TestFixture.normalMemberFixture());
+        Long id = savedMember.getId();
+        // when
+        readingService.initializeReadingInformation(id);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(continueReadingRepository.findByMemberId(id)).isPresent();
+            softly.assertThat(todayReadingRepository.findByMemberId(id)).isPresent();
+            softly.assertThat(weeklyReadingRepository.findByMemberId(id)).isPresent();
+        });
+    }
 }


### PR DESCRIPTION
로그 삭제보다 읽기 정보 초기화 비중이 커져서 브랜치 이름을 바꿨더니, 기존 PR에 반영이 안돼서 새로 PR 올립니다. merge후 기존 pr은 close 하겠습니다.
[수정범위](https://github.com/woowacourse-teams/2025-bom-bom/pull/102/files/5e3592f52ab4119df695620c5179175d7da5cb7c..56f5bd28b0994de7a610613c37349f6ccf7ea70d)
[기존PR](https://github.com/woowacourse-teams/2025-bom-bom/pull/93)

## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
회원가입 시 읽기 정보 초기화 방식 수정

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
UX 개선

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
회원가입과 같은 트랜잭션에서 수행하던 읽기 정보 초기화를 동기 이벤트 리스너 기반으로 수정하였습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
테스트 방식에 대해서 생각해봐야 할 것 같습니다. `SpringBootTest`에서 `@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)`이 반영되지 않는 문제가 있어서, 일단 `ReadingServiceTest`만 작성하였습니다.
