### PR TITLE
[BE][BOM-225] refactor: Color 값 객체로 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/controller/HighlightController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/controller/HighlightController.java
@@ -29,8 +29,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/highlights")
 public class HighlightController {
 
-    public static final String COLOR_HEX_PATTERN = "^#[0-9a-fA-F]{6}$";
-
     private final HighlightService highlightService;
 
     @GetMapping

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/domain/Color.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/domain/Color.java
@@ -1,0 +1,37 @@
+package me.bombom.api.v1.highlight.domain;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonCreator.Mode;
+import jakarta.persistence.Embeddable;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+
+@Getter
+@Embeddable
+@EqualsAndHashCode
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class Color {
+
+    private static final String COLOR_HEX_PATTERN = "^#[0-9a-fA-F]{6}$";
+
+    private String value;
+
+    @JsonCreator(mode = Mode.DELEGATING)
+    public static Color from(String value) {
+        validateFormat(value);
+        return new Color(value);
+    }
+
+    private static void validateFormat(String value) {
+        if (!Pattern.matches(COLOR_HEX_PATTERN, value)) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE);
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/domain/Highlight.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/domain/Highlight.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.highlight.domain;
 
+import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
@@ -28,8 +29,9 @@ public class Highlight extends BaseEntity {
     @Column(nullable = false)
     private Long articleId;
 
-    @Column(nullable = false, length = 10)
-    private String color;
+    @Embedded
+    @AttributeOverride(name = "value", column = @Column(nullable = false, name = "color", length = 10))
+    private Color color;
 
     @Column(nullable = false, columnDefinition = "text")
     private String text;
@@ -42,7 +44,7 @@ public class Highlight extends BaseEntity {
             Long id,
             @NotNull HighlightLocation highlightLocation,
             @NotNull Long articleId,
-            @NotNull String color,
+            @NotNull Color color,
             @NotNull String text,
             String memo
     ) {
@@ -54,7 +56,7 @@ public class Highlight extends BaseEntity {
         this.memo = memo;
     }
 
-    public void changeColor(String color) {
+    public void changeColor(Color color) {
         this.color = color;
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/dto/request/HighlightCreateRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/dto/request/HighlightCreateRequest.java
@@ -1,16 +1,14 @@
 package me.bombom.api.v1.highlight.dto.request;
 
-import static me.bombom.api.v1.highlight.controller.HighlightController.COLOR_HEX_PATTERN;
-
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
+import me.bombom.api.v1.highlight.domain.Color;
 
 public record HighlightCreateRequest(
         @NotNull HighlightLocationRequest location,
         @Positive(message = "id는 1 이상의 값이어야 합니다.") Long articleId,
-        @Pattern(regexp = COLOR_HEX_PATTERN) String color,
+        @NotNull Color color,
         @NotNull String text,
         @Size(max = 500) String memo
 ) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/dto/request/UpdateHighlightRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/dto/request/UpdateHighlightRequest.java
@@ -1,9 +1,10 @@
 package me.bombom.api.v1.highlight.dto.request;
 
 import jakarta.validation.constraints.Size;
+import me.bombom.api.v1.highlight.domain.Color;
 
 public record UpdateHighlightRequest(
-    String color,
+    Color color,
     @Size(max = 500) String memo
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/dto/response/HighlightResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/dto/response/HighlightResponse.java
@@ -24,7 +24,7 @@ public record HighlightResponse(
                 highlight.getId(),
                 highlight.getHighlightLocation(),
                 highlight.getArticleId(),
-                highlight.getColor(),
+                highlight.getColor().getValue(),
                 highlight.getText(),
                 highlight.getMemo()
         );

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1;
 import java.time.LocalDateTime;
 import java.util.List;
 import me.bombom.api.v1.article.domain.Article;
+import me.bombom.api.v1.highlight.domain.Color;
 import me.bombom.api.v1.highlight.domain.Highlight;
 import me.bombom.api.v1.highlight.domain.HighlightLocation;
 import me.bombom.api.v1.highlight.dto.request.HighlightCreateRequest;
@@ -174,21 +175,21 @@ public final class TestFixture {
                 Highlight.builder()
                         .highlightLocation(new HighlightLocation("0", "div[0]/p[0]", "10", "div[0]/p[0]"))
                         .articleId(firstArticleId)
-                        .color("#ffeb3b")
+                        .color(Color.from("#ffeb3b"))
                         .text("첫 번째 하이라이트")
                         .memo("메모")
                         .build(),
                 Highlight.builder()
                         .highlightLocation(new HighlightLocation("15", "div[0]/p[1]", "25", "div[0]/p[1]"))
                         .articleId(firstArticleId)
-                        .color("#4caf50")
+                        .color(Color.from("#4caf50"))
                         .text("두 번째 하이라이트")
                         .memo("메모")
                         .build(),
                 Highlight.builder()
                         .highlightLocation(new HighlightLocation("5", "div[0]/h1", "15", "div[0]/h1"))
                         .articleId(secondArticleId)
-                        .color("#2196f3")
+                        .color(Color.from("#2196f3"))
                         .text("세 번째 하이라이트")
                         .memo("메모")
                         .build()
@@ -199,7 +200,7 @@ public final class TestFixture {
         return new HighlightCreateRequest(
                 new HighlightLocationRequest("0", "div[0]/p[2]", "20", "div[0]/p[2]"),
                 articleId,
-                "#f44336",
+                Color.from("#f44336"),
                 "새로운 하이라이트 텍스트",
                 "메모"
         );

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/highlight/controller/HighlightControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/highlight/controller/HighlightControllerTest.java
@@ -1,0 +1,171 @@
+package me.bombom.api.v1.highlight.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.article.domain.Article;
+import me.bombom.api.v1.article.repository.ArticleRepository;
+import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.auth.handler.OAuth2LoginSuccessHandler;
+import me.bombom.api.v1.highlight.domain.Highlight;
+import me.bombom.api.v1.highlight.repository.HighlightRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.domain.Category;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.repository.CategoryRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class HighlightControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private NewsletterRepository newsletterRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private HighlightRepository highlightRepository;
+
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    private List<Highlight> highlights;
+    private CustomOAuth2User customOAuth2User;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAllInBatch();
+        articleRepository.deleteAllInBatch();
+
+        Member member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        List<Category> categories = TestFixture.createCategories();
+        categoryRepository.saveAll(categories);
+
+        List<Newsletter> newsletters = TestFixture.createNewsletters(categories);
+        newsletterRepository.saveAll(newsletters);
+
+        List<Article> articles = TestFixture.createArticles(member, newsletters);
+        articleRepository.saveAll(articles);
+
+        highlights = TestFixture.createHighlightFixtures(articles);
+        highlightRepository.saveAll(highlights);
+
+        // Argument Resolver를 위해 CustomOAuth2User 생성
+        Map<String, Object> attributes = Map.of(
+                "id", member.getId().toString(),
+                "email", member.getEmail(),
+                "name", member.getNickname()
+        );
+        customOAuth2User = new CustomOAuth2User(attributes, member);
+    }
+
+    private void setAuthentication() {
+        // OAuth2AuthenticationToken 생성
+        OAuth2AuthenticationToken authToken = new OAuth2AuthenticationToken(
+                customOAuth2User,
+                customOAuth2User.getAuthorities(),
+                "registrationId"
+        );
+
+        // SecurityContext에 인증 정보 설정
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authToken);
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    void 하이라이트_생성_성공() throws Exception {
+        // given
+        setAuthentication();
+
+        // when & then
+        String content = String.format("""
+        {
+          "location": {
+            "startOffset": "0",
+            "startXPath": "div[0]/p[0]",
+            "endOffset": "10",
+            "endXPath": "div[0]/p[0]"
+          },
+          "articleId": %d,
+          "color": "#ffeb3b",
+          "text": "하이라이트할 텍스트",
+          "memo": "메모 내용 (선택사항)"
+        }
+        """, highlights.getFirst().getArticleId());
+        mockMvc.perform(post("/api/v1/highlights")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content))
+                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void 하이라이트_수정_성공() throws Exception {
+        // given
+        setAuthentication();
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/highlights/{id}", highlights.getFirst().getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                                "color": "#4caf50"
+                            }
+                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.color").value("#4caf50"));
+    }
+
+    @Test
+    void 하이라이트_수정_포맷에_맞지_않는_color_입력() throws Exception {
+        // given
+        setAuthentication();
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/highlights/{id}", highlights.getFirst().getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                            {
+                                "color": "4caf50",
+                                "memo": "수정된 메모"
+                            }
+                        """))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/highlight/service/HighlightServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/highlight/service/HighlightServiceTest.java
@@ -11,6 +11,7 @@ import me.bombom.api.v1.article.repository.ArticleRepository;
 import me.bombom.api.v1.common.config.QuerydslConfig;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.highlight.domain.Color;
 import me.bombom.api.v1.highlight.domain.Highlight;
 import me.bombom.api.v1.highlight.dto.request.HighlightCreateRequest;
 import me.bombom.api.v1.highlight.dto.request.HighlightLocationRequest;
@@ -76,7 +77,7 @@ class HighlightServiceTest {
         return new HighlightCreateRequest(
                 new HighlightLocationRequest("0", "div[0]/p[0]", "10", "div[0]/p[0]"),
                 firstArticleId,
-                "#ffeb3b",
+                Color.from("#ffeb3b"),
                 "중복된 하이라이트",
                 "메모"
         );
@@ -168,13 +169,13 @@ class HighlightServiceTest {
     void 하이라이트_색상을_변경할_수_있다() {
         // given
         Long highlightId = highlights.getFirst().getId();
-        UpdateHighlightRequest request = new UpdateHighlightRequest("#9c27b0", null);
+        UpdateHighlightRequest request = new UpdateHighlightRequest(Color.from("#9c27b0"), null);
 
         // when
         HighlightResponse updated = highlightService.update(highlightId, request, member);
 
         // then
-        assertThat(updated.color()).isEqualTo(request.color());
+        assertThat(updated.color()).isEqualTo(request.color().getValue());
     }
 
     @Test
@@ -193,14 +194,14 @@ class HighlightServiceTest {
     void 하이라이트_색상과_메모를_변경할_수_있다() {
         // given
         Long highlightId = highlights.getFirst().getId();
-        UpdateHighlightRequest request = new UpdateHighlightRequest("#9c27b0", "새로운 메모입니다.");
+        UpdateHighlightRequest request = new UpdateHighlightRequest(Color.from("#9c27b0"), "새로운 메모입니다.");
 
         // when
         HighlightResponse updated = highlightService.update(highlightId, request, member);
 
         // then
         assertSoftly(softly -> {
-                assertThat(updated.color()).isEqualTo(request.color());
+                assertThat(updated.color()).isEqualTo(request.color().getValue());
                 assertThat(updated.memo()).isEqualTo(request.memo());
         });
     }
@@ -210,7 +211,7 @@ class HighlightServiceTest {
     void 존재하지_않는_하이라이트_색상_변경시_예외_발생() {
         // given
         Long nonExistentHighlightId = 0L;
-        UpdateHighlightRequest request = new UpdateHighlightRequest("#9c27b0", null);
+        UpdateHighlightRequest request = new UpdateHighlightRequest(Color.from("#9c27b0"), null);
 
 
         // when & then


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
기존에 String으로 color를 받기 때문에, 정규식 검증이 흩어져있었습니다.
한 지점에서 검증하고자 Color 값 객체를 사용하도록 수정했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
입력 값 검증을 한 지점에서 하도록 하기 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

[작성한 글](https://luminous-november-24d.notion.site/Color-2462380f6fa580baab1ccd5387f9d6d4?source=copy_link)

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

천천히 해주셔도 됩니다.

입력값을 통한 역직렬화가 제대로 동작하는지 확인하기 위해 HighlightControllerTest를 작성하였습니다.