### PR TITLE
[FE][BOM-218] feat: 오늘 안읽은 뉴스레터 클릭 기능 추가

### DIFF
--- a/frontend/src/apis/articles.ts
+++ b/frontend/src/apis/articles.ts
@@ -2,7 +2,7 @@ import { fetcher } from './fetcher';
 import { components } from '@/types/openapi';
 
 interface GetArticlesParams {
-  sorted: 'ASC' | 'DESC';
+  sorted?: 'ASC' | 'DESC';
   date?: Date;
   category?: string;
   size?: number;

--- a/frontend/src/pages/detail/components/NewsletterItemCard/NewsletterItemCard.tsx
+++ b/frontend/src/pages/detail/components/NewsletterItemCard/NewsletterItemCard.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { Link } from '@tanstack/react-router';
 import Badge from '@/components/Badge/Badge';
 import ImageWithFallback from '@/components/ImageWithFallback/ImageWithFallback';
 import { components } from '@/types/openapi';
@@ -9,11 +10,17 @@ interface NewsletterItemCardProps {
 }
 
 export default function NewsletterItemCard({ data }: NewsletterItemCardProps) {
-  const { title, contentsSummary, thumbnailUrl, expectedReadTime, newsletter } =
-    data;
+  const {
+    articleId,
+    title,
+    contentsSummary,
+    thumbnailUrl,
+    expectedReadTime,
+    newsletter,
+  } = data;
 
   return (
-    <Container>
+    <Container to={`/articles/${articleId}`}>
       <NewsletterImage
         src={thumbnailUrl ?? newsletter?.imageUrl ?? ''}
         alt={title ?? ''}
@@ -41,18 +48,17 @@ export default function NewsletterItemCard({ data }: NewsletterItemCardProps) {
   );
 }
 
-const Container = styled.div`
+const Container = styled(Link)`
   overflow: hidden;
-
-  display: flex;
-  flex-direction: column;
-
   width: 100%;
   max-width: 320px;
   border-radius: 20px;
   box-shadow:
     0 4px 6px -1px rgb(0 0 0 / 10%),
     0 2px 4px -1px rgb(0 0 0 / 6%);
+
+  display: flex;
+  flex-direction: column;
 
   background: ${({ theme }) => theme.colors.white};
 
@@ -67,12 +73,12 @@ const NewsletterImage = styled(ImageWithFallback)`
 `;
 
 const ContentWrapper = styled.div`
+  padding: 20px;
+
   display: flex;
   flex: 1;
   flex-direction: column;
   justify-content: space-between;
-
-  padding: 20px;
 `;
 
 const TextContent = styled.div`
@@ -81,10 +87,9 @@ const TextContent = styled.div`
 
 const Title = styled.h3`
   overflow: hidden;
+  margin-bottom: 8px;
 
   display: -webkit-box;
-
-  margin-bottom: 8px;
 
   color: ${({ theme }) => theme.colors.textPrimary};
   font: ${({ theme }) => theme.fonts.heading5};

--- a/frontend/src/pages/today/components/ArticleCard/ArticleCard.tsx
+++ b/frontend/src/pages/today/components/ArticleCard/ArticleCard.tsx
@@ -68,18 +68,17 @@ const Container = styled(Link)<{
   isRead: boolean;
   readVariant: ReadVariantType;
 }>`
-  display: flex;
-  gap: 12px;
-  align-items: center;
-
   padding: 20px;
   border-bottom: ${({ theme, isRead }) =>
     `${isRead ? '0' : '4px'} solid ${theme.colors.primary}`};
   border-radius: 20px;
   box-shadow: 0 20px 25px -5px rgb(0 0 0 / 10%);
 
-  background-color: ${({ theme }) => theme.colors.white};
+  display: flex;
+  gap: 12px;
+  align-items: center;
 
+  background-color: ${({ theme }) => theme.colors.white};
   color: inherit;
 
   box-sizing: border-box;
@@ -91,12 +90,12 @@ const Container = styled(Link)<{
 `;
 
 const InfoWrapper = styled.div`
+  width: 100%;
+
   display: flex;
   gap: 12px;
   flex-direction: column;
   align-items: flex-start;
-
-  width: 100%;
 `;
 
 const Title = styled.h2`
@@ -138,11 +137,11 @@ const ThumbnailWrapper = styled.div`
 `;
 
 const Thumbnail = styled(ImageWithFallback)`
-  flex-shrink: 0;
-  align-self: stretch;
-
   width: 126px;
   border-radius: 12px;
+
+  flex-shrink: 0;
+  align-self: stretch;
 
   aspect-ratio: 1 / 1;
   object-fit: cover;

--- a/frontend/src/pages/today/components/ArticleCardList/ArticleCardList.tsx
+++ b/frontend/src/pages/today/components/ArticleCardList/ArticleCardList.tsx
@@ -57,12 +57,12 @@ function ArticleCardList({ articles }: ArticleCardListProps) {
 export default ArticleCardList;
 
 const Container = styled.div`
+  width: 100%;
+
   display: flex;
   gap: 16px;
   flex-direction: column;
   align-items: flex-start;
-
-  width: 100%;
 `;
 
 const ListTitleBox = styled.div`
@@ -77,9 +77,9 @@ const ListTitle = styled.h5`
 `;
 
 const CardList = styled.ul`
+  width: 100%;
+
   display: flex;
   gap: 16px;
   flex-direction: column;
-
-  width: 100%;
 `;

--- a/frontend/src/routes/_bombom/articles.$articleId.tsx
+++ b/frontend/src/routes/_bombom/articles.$articleId.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { getArticleById, getArticles, patchArticleRead } from '@/apis/articles';
 import Chip from '@/components/Chip/Chip';
 import Spacing from '@/components/Spacing/Spacing';
@@ -35,7 +35,7 @@ function ArticleDetailPage() {
         articleId: Number(articleId),
       }),
   });
