### PR TITLE
[BE][BOM-202] feat: 키우기 관련 기능 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
@@ -24,6 +24,7 @@ import me.bombom.api.v1.article.dto.GetArticlesOptions;
 import me.bombom.api.v1.article.dto.QArticleResponse;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.newsletter.dto.QNewsletterSummaryResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -73,6 +74,17 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
                 .where(createMemberWhereClause(memberId))
                 .where(createKeywordWhereClause(keyword))
                 .where(createCategoryIdWhereClause(categoryId))
+                .fetchOne()
+                .intValue();
+    }
+
+    @Override
+    public int countByMemberIdAndArrivedDateTimeAndIsRead(Long memberId, LocalDate date, boolean isRead) {
+        return jpaQueryFactory.select(article.count())
+                .from(article)
+                .where(createMemberWhereClause(memberId))
+                .where(createDateWhereClause(date))
+                .where(article.isRead.eq(isRead))
                 .fetchOne()
                 .intValue();
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
@@ -57,35 +57,44 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
 
     @Override
     public int countAllByMemberId(Long memberId, String keyword) {
-        return jpaQueryFactory.select(article.count())
+        Long count = jpaQueryFactory.select(article.count())
                 .from(article)
                 .where(createMemberWhereClause(memberId))
                 .where(createKeywordWhereClause(keyword))
-                .fetchOne()
+                .fetchOne();
+
+        return Optional.ofNullable(count)
+                .orElse(0L)
                 .intValue();
     }
 
     @Override
     public int countAllByCategoryIdAndMemberId(Long memberId, Long categoryId, String keyword) {
-        return jpaQueryFactory.select(article.count())
+        Long count = jpaQueryFactory.select(article.count())
                 .from(article)
                 .join(newsletter).on(article.newsletterId.eq(newsletter.id))
                 .join(category).on(newsletter.categoryId.eq(category.id))
                 .where(createMemberWhereClause(memberId))
                 .where(createKeywordWhereClause(keyword))
                 .where(createCategoryIdWhereClause(categoryId))
-                .fetchOne()
+                .fetchOne();
+
+        return Optional.ofNullable(count)
+                .orElse(0L)
                 .intValue();
     }
 
     @Override
     public int countByMemberIdAndArrivedDateTimeAndIsRead(Long memberId, LocalDate date, boolean isRead) {
-        return jpaQueryFactory.select(article.count())
+        Long count = jpaQueryFactory.select(article.count())
                 .from(article)
                 .where(createMemberWhereClause(memberId))
                 .where(createDateWhereClause(date))
                 .where(article.isRead.eq(isRead))
-                .fetchOne()
+                .fetchOne();
+
+        return Optional.ofNullable(count)
+                .orElse(0L)
                 .intValue();
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/CustomArticleRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/CustomArticleRepository.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.article.repository;
 
+import java.time.LocalDate;
 import me.bombom.api.v1.article.dto.ArticleResponse;
 import me.bombom.api.v1.article.dto.GetArticlesOptions;
 import org.springframework.data.domain.Page;
@@ -10,4 +11,5 @@ public interface CustomArticleRepository {
     Page<ArticleResponse> findByMemberId(Long memberId, GetArticlesOptions options, Pageable pageable);
     int countAllByMemberId(Long memberId, String keyword);
     int countAllByCategoryIdAndMemberId(Long memberId, Long categoryId, String keyword);
+    int countByMemberIdAndArrivedDateTimeAndIsRead(Long memberId, LocalDate date, boolean isRead);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
@@ -62,6 +62,9 @@ public class ArticleService {
     public void markAsRead(Long articleId, Member member) {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        if(article.isRead()) {
+            return;
+        }
         validateArticleOwner(article, member.getId());
         article.markAsRead();
         readingService.updateReadingCount(article);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.article.service;
 
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.article.domain.Article;
@@ -16,10 +17,14 @@ import me.bombom.api.v1.newsletter.domain.Category;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
 import me.bombom.api.v1.newsletter.repository.CategoryRepository;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
+import me.bombom.api.v1.pet.ScorePolicyConstants;
+import me.bombom.api.v1.pet.event.AddArticleScoreEvent;
 import me.bombom.api.v1.reading.service.ReadingService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -30,6 +35,7 @@ public class ArticleService {
     private final ArticleRepository articleRepository;
     private final CategoryRepository categoryRepository;
     private final NewsletterRepository newsletterRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final ReadingService readingService;
 
     public Page<ArticleResponse> getArticles(
@@ -59,6 +65,7 @@ public class ArticleService {
         validateArticleOwner(article, member.getId());
         article.markAsRead();
         readingService.updateReadingCount(article);
+        applicationEventPublisher.publishEvent(new AddArticleScoreEvent(member));
     }
 
     public GetArticleCategoryStatisticsResponse getArticleCategoryStatistics(Member member, String keyword) {
@@ -71,6 +78,12 @@ public class ArticleService {
                 })
                 .toList();
         return GetArticleCategoryStatisticsResponse.of(totalCount, countResponse);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
+    public boolean canAddArticleScore(Member member){
+        int todayReadCount = articleRepository.countByMemberIdAndArrivedDateTimeAndIsRead(member.getId(), LocalDate.now(), true);
+        return todayReadCount <= ScorePolicyConstants.MAX_TODAY_READING_COUNT;
     }
 
     private void validateCategoryName(String categoryName) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
@@ -68,7 +68,7 @@ public class ArticleService {
         validateArticleOwner(article, member.getId());
         article.markAsRead();
         readingService.updateReadingCount(article);
-        applicationEventPublisher.publishEvent(new AddArticleScoreEvent(member));
+        applicationEventPublisher.publishEvent(new AddArticleScoreEvent(member.getId()));
     }
 
     public GetArticleCategoryStatisticsResponse getArticleCategoryStatistics(Member member, String keyword) {
@@ -84,8 +84,8 @@ public class ArticleService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
-    public boolean canAddArticleScore(Member member){
-        int todayReadCount = articleRepository.countByMemberIdAndArrivedDateTimeAndIsRead(member.getId(), LocalDate.now(), true);
+    public boolean canAddArticleScore(Long memberId){
+        int todayReadCount = articleRepository.countByMemberIdAndArrivedDateTimeAndIsRead(memberId, LocalDate.now(), true);
         return todayReadCount <= ScorePolicyConstants.MAX_TODAY_READING_COUNT;
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/CServerErrorException.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/CServerErrorException.java
@@ -1,0 +1,16 @@
+package me.bombom.api.v1.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public class CServerErrorException extends RuntimeException{
+
+    private final ErrorDetail errorDetail;
+
+    public HttpStatus getHttpStatus(){
+        return errorDetail.getStatus();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
@@ -25,4 +25,10 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION.getStatus())
                 .body(ErrorResponse.from(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION));
     }
+
+    @ExceptionHandler(CServerErrorException.class)
+    public ResponseEntity<ErrorResponse> handleCServerErrorException(CServerErrorException e){
+        return ResponseEntity.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getErrorDetail()));
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/event/MemberSignupListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/event/MemberSignupListener.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.member.event;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.pet.service.PetService;
 import me.bombom.api.v1.reading.service.ReadingService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -12,11 +13,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class MemberSignupListener {
 
     private final ReadingService readingService;
+    private final PetService petService;
 
     @TransactionalEventListener
     public void on(MemberSignupEvent event) {
         try {
             readingService.initializeReadingInformation(event.getMemberId());
+            petService.createPet(event.getMemberId());
         } catch (Exception e) {
             // TODO: 로깅 및 로직 추가
             log.error("읽기 정보 초기화에 실패했습니다.");

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/ScorePolicyConstants.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/ScorePolicyConstants.java
@@ -1,0 +1,19 @@
+package me.bombom.api.v1.pet;
+
+public final class ScorePolicyConstants {
+
+    /**
+     * 정책 별 할당 점수
+     */
+    public static final int ATTENDANCE_SCORE = 5;
+    public static final int ARTICLE_READING_SCORE = 10;
+    public static final int CONTINUE_READING_BONUS_SCORE = 5;
+
+    /**
+     * 읽기 점수 부여 기준
+     */
+    public static final int MIN_CONTINUE_READING_COUNT = 7;
+    public static final int MAX_TODAY_READING_COUNT = 3;
+
+    private ScorePolicyConstants() {}
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/controller/PetController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/controller/PetController.java
@@ -12,17 +12,17 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/members/me/pet")
 public class PetController {
 
     private final PetService petService;
 
-    @GetMapping("/members/me/pet")
+    @GetMapping
     public PetResponse getPet(@LoginMember Member member){
         return petService.getPet(member);
     }
 
-    @PostMapping("/members/me/attendance")
+    @PostMapping("/attendance")
     public void addAttendanceScore(@LoginMember Member member){
         petService.addAttendanceScore(member);
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/controller/PetController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/controller/PetController.java
@@ -6,6 +6,7 @@ import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.pet.dto.PetResponse;
 import me.bombom.api.v1.pet.service.PetService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +20,10 @@ public class PetController {
     @GetMapping("/members/me/pet")
     public PetResponse getPet(@LoginMember Member member){
         return petService.getPet(member);
+    }
+
+    @PostMapping("/members/me/attendance")
+    public void addAttendanceScore(@LoginMember Member member){
+        petService.addAttendanceScore(member);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/controller/PetController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/controller/PetController.java
@@ -1,0 +1,23 @@
+package me.bombom.api.v1.pet.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.pet.dto.PetResponse;
+import me.bombom.api.v1.pet.service.PetService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class PetController {
+
+    private final PetService petService;
+
+    @GetMapping("/members/me/pet")
+    public PetResponse getPet(@LoginMember Member member){
+        return petService.getPet(member);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
@@ -17,6 +17,10 @@ import me.bombom.api.v1.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pet extends BaseEntity {
 
+    public static final int ATTENDANCE_SCORE = 5;
+    public static final int ARTICLE_READING_SCORE = 10;
+    public static final int CONTINUE_READING_BONUS_SCORE = 5;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
@@ -27,7 +27,7 @@ public class Pet extends BaseEntity {
     @Column(nullable = false)
     private Long stageId;
 
-    private int currentScore;
+    private int currentScore = 0;
 
     @Builder
     public Pet(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
@@ -27,6 +27,7 @@ public class Pet extends BaseEntity {
     @Column(nullable = false)
     private Long stageId;
 
+    @Column(nullable = false, columnDefinition = "int default 0")
     private int currentScore = 0;
 
     @Builder

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
@@ -1,0 +1,44 @@
+package me.bombom.api.v1.pet.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Pet extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Long stageId;
+
+    private int currentScore;
+
+    @Builder
+    public Pet(
+            Long id,
+            @NotNull Long memberId,
+            @NotNull Long stageId,
+            int currentScore
+    ) {
+        this.id = id;
+        this.memberId = memberId;
+        this.stageId = stageId;
+        this.currentScore = currentScore;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
@@ -41,4 +41,8 @@ public class Pet extends BaseEntity {
         this.stageId = stageId;
         this.currentScore = currentScore;
     }
+
+    public void increaseCurrentScore(int score) {
+        this.currentScore += score;
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Pet.java
@@ -17,10 +17,6 @@ import me.bombom.api.v1.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Pet extends BaseEntity {
 
-    public static final int ATTENDANCE_SCORE = 5;
-    public static final int ARTICLE_READING_SCORE = 10;
-    public static final int CONTINUE_READING_BONUS_SCORE = 5;
-
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Stage.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Stage.java
@@ -20,7 +20,10 @@ public class Stage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private int level;
+
+    @Column(nullable = false)
     private int totalScore;
 
     @Builder

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Stage.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Stage.java
@@ -1,0 +1,36 @@
+package me.bombom.api.v1.pet.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int level;
+    private int totalScore;
+
+    @Builder
+    public Stage(
+            Long id,
+            int level,
+            int totalScore
+    ) {
+        this.id = id;
+        this.level = level;
+        this.totalScore = totalScore;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Stage.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Stage.java
@@ -24,16 +24,16 @@ public class Stage extends BaseEntity {
     private int level;
 
     @Column(nullable = false)
-    private int totalScore;
+    private int requiredScore;
 
     @Builder
     public Stage(
             Long id,
             int level,
-            int totalScore
+            int requiredScore
     ) {
         this.id = id;
         this.level = level;
-        this.totalScore = totalScore;
+        this.requiredScore = requiredScore;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/dto/PetResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/dto/PetResponse.java
@@ -12,7 +12,7 @@ public record PetResponse(
     public static PetResponse of(Pet pet, Stage stage) {
         return new PetResponse(
                 stage.getLevel(),
-                stage.getTotalScore(),
+                stage.getRequiredScore(),
                 pet.getCurrentScore()
         );
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/dto/PetResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/dto/PetResponse.java
@@ -1,0 +1,19 @@
+package me.bombom.api.v1.pet.dto;
+
+import me.bombom.api.v1.pet.domain.Pet;
+import me.bombom.api.v1.pet.domain.Stage;
+
+public record PetResponse(
+        int level,
+        int totalScore,
+        int currentScore
+) {
+
+    public static PetResponse of(Pet pet, Stage stage) {
+        return new PetResponse(
+                stage.getLevel(),
+                stage.getTotalScore(),
+                pet.getCurrentScore()
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/event/AddArticleScoreEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/event/AddArticleScoreEvent.java
@@ -6,9 +6,9 @@ import me.bombom.api.v1.member.domain.Member;
 @Getter
 public class AddArticleScoreEvent {
 
-    private Member member;
+    private final Long memberId;
 
-    public AddArticleScoreEvent(Member member) {
-        this.member = member;
+    public AddArticleScoreEvent(Long memberId) {
+        this.memberId = memberId;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/event/AddArticleScoreEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/event/AddArticleScoreEvent.java
@@ -1,0 +1,14 @@
+package me.bombom.api.v1.pet.event;
+
+import lombok.Getter;
+import me.bombom.api.v1.member.domain.Member;
+
+@Getter
+public class AddArticleScoreEvent {
+
+    private Member member;
+
+    public AddArticleScoreEvent(Member member) {
+        this.member = member;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/event/AddArticleScoreListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/event/AddArticleScoreListener.java
@@ -1,0 +1,33 @@
+package me.bombom.api.v1.pet.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.article.service.ArticleService;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.pet.service.PetService;
+import me.bombom.api.v1.reading.service.ReadingService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AddArticleScoreListener {
+
+    private final ArticleService articleService;
+    private final ReadingService readingService;
+    private final PetService petService;
+
+    @TransactionalEventListener
+    public void on(AddArticleScoreEvent event){
+        try {
+            Member member = event.getMember();
+            if(articleService.canAddArticleScore(member)) {
+                int score = readingService.calculateArticleScore(member);
+                petService.increaseCurrentScore(member, score);
+            }
+        } catch (Exception e){
+            log.error("아티클 점수 추가 실패, member: {}", event.getMember().getId(), e);
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/event/AddArticleScoreListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/event/AddArticleScoreListener.java
@@ -21,13 +21,12 @@ public class AddArticleScoreListener {
     @TransactionalEventListener
     public void on(AddArticleScoreEvent event){
         try {
-            Member member = event.getMember();
-            if(articleService.canAddArticleScore(member)) {
-                int score = readingService.calculateArticleScore(member);
-                petService.increaseCurrentScore(member, score);
+            if(articleService.canAddArticleScore(event.getMemberId())) {
+                int score = readingService.calculateArticleScore(event.getMemberId());
+                petService.increaseCurrentScore(event.getMemberId(), score);
             }
         } catch (Exception e){
-            log.error("아티클 점수 추가 실패, member: {}", event.getMember().getId(), e);
+            log.error("아티클 점수 추가 실패, member: {}", event.getMemberId(), e);
         }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/repository/PetRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/repository/PetRepository.java
@@ -1,0 +1,10 @@
+package me.bombom.api.v1.pet.repository;
+
+import java.util.Optional;
+import me.bombom.api.v1.pet.domain.Pet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PetRepository extends JpaRepository<Pet, Long> {
+
+    Optional<Pet> findByMemberId(Long memberId);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/repository/StageRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/repository/StageRepository.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.pet.repository;
+
+import me.bombom.api.v1.pet.domain.Stage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StageRepository extends JpaRepository<Stage, Long> {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
@@ -5,12 +5,14 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.pet.ScorePolicyConstants;
 import me.bombom.api.v1.pet.domain.Pet;
 import me.bombom.api.v1.pet.domain.Stage;
 import me.bombom.api.v1.pet.dto.PetResponse;
 import me.bombom.api.v1.pet.repository.PetRepository;
 import me.bombom.api.v1.pet.repository.StageRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -31,8 +33,13 @@ public class PetService {
 
     @Transactional
     public void addAttendanceScore(Member member) {
+        increaseCurrentScore(member, ScorePolicyConstants.ATTENDANCE_SCORE);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void increaseCurrentScore(Member member, int score){
         Pet pet = petRepository.findByMemberId(member.getId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
-        pet.increaseCurrentScore(Pet.ATTENDANCE_SCORE);
+        pet.increaseCurrentScore(score);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
@@ -33,12 +33,12 @@ public class PetService {
 
     @Transactional
     public void addAttendanceScore(Member member) {
-        increaseCurrentScore(member, ScorePolicyConstants.ATTENDANCE_SCORE);
+        increaseCurrentScore(member.getId(), ScorePolicyConstants.ATTENDANCE_SCORE);
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void increaseCurrentScore(Member member, int score){
-        Pet pet = petRepository.findByMemberId(member.getId())
+    public void increaseCurrentScore(Long memberId, int score){
+        Pet pet = petRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
         pet.increaseCurrentScore(score);
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
@@ -18,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PetService {
 
+    private static final int ATTENDANCE_SCORE = 5;
+
     private final PetRepository petRepository;
     private final StageRepository stageRepository;
 
@@ -27,5 +29,15 @@ public class PetService {
         Stage stage = stageRepository.findById(pet.getStageId())
                 .orElseThrow(() -> new CServerErrorException(ErrorDetail.INTERNAL_SERVER_ERROR));
         return PetResponse.of(pet,stage);
+    }
+
+    /*
+    점수 바뀌면 자동으로 레벨업 갱신하는 이벤트 리스너 필요
+     */
+    @Transactional
+    public void addAttendanceScore(Member member) {
+        Pet pet = petRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        pet.increaseCurrentScore(ATTENDANCE_SCORE);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
@@ -1,0 +1,31 @@
+package me.bombom.api.v1.pet.service;
+
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.CServerErrorException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.pet.domain.Pet;
+import me.bombom.api.v1.pet.domain.Stage;
+import me.bombom.api.v1.pet.dto.PetResponse;
+import me.bombom.api.v1.pet.repository.PetRepository;
+import me.bombom.api.v1.pet.repository.StageRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PetService {
+
+    private final PetRepository petRepository;
+    private final StageRepository stageRepository;
+
+    public PetResponse getPet(Member member) {
+        Pet pet = petRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        Stage stage = stageRepository.findById(pet.getStageId())
+                .orElseThrow(() -> new CServerErrorException(ErrorDetail.INTERNAL_SERVER_ERROR));
+        return PetResponse.of(pet,stage);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
@@ -18,8 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class PetService {
 
-    private static final int ATTENDANCE_SCORE = 5;
-
     private final PetRepository petRepository;
     private final StageRepository stageRepository;
 
@@ -31,13 +29,10 @@ public class PetService {
         return PetResponse.of(pet,stage);
     }
 
-    /*
-    점수 바뀌면 자동으로 레벨업 갱신하는 이벤트 리스너 필요
-     */
     @Transactional
     public void addAttendanceScore(Member member) {
         Pet pet = petRepository.findByMemberId(member.getId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
-        pet.increaseCurrentScore(ATTENDANCE_SCORE);
+        pet.increaseCurrentScore(Pet.ATTENDANCE_SCORE);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
@@ -42,4 +42,12 @@ public class PetService {
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
         pet.increaseCurrentScore(score);
     }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void createPet(Long memberId) {
+        petRepository.save(Pet.builder()
+                .memberId(memberId)
+                .stageId(1L) // TODO: stage ID 따른 상수화 필요
+                .build());
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -6,6 +6,7 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.pet.ScorePolicyConstants;
 import me.bombom.api.v1.reading.domain.ContinueReading;
 import me.bombom.api.v1.reading.domain.TodayReading;
 import me.bombom.api.v1.reading.domain.WeeklyReading;
@@ -80,6 +81,18 @@ public class ReadingService {
     public void updateReadingCount(Article article){
         updateTodayReadingCount(article);
         updateWeeklyReadingCount(article);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
+    public int calculateArticleScore(Member member){
+        // 연속 읽기 날 수가 7일 이상이면 아티클 당 보너스 점수 +5
+        int score = ScorePolicyConstants.ARTICLE_READING_SCORE;
+        ContinueReading continueReading = continueReadingRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
+        if(continueReading.getDayCount() >= ScorePolicyConstants.MIN_CONTINUE_READING_COUNT){
+            score += ScorePolicyConstants.CONTINUE_READING_BONUS_SCORE;
+        }
+        return score;
     }
 
     private void updateTodayReadingCount(Article article) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -84,12 +84,11 @@ public class ReadingService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
-    public int calculateArticleScore(Long memberId){
-        // 연속 읽기 날 수가 7일 이상이면 아티클 당 보너스 점수 +5
+    public int calculateArticleScore(Long memberId) {
         int score = ScorePolicyConstants.ARTICLE_READING_SCORE;
         ContinueReading continueReading = continueReadingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
-        if(continueReading.getDayCount() >= ScorePolicyConstants.MIN_CONTINUE_READING_COUNT){
+        if (isBonusApplicable(continueReading)) {
             score += ScorePolicyConstants.CONTINUE_READING_BONUS_SCORE;
         }
         return score;
@@ -107,6 +106,10 @@ public class ReadingService {
         WeeklyReading weeklyReading = weeklyReadingRepository.findByMemberId(article.getMemberId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
         weeklyReading.increaseCurrentCount();
+    }
+
+    private boolean isBonusApplicable(ContinueReading continueReading) {
+        return continueReading.getDayCount() >= ScorePolicyConstants.MIN_CONTINUE_READING_COUNT;
     }
 }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -84,10 +84,10 @@ public class ReadingService {
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW, readOnly = true)
-    public int calculateArticleScore(Member member){
+    public int calculateArticleScore(Long memberId){
         // 연속 읽기 날 수가 7일 이상이면 아티클 당 보너스 점수 +5
         int score = ScorePolicyConstants.ARTICLE_READING_SCORE;
-        ContinueReading continueReading = continueReadingRepository.findByMemberId(member.getId())
+        ContinueReading continueReading = continueReadingRepository.findByMemberId(memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
         if(continueReading.getDayCount() >= ScorePolicyConstants.MIN_CONTINUE_READING_COUNT){
             score += ScorePolicyConstants.CONTINUE_READING_BONUS_SCORE;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -211,7 +211,7 @@ public final class TestFixture {
     public static Stage createStage(int level, int totalScore) {
         return Stage.builder()
                 .level(level)
-                .totalScore(totalScore)
+                .requiredScore(totalScore)
                 .build();
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -11,6 +11,8 @@ import me.bombom.api.v1.member.enums.Gender;
 import me.bombom.api.v1.newsletter.domain.Category;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
 import me.bombom.api.v1.newsletter.domain.NewsletterDetail;
+import me.bombom.api.v1.pet.domain.Pet;
+import me.bombom.api.v1.pet.domain.Stage;
 import me.bombom.api.v1.reading.domain.ContinueReading;
 import me.bombom.api.v1.reading.domain.TodayReading;
 import me.bombom.api.v1.reading.domain.WeeklyReading;
@@ -201,5 +203,36 @@ public final class TestFixture {
                 "#f44336",
                 "새로운 하이라이트 텍스트"
         );
+    }
+
+    /**
+     * Stage
+     */
+    public static Stage createStage(int level, int totalScore) {
+        return Stage.builder()
+                .level(level)
+                .totalScore(totalScore)
+                .build();
+    }
+
+    public static List<Stage> createStages() {
+        return List.of(
+                createStage(1, 50),
+                createStage(2, 100),
+                createStage(3, 160),
+                createStage(4, 215),
+                createStage(5, 330)
+        );
+    }
+
+    /**
+     * Pet
+     */
+    public static Pet createPet(Member member, Long stageId) {
+        return Pet.builder()
+                .memberId(member.getId())
+                .stageId(stageId)
+                .currentScore(15)
+                .build();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -232,7 +232,7 @@ public final class TestFixture {
         return Pet.builder()
                 .memberId(member.getId())
                 .stageId(stageId)
-                .currentScore(15)
+                .currentScore(0)
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/event/MemberSignupListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/event/MemberSignupListenerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.pet.service.PetService;
 import me.bombom.api.v1.reading.service.ReadingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -30,6 +31,9 @@ class MemberSignupListenerTest {
     @MockitoBean
     ReadingService readingService;
 
+    @MockitoBean
+    PetService petService;
+
     @Test
     void 회원가입_이벤트_발행_시_읽기정보_초기화_메서드가_호출된다() {
         // given
@@ -42,5 +46,6 @@ class MemberSignupListenerTest {
 
         // then
         verify(readingService, times(1)).initializeReadingInformation(member.getId());
+        verify(petService, times(1)).createPet(member.getId());
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/event/AddArticleScoreListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/event/AddArticleScoreListenerTest.java
@@ -93,7 +93,7 @@ public class AddArticleScoreListenerTest {
         );
 
         // when
-        publisher.publishEvent(new AddArticleScoreEvent(member));
+        publisher.publishEvent(new AddArticleScoreEvent(member.getId()));
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
@@ -120,7 +120,7 @@ public class AddArticleScoreListenerTest {
         );
 
         // when
-        publisher.publishEvent(new AddArticleScoreEvent(member));
+        publisher.publishEvent(new AddArticleScoreEvent(member.getId()));
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
@@ -141,7 +141,7 @@ public class AddArticleScoreListenerTest {
         );
 
         // when
-        publisher.publishEvent(new AddArticleScoreEvent(member));
+        publisher.publishEvent(new AddArticleScoreEvent(member.getId()));
         TestTransaction.flagForCommit();
         TestTransaction.end();
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/event/AddArticleScoreListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/event/AddArticleScoreListenerTest.java
@@ -1,0 +1,168 @@
+package me.bombom.api.v1.pet.event;
+
+import jakarta.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.article.domain.Article;
+import me.bombom.api.v1.article.repository.ArticleRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.domain.Category;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.repository.CategoryRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
+import me.bombom.api.v1.pet.domain.Pet;
+import me.bombom.api.v1.pet.domain.Stage;
+import me.bombom.api.v1.pet.repository.PetRepository;
+import me.bombom.api.v1.pet.repository.StageRepository;
+import me.bombom.api.v1.reading.domain.ContinueReading;
+import me.bombom.api.v1.reading.repository.ContinueReadingRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.transaction.TestTransaction;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+public class AddArticleScoreListenerTest {
+
+    @Autowired
+    private ApplicationEventPublisher publisher;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private NewsletterRepository newsletterRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private StageRepository stageRepository;
+
+    @Autowired
+    private ContinueReadingRepository continueReadingRepository;
+
+    private Member member;
+    private Pet pet;
+    private Stage stage;
+    private Category category;
+    private Newsletter newsletter;
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(TestFixture.normalMemberFixture());
+        category = categoryRepository.save(TestFixture.createCategories().getFirst());
+        newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter("뉴스레터", "test@email.com", category.getId())
+        );
+        stage = stageRepository.save(TestFixture.createStage(1, 50));
+        pet = petRepository.save(TestFixture.createPet(member, stage.getId()));
+    }
+
+    @Test
+    @Transactional
+    void 연속_읽기_보너스_점수와_아티클_점수를_받을_수_있는_경우() {
+        // given
+        articleRepository.saveAll(List.of(
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), false, newsletter.getId(), LocalDateTime.now())
+                )
+        );
+        continueReadingRepository.save(
+                ContinueReading.builder()
+                        .memberId(member.getId())
+                        .dayCount(7)
+                        .build()
+        );
+
+        // when
+        publisher.publishEvent(new AddArticleScoreEvent(member));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then
+        pet = petRepository.findById(pet.getId()).orElseThrow();
+        Assertions.assertThat(pet.getCurrentScore()).isEqualTo(15);
+    }
+
+    @Test
+    @Transactional
+    void 아티클_점수만_받을_수_있는_경우() {
+        // given
+        articleRepository.saveAll(List.of(
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), false, newsletter.getId(), LocalDateTime.now())
+                )
+        );
+        continueReadingRepository.save(
+                ContinueReading.builder()
+                        .memberId(member.getId())
+                        .dayCount(6)
+                        .build()
+        );
+
+        // when
+        publisher.publishEvent(new AddArticleScoreEvent(member));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then
+        pet = petRepository.findById(pet.getId()).orElseThrow();
+        Assertions.assertThat(pet.getCurrentScore()).isEqualTo(10);
+    }
+
+    @Test
+    @Transactional
+    void 아티클_점수를_받을_수_없는_경우() {
+        // given
+        articleRepository.saveAll(List.of(
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now()),
+                        createArticle(member.getId(), true, newsletter.getId(), LocalDateTime.now())
+                )
+        );
+
+        // when
+        publisher.publishEvent(new AddArticleScoreEvent(member));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then
+        pet = petRepository.findById(pet.getId()).orElseThrow();
+        Assertions.assertThat(pet.getCurrentScore()).isEqualTo(0);
+    }
+
+    private Article createArticle(Long memberId, boolean isRead, Long newsletterId, LocalDateTime arrivedTime) {
+        return Article.builder()
+                .title("title")
+                .contents("<h1>아티클</h1>")
+                .thumbnailUrl("https://example.com/images/thumb.png")
+                .expectedReadTime(5)
+                .contentsSummary("요약")
+                .isRead(isRead)
+                .memberId(memberId)
+                .newsletterId(newsletterId)
+                .arrivedDateTime(arrivedTime)
+                .build();
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/event/AddArticleScoreListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/event/AddArticleScoreListenerTest.java
@@ -28,6 +28,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.transaction.TestTransaction;
 
+@Transactional
 @SpringBootTest
 @ActiveProfiles("test")
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
@@ -75,7 +76,6 @@ public class AddArticleScoreListenerTest {
     }
 
     @Test
-    @Transactional
     void 연속_읽기_보너스_점수와_아티클_점수를_받을_수_있는_경우() {
         // given
         articleRepository.saveAll(List.of(
@@ -103,7 +103,6 @@ public class AddArticleScoreListenerTest {
     }
 
     @Test
-    @Transactional
     void 아티클_점수만_받을_수_있는_경우() {
         // given
         articleRepository.saveAll(List.of(
@@ -131,7 +130,6 @@ public class AddArticleScoreListenerTest {
     }
 
     @Test
-    @Transactional
     void 아티클_점수를_받을_수_없는_경우() {
         // given
         articleRepository.saveAll(List.of(

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/service/PetServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/service/PetServiceTest.java
@@ -1,0 +1,86 @@
+package me.bombom.api.v1.pet.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.CServerErrorException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.pet.domain.Pet;
+import me.bombom.api.v1.pet.domain.Stage;
+import me.bombom.api.v1.pet.dto.PetResponse;
+import me.bombom.api.v1.pet.repository.PetRepository;
+import me.bombom.api.v1.pet.repository.StageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(PetService.class)
+class PetServiceTest {
+
+    @Autowired
+    private PetService petService;
+
+    @Autowired
+    private PetRepository petRepository;
+
+    @Autowired
+    private StageRepository stageRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    Member member;
+    Stage stage;
+
+    @BeforeEach
+    void setUp() {
+        member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+        stage = TestFixture.createStage(1, 50);
+        stageRepository.save(stage);
+    }
+
+    @Test
+    void 키우기_정보_조회() {
+        // given
+        Pet pet = TestFixture.createPet(member, stage.getId());
+        petRepository.save(pet);
+
+        // when
+        PetResponse result = petService.getPet(member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.level()).isEqualTo(1);
+            softly.assertThat(result.totalScore()).isEqualTo(50);
+            softly.assertThat(result.currentScore()).isEqualTo(15);
+        });
+    }
+
+    @Test
+    void 키우기_정보_조회_시_키우기가_없을_경우_에러() {
+        // when & then
+        assertThatThrownBy(() -> petService.getPet(member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 키우기_정보_조회_시_성장_단계가_없을_경우_에러() {
+        // given
+        Pet pet = TestFixture.createPet(member, 100L);
+        petRepository.save(pet);
+
+        // when & then
+        assertThatThrownBy(() -> petService.getPet(member))
+                .isInstanceOf(CServerErrorException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/service/PetServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/service/PetServiceTest.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.pet.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -60,7 +61,7 @@ class PetServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(result.level()).isEqualTo(1);
             softly.assertThat(result.totalScore()).isEqualTo(50);
-            softly.assertThat(result.currentScore()).isEqualTo(15);
+            softly.assertThat(result.currentScore()).isEqualTo(0);
         });
     }
 
@@ -82,5 +83,26 @@ class PetServiceTest {
         assertThatThrownBy(() -> petService.getPet(member))
                 .isInstanceOf(CServerErrorException.class)
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    void 키우기_출석_점수_반영() {
+        // given
+        Pet pet = TestFixture.createPet(member, stage.getId());
+        petRepository.save(pet);
+
+        // when
+        petService.addAttendanceScore(member);
+
+        // then
+        assertThat(pet.getCurrentScore()).isEqualTo(5);
+    }
+
+    @Test
+    void 키우기_출석_시_키우기가_없을_경우_에러() {
+        // when & then
+        assertThatThrownBy(() -> petService.addAttendanceScore(member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/service/PetServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/service/PetServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.common.config.QuerydslConfig;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
@@ -22,7 +23,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
-@Import(PetService.class)
+@Import({PetService.class, QuerydslConfig.class})
 class PetServiceTest {
 
     @Autowired
@@ -37,8 +38,8 @@ class PetServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
-    Member member;
-    Stage stage;
+    private Member member;
+    private Stage stage;
 
     @BeforeEach
     void setUp() {


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 키우기에 필요한 기능들을 구현합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 습관형성을 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

### entity 추가
- `Pet` : 사용자의 키우기 정보를 저장합니다.
- `Stage` : 각 레벨 별 정보를 저장합니다.
  - 해당 PR이 merge 되면 추후에 수기 작업으로 데이터를 삽입할 예정입니다.
  - enum으로 관리할까도 고민했지만, 현재 키우기에 대한 스펙이 명확하지 않아 테이블로 관리하는게 편리할 것이라고 판단했습니다.
 
### 구현한 기능 목록
1. `/members/me/pet` : 회원의 키우기 정보를 조회합니다.
2. `/members/me/attendance` : 회원이 '출석하기' 버튼을 통해 출석 점수를 받습니다.
3. 아티클 읽음 시 키우기 점수 추가 이벤트 등록 : 키우기 정책에 따라 `아티클 다읽음 처리 API` 호출 시, 읽음 키우기 점수를 판별하고 추가하는 이벤트를 등록합니다.
  - 정책은 아래와 같습니다. 
  ```text
- 점수 기준
    - 하나의 아티클을 읽을 때 → 10점
        - max : 최대 3개
    - 연속 읽기 날짜
        - 일주일 이상 읽기 시작하면 아티클 당 가중치 +5점씩 (총 아티클 당 점수는 15점 됨)
    - 출석
        - 매일 5점
   ```
4. 회원가입 시 `MemberSignUpEvent`에 `Pet`을 등록하는 로직을 추가했습니다. 

### 추후에 추가될 기능
- 점수가 추가되는 이벤트들에 대해 레벨업 처리를 해주는 이벤트 등록은 다른 PR로 올라올 예정입니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
1. 이벤트 리스너를 직접 도입해보는건 처음인데, 점수에 대한 이벤트라고 생각해서 `AddArticleScoreEvent`를 `pet/event` 패키지로 두었는데 어색하진 않은지 피드백 받고싶습니다!
2. 기능이 많아서 빼먹은 로직이 꽤 있을 것 같습니다 ㅜ 빠진 검증이 있거나 더 좋은 로직 있다면 알려주세요! 
3. 이 외에 피드백 받고싶은 부분은 코드 코멘트로 남겨두겠습니다!
