### PR TITLE
[BE][BOM-256] fix: 펫 정보 조회 응답 데이터 형식 변경

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Stage.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/domain/Stage.java
@@ -16,6 +16,7 @@ import me.bombom.api.v1.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stage extends BaseEntity {
 
+    // TODO: 규칙 확정 후 ENUM 전환
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/dto/PetResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/dto/PetResponse.java
@@ -4,18 +4,20 @@ import me.bombom.api.v1.pet.domain.Pet;
 import me.bombom.api.v1.pet.domain.Stage;
 
 public record PetResponse(
-        int level,
-        int totalScore,
-        int currentScore,
-        boolean isAttended
+    int level,
+    int currentStageScore,
+    int requiredStageScore,
+    boolean isAttended
 ) {
+    public static PetResponse of(Pet pet, Stage currentStage, Stage nextStage) {
+        int currentStageScore = pet.getCurrentScore() - currentStage.getRequiredScore();
+        int requiredStageScore = nextStage.getRequiredScore() - currentStage.getRequiredScore();
 
-    public static PetResponse of(Pet pet, Stage stage) {
         return new PetResponse(
-                stage.getLevel(),
-                stage.getRequiredScore(),
-                pet.getCurrentScore(),
-                pet.isAttended()
+            currentStage.getLevel(),
+            currentStageScore,
+            requiredStageScore,
+            pet.isAttended()
         );
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/repository/StageRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/repository/StageRepository.java
@@ -15,5 +15,14 @@ public interface StageRepository extends JpaRepository<Stage, Long> {
                 ORDER BY s.requiredScore DESC
                 LIMIT 1
             """)
+    Optional<Stage> findCurrentStageByScore(@Param("score") int score);
+
+    @Query("""
+                SELECT s
+                FROM Stage s
+                WHERE s.requiredScore > :score
+                ORDER BY s.requiredScore ASC
+                LIMIT 1
+            """)
     Optional<Stage> findNextStageByScore(@Param("score") int score);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/pet/service/PetService.java
@@ -26,9 +26,11 @@ public class PetService {
     public PetResponse getPet(Member member) {
         Pet pet = petRepository.findByMemberId(member.getId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND));
-        Stage stage = stageRepository.findById(pet.getStageId())
+        Stage currentStage = stageRepository.findById(pet.getStageId())
                 .orElseThrow(() -> new CServerErrorException(ErrorDetail.INTERNAL_SERVER_ERROR));
-        return PetResponse.of(pet,stage);
+        Stage nextStage = stageRepository.findNextStageByScore(pet.getCurrentScore())
+                .orElseThrow(() -> new CServerErrorException(ErrorDetail.INTERNAL_SERVER_ERROR));
+        return PetResponse.of(pet, currentStage, nextStage);
     }
 
     @Transactional
@@ -64,7 +66,7 @@ public class PetService {
     }
 
     private void updatePetStage(Pet pet) {
-        Stage stageByScore = stageRepository.findNextStageByScore(pet.getCurrentScore())
+        Stage stageByScore = stageRepository.findCurrentStageByScore(pet.getCurrentScore())
                 .orElseThrow(() -> new CServerErrorException(ErrorDetail.INTERNAL_SERVER_ERROR));
         pet.updateStage(stageByScore);
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/service/PetServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/pet/service/PetServiceTest.java
@@ -54,9 +54,9 @@ class PetServiceTest {
     void setUp() {
         member = TestFixture.createUniqueMember(UUID.randomUUID().toString(), UUID.randomUUID().toString());
         memberRepository.save(member);
-        firstStage = TestFixture.createStage(1, 50);
+        firstStage = TestFixture.createStage(1, 0);
         stageRepository.save(firstStage);
-        secondStage = TestFixture.createStage(2, 100);
+        secondStage = TestFixture.createStage(2, 50);
         stageRepository.save(secondStage);
     }
 
@@ -72,8 +72,8 @@ class PetServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(result.level()).isEqualTo(1);
-            softly.assertThat(result.totalScore()).isEqualTo(50);
-            softly.assertThat(result.currentScore()).isEqualTo(0);
+            softly.assertThat(result.currentStageScore()).isEqualTo(0);
+            softly.assertThat(result.requiredStageScore()).isEqualTo(50);
         });
     }
 
@@ -159,14 +159,14 @@ class PetServiceTest {
     @Test
     void 펫_스테이지_업데이트_성공() {
         // given
-        Pet pet = TestFixture.createPetWithScore(member, firstStage.getId(), 99);
+        Pet pet = TestFixture.createPetWithScore(member, firstStage.getId(), 49);
         petRepository.save(pet);
 
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
         // when
-        petService.increaseCurrentScore(member.getId(), 2);
+        petService.increaseCurrentScore(member.getId(), 1);
         Pet updatedPet = petRepository.findById(pet.getId()).orElseThrow();
         Stage stage = stageRepository.findById(updatedPet.getStageId()).orElseThrow();
 
@@ -177,14 +177,14 @@ class PetServiceTest {
     @Test
     void 점수_부족_시_펫_스테이지_업데이트_실패() {
         // given
-        Pet pet = TestFixture.createPetWithScore(member, firstStage.getId(), 99);
+        Pet pet = TestFixture.createPetWithScore(member, firstStage.getId(), 48);
         petRepository.save(pet);
 
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
         // when
-        petService.increaseCurrentScore(member.getId(), 0);
+        petService.increaseCurrentScore(member.getId(), 1);
         Pet updatedPet = petRepository.findById(pet.getId()).orElseThrow();
         Stage stage = stageRepository.findById(updatedPet.getStageId()).orElseThrow();
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
누적 score 방식을 사용하되, 펫 정보 조회 응답은 stage별 score로 반환하도록 수정

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
현재 스코어 상태를 퍼센트로 표현하기 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
현재 스테이지 스코어 = 나의 토탈 스코어 - 현재 스테이지가 되기 위해 필요한 토탈 스코어

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 현재 Stage를 DB에 저장하고 필요할 때 마다 계속해서 조회하고 있는데, 추후에 레벨업 방식이 확정이 되면 Enum으로 관리해보면 좋을 것 같습니다.(TODO로 남겨둠)
- 펫 정보 조회시에 다음 스테이지를 조회해야 하는데, 지금 구현에서는 최고 레벨일 경우에 에러가 발생합니다. 최고 레벨일 시의 처리를 구체화 한 뒤에 구현하면 좋을 것 같아서 남겨뒀습니다