-  const today = new Date();
+  const today = useMemo(() => new Date(), []);
   const { data: otherArticles } = useQuery({
     queryKey: ['articles', { date: today, sorted: 'ASC' }],
     queryFn: () => getArticles({ date: today, sorted: 'ASC' }),

--- a/frontend/src/routes/_bombom/articles.$articleId.tsx
+++ b/frontend/src/routes/_bombom/articles.$articleId.tsx
@@ -65,7 +65,6 @@ function ArticleDetailPage() {
   const unReadArticles = otherArticles?.content?.filter(
     (article) => !article.isRead && article.articleId !== Number(articleId),
   );
-  console.log(unReadArticles);
 
   return (
     <Container>

--- a/frontend/src/routes/_bombom/articles.$articleId.tsx
+++ b/frontend/src/routes/_bombom/articles.$articleId.tsx
@@ -35,9 +35,10 @@ function ArticleDetailPage() {
         articleId: Number(articleId),
       }),
   });
+  const today = new Date();
   const { data: otherArticles } = useQuery({
-    queryKey: ['otherArticles'],
-    queryFn: () => getArticles({ date: new Date(), sorted: 'ASC' }),
+    queryKey: ['articles', { date: today, sorted: 'ASC' }],
+    queryFn: () => getArticles({ date: today, sorted: 'ASC' }),
   });
   const { mutate: updateArticleAsRead } = useMutation({
     mutationKey: ['read', articleId],
@@ -45,6 +46,9 @@ function ArticleDetailPage() {
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: ['article', articleId],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['articles', { date: today, sorted: 'ASC' }],
       });
     },
   });
@@ -61,6 +65,7 @@ function ArticleDetailPage() {
   const unReadArticles = otherArticles?.content?.filter(
     (article) => !article.isRead && article.articleId !== Number(articleId),
   );
+  console.log(unReadArticles);
 
   return (
     <Container>

--- a/frontend/src/routes/_bombom/index.tsx
+++ b/frontend/src/routes/_bombom/index.tsx
@@ -11,9 +11,10 @@ export const Route = createFileRoute('/_bombom/')({
 });
 
 function Index() {
+  const today = new Date();
   const { data: articles } = useQuery({
-    queryKey: ['todayArticles'],
-    queryFn: () => getArticles({ date: new Date(), sorted: 'DESC' }),
+    queryKey: ['articles', { date: today }],
+    queryFn: () => getArticles({ date: today }),
   });
 
   return (

--- a/frontend/src/routes/_bombom/index.tsx
+++ b/frontend/src/routes/_bombom/index.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
+import { useMemo } from 'react';
 import ArticleCardList from '../../pages/today/components/ArticleCardList/ArticleCardList';
 import ReadingStatusCard from '../../pages/today/components/ReadingStatusCard/ReadingStatusCard';
 import { getArticles } from '@/apis/articles';
@@ -11,7 +12,7 @@ export const Route = createFileRoute('/_bombom/')({
 });
 
 function Index() {
-  const today = new Date();
+  const today = useMemo(() => new Date(), []);
   const { data: articles } = useQuery({
     queryKey: ['articles', { date: today }],
     queryFn: () => getArticles({ date: today }),


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 뉴스레터 읽기 페이지 하단에 안읽은 뉴스레터 클릭 기능 추가

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 뉴스레터 카드를 Link 태그로 변경하였습니다.
- 읽음 처리한 이후에 오늘 안읽은 뉴스레터 리스트가 갱신되지 않는 문제가 있어서, invalidateQuery에 추가했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
