### PR TITLE
[FE][BOM-194] feat: 보관함 페이지 반응형

### DIFF
--- a/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/frontend/src/components/PageLayout/PageLayout.tsx
@@ -29,6 +29,8 @@ const Container = styled.div`
   width: 100%;
   min-height: 100vh;
   padding: 72px 0; /* header 높이 */
+  padding-right: 16px;
+  padding-left: 16px;
 
   display: flex;
   flex-direction: column;

--- a/frontend/src/components/Tab/Tab.tsx
+++ b/frontend/src/components/Tab/Tab.tsx
@@ -38,6 +38,9 @@ const Container = styled.li<{ selected: boolean }>`
   width: 100%;
   min-width: fit-content;
   padding: 10px 12px;
+  border: 2px solid
+    ${({ selected, theme }) =>
+      selected ? theme.colors.primary : 'transparent'};
   border-radius: 12px;
 
   display: flex;
@@ -53,4 +56,10 @@ const Container = styled.li<{ selected: boolean }>`
   font-weight: ${({ selected }) => (selected ? '600' : '400')};
 
   cursor: pointer;
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    background-color: ${({ selected, theme }) =>
+      selected ? theme.colors.primary : theme.colors.disabledBackground};
+  }
 `;

--- a/frontend/src/components/Tabs/Tabs.tsx
+++ b/frontend/src/components/Tabs/Tabs.tsx
@@ -25,7 +25,7 @@ export default Tabs;
 
 const Container = styled.ul<{ direction: DirectionType }>`
   display: flex;
-  gap: 8px;
+  gap: ${({ direction }) => (direction === 'horizontal' ? '12px' : '8px')};
   flex-direction: ${({ direction }) =>
     direction === 'horizontal' ? 'row' : 'column'};
 `;

--- a/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
@@ -55,7 +55,6 @@ export default CategoryFilter;
 
 const Container = styled.nav<{ isPc: boolean }>`
   width: 100%;
-  padding: 16px;
   border: ${({ isPc, theme }) =>
     isPc ? `1px solid ${theme.colors.stroke}` : 'none'};
   border-radius: 20px;
@@ -88,7 +87,7 @@ const Title = styled.h3`
 `;
 
 const StyledTabs = styled(Tabs)`
-  padding-bottom: 4px;
+  padding-bottom: 8px;
   overflow-x: auto;
 
   &::-webkit-scrollbar {

--- a/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
@@ -56,8 +56,8 @@ export default CategoryFilter;
 const Container = styled.nav<{ isPc: boolean }>`
   width: 100%;
   padding: 16px;
-  border: ${({ isPc }) => (isPc ? '1px solid' : 'none')}
-    ${({ theme }) => theme.colors.stroke};
+  border: ${({ isPc, theme }) =>
+    isPc ? `1px solid ${theme.colors.stroke}` : 'none'};
   border-radius: 20px;
 
   display: flex;

--- a/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
@@ -26,13 +26,15 @@ function CategoryFilter<T extends string>({
   const deviceType = useDeviceType();
 
   return (
-    <Container aria-label="카테고리">
-      <TitleWrapper>
-        <IconWrapper>
-          <CategoryIcon width={16} height={16} fill={theme.colors.white} />
-        </IconWrapper>
-        <Title>카테고리</Title>
-      </TitleWrapper>
+    <Container aria-label="카테고리" isPc={deviceType === 'pc'}>
+      {deviceType === 'pc' && (
+        <TitleWrapper>
+          <IconWrapper>
+            <CategoryIcon width={16} height={16} fill={theme.colors.white} />
+          </IconWrapper>
+          <Title>카테고리</Title>
+        </TitleWrapper>
+      )}
       <StyledTabs direction={deviceType === 'pc' ? 'vertical' : 'horizontal'}>
         {categoryList.map(({ value, label, quantity }) => (
           <Tab
@@ -51,10 +53,11 @@ function CategoryFilter<T extends string>({
 
 export default CategoryFilter;
 
-const Container = styled.nav`
+const Container = styled.nav<{ isPc: boolean }>`
   width: 100%;
   padding: 16px;
-  border: 1px solid ${({ theme }) => theme.colors.stroke};
+  border: ${({ isPc }) => (isPc ? '1px solid' : 'none')}
+    ${({ theme }) => theme.colors.stroke};
   border-radius: 20px;
 
   display: flex;

--- a/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
@@ -30,7 +30,7 @@ function CategoryFilter<T extends string>({
         </IconWrapper>
         <Title>카테고리</Title>
       </TitleWrapper>
-      <Tabs direction="vertical">
+      <StyledTabs direction="horizontal">
         {categoryList.map(({ value, label, quantity }) => (
           <Tab
             key={value}
@@ -41,7 +41,7 @@ function CategoryFilter<T extends string>({
             EndComponent={<Badge text={String(quantity)} />}
           />
         ))}
-      </Tabs>
+      </StyledTabs>
     </Container>
   );
 }
@@ -49,7 +49,7 @@ function CategoryFilter<T extends string>({
 export default CategoryFilter;
 
 const Container = styled.nav`
-  width: 310px;
+  width: 100%;
   padding: 16px;
   border: 1px solid ${({ theme }) => theme.colors.stroke};
   border-radius: 20px;
@@ -79,4 +79,22 @@ const IconWrapper = styled.div`
 
 const Title = styled.h3`
   font: ${({ theme }) => theme.fonts.heading5};
+`;
+
+const StyledTabs = styled(Tabs)`
+  padding-bottom: 4px;
+  overflow-x: auto;
+
+  &::-webkit-scrollbar {
+    height: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 2px;
+    background: ${({ theme }) => theme.colors.stroke};
+  }
 `;

--- a/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import Badge from '@/components/Badge/Badge';
 import Tab from '@/components/Tab/Tab';
 import Tabs from '@/components/Tabs/Tabs';
+import { useDeviceType } from '@/hooks/useDeviceType';
 import { theme } from '@/styles/theme';
 import CategoryIcon from '#/assets/category.svg';
 
@@ -22,6 +23,8 @@ function CategoryFilter<T extends string>({
   selectedValue,
   onSelectCategory,
 }: CategoryFilterProps<T>) {
+  const deviceType = useDeviceType();
+
   return (
     <Container aria-label="카테고리">
       <TitleWrapper>
@@ -30,7 +33,7 @@ function CategoryFilter<T extends string>({
         </IconWrapper>
         <Title>카테고리</Title>
       </TitleWrapper>
-      <StyledTabs direction="horizontal">
+      <StyledTabs direction={deviceType === 'pc' ? 'vertical' : 'horizontal'}>
         {categoryList.map(({ value, label, quantity }) => (
           <Tab
             key={value}

--- a/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
+++ b/frontend/src/pages/storage/components/CategoryFilter/CategoryFilter.tsx
@@ -55,6 +55,7 @@ export default CategoryFilter;
 
 const Container = styled.nav<{ isPc: boolean }>`
   width: 100%;
+  padding: ${({ isPc }) => (isPc ? '16px' : '0')};
   border: ${({ isPc, theme }) =>
     isPc ? `1px solid ${theme.colors.stroke}` : 'none'};
   border-radius: 20px;

--- a/frontend/src/pages/storage/components/QuickMenu/QuickMenu.tsx
+++ b/frontend/src/pages/storage/components/QuickMenu/QuickMenu.tsx
@@ -1,19 +1,24 @@
 import styled from '@emotion/styled';
 import { Link } from '@tanstack/react-router';
+import { useDeviceType } from '@/hooks/useDeviceType';
 import { theme } from '@/styles/theme';
 import BookmarkIcon from '#/assets/bookmark-inactive.svg';
 import MemoIcon from '#/assets/memo.svg';
 import QuickMenuIcon from '#/assets/quick-menu.svg';
 
 const QuickMenu = () => {
+  const deviceType = useDeviceType();
+
   return (
     <Container>
-      <TitleWrapper>
-        <QuickMenuIconWrapper>
-          <StyledQuickMenuIcon />
-        </QuickMenuIconWrapper>
-        <Title>바로 가기</Title>
-      </TitleWrapper>
+      {deviceType === 'pc' && (
+        <TitleWrapper>
+          <QuickMenuIconWrapper>
+            <StyledQuickMenuIcon />
+          </QuickMenuIconWrapper>
+          <Title>바로 가기</Title>
+        </TitleWrapper>
+      )}
       <ButtonContainer>
         <ButtonWrapper>
           <StyledBookmarkIcon />

--- a/frontend/src/pages/storage/components/QuickMenu/QuickMenu.tsx
+++ b/frontend/src/pages/storage/components/QuickMenu/QuickMenu.tsx
@@ -71,6 +71,9 @@ const Title = styled.h3`
 `;
 
 const ButtonWrapper = styled.div`
+  padding: 8px;
+  border-radius: 8px;
+
   display: flex;
   gap: 4px;
   align-items: center;

--- a/frontend/src/pages/storage/components/QuickMenu/QuickMenu.tsx
+++ b/frontend/src/pages/storage/components/QuickMenu/QuickMenu.tsx
@@ -14,14 +14,16 @@ const QuickMenu = () => {
         </QuickMenuIconWrapper>
         <Title>바로 가기</Title>
       </TitleWrapper>
-      <ButtonWrapper>
-        <StyledBookmarkIcon />
-        <LinkButton to={'/bookmark'}>북마크</LinkButton>
-      </ButtonWrapper>
-      <ButtonWrapper>
-        <MemoIcon width={20} height={20} fill={theme.colors.primary} />
-        <LinkButton to={'/memo'}>메모</LinkButton>
-      </ButtonWrapper>
+      <ButtonContainer>
+        <ButtonWrapper>
+          <StyledBookmarkIcon />
+          <LinkButton to={'/bookmark'}>북마크</LinkButton>
+        </ButtonWrapper>
+        <ButtonWrapper>
+          <MemoIcon width={20} height={20} fill={theme.colors.primary} />
+          <LinkButton to={'/memo'}>메모</LinkButton>
+        </ButtonWrapper>
+      </ButtonContainer>
     </Container>
   );
 };
@@ -29,7 +31,7 @@ const QuickMenu = () => {
 export default QuickMenu;
 
 const Container = styled.nav`
-  width: 310px;
+  width: 100%;
   padding: 16px;
   border: 1px solid ${({ theme }) => theme.colors.stroke};
   border-radius: 20px;
@@ -83,4 +85,10 @@ const StyledBookmarkIcon = styled(BookmarkIcon)`
 
 const LinkButton = styled(Link)`
   font: ${({ theme }) => theme.fonts.body1};
+`;
+
+const ButtonContainer = styled.div`
+  display: flex;
+  gap: 16px;
+  align-items: center;
 `;

--- a/frontend/src/pages/today/components/ArticleCard/ArticleCard.tsx
+++ b/frontend/src/pages/today/components/ArticleCard/ArticleCard.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 import { Link } from '@tanstack/react-router';
 import Badge from '@/components/Badge/Badge';
-import Chip from '@/components/Chip/Chip';
 import ImageWithFallback from '@/components/ImageWithFallback/ImageWithFallback';
 import { trackEvent } from '@/libs/googleAnalytics/gaEvents';
 import { components } from '@/types/openapi';
@@ -44,7 +43,6 @@ function ArticleCard({ data, readVariant = 'transparent' }: ArticleCardProps) {
         <Title>{title}</Title>
         <Description>{contentsSummary || title}</Description>
         <MetaInfoRow>
-          <Chip text={newsletter?.category ?? ''} />
           <MetaInfoText>from {newsletter?.name ?? ''}</MetaInfoText>
           <MetaInfoText>
             {formatDate(new Date(arrivedDateTime ?? ''))}
@@ -107,7 +105,15 @@ const InfoWrapper = styled.div`
 `;
 
 const Title = styled.h2`
+  overflow: hidden;
+
+  display: -webkit-box;
+
   font: ${({ theme }) => theme.fonts.heading4};
+
+  -webkit-box-orient: vertical;
+
+  -webkit-line-clamp: 2;
 `;
 
 const Description = styled.p`

--- a/frontend/src/routes/_bombom/storage.tsx
+++ b/frontend/src/routes/_bombom/storage.tsx
@@ -73,9 +73,6 @@ function Storage() {
 
   return (
     <Container>
-      <SideSection>
-        <QuickMenu />
-      </SideSection>
       <MainSection>
         <TitleWrapper>
           <TitleIconBox>
@@ -106,6 +103,7 @@ function Storage() {
             onSelectCategory={handleCategoryChange}
           />
         </CategoryFilterWrapper>
+        <QuickMenu />
         <SummaryBar>
           <SummaryText>총 {articles?.totalElements ?? 0}개</SummaryText>
           <Select
@@ -146,17 +144,8 @@ const Container = styled.div`
   padding: 64px 0;
 
   display: flex;
-  gap: 24px;
   align-items: flex-start;
   justify-content: center;
-`;
-
-const SideSection = styled.div`
-  margin-top: 70px;
-
-  display: flex;
-  gap: 32px;
-  flex-direction: column;
 `;
 
 const MainSection = styled.div`

--- a/frontend/src/routes/_bombom/storage.tsx
+++ b/frontend/src/routes/_bombom/storage.tsx
@@ -85,54 +85,60 @@ function Storage() {
           value={searchInput}
           onChange={handleSearchChange}
         />
-        <CategoryFilterWrapper>
-          <CategoryFilter
-            categoryList={[
-              {
-                value: '전체',
-                label: '전체',
-                quantity: categoryCounts?.totalCount ?? 0,
-              },
-              ...(existCategories?.map(({ category, count }) => ({
-                value: category as CategoryType,
-                label: category ?? '',
-                quantity: count ?? 0,
-              })) ?? []),
-            ]}
-            selectedValue={selectedCategory}
-            onSelectCategory={handleCategoryChange}
-          />
-        </CategoryFilterWrapper>
-        <QuickMenu />
-        <SummaryBar>
-          <SummaryText>총 {articles?.totalElements ?? 0}개</SummaryText>
-          <Select
-            options={[
-              { value: 'DESC', label: '최신순' },
-              { value: 'ASC', label: '오래된순' },
-            ]}
-            selectedValue={sortFilter}
-            onSelectOption={handleSortChange}
-          />
-        </SummaryBar>
-        {isLoadingOrHaveContent ? (
-          <>
-            <ArticleList>
-              {articles?.content?.map((article) => (
-                <li key={article.articleId}>
-                  <ArticleCard data={article} readVariant="badge" />
-                </li>
-              ))}
-            </ArticleList>
-            <Pagination
-              currentPage={currentPage}
-              totalPages={articles?.totalPages ?? 1}
-              onPageChange={handlePageChange}
-            />
-          </>
-        ) : (
-          <EmptyLetterCard title="보관된 뉴스레터가 없어요" />
-        )}
+        <ContentWrapper>
+          <SidebarSection>
+            <CategoryFilterWrapper>
+              <CategoryFilter
+                categoryList={[
+                  {
+                    value: '전체',
+                    label: '전체',
+                    quantity: categoryCounts?.totalCount ?? 0,
+                  },
+                  ...(existCategories?.map(({ category, count }) => ({
+                    value: category as CategoryType,
+                    label: category ?? '',
+                    quantity: count ?? 0,
+                  })) ?? []),
+                ]}
+                selectedValue={selectedCategory}
+                onSelectCategory={handleCategoryChange}
+              />
+            </CategoryFilterWrapper>
+            <QuickMenu />
+          </SidebarSection>
+          <MainContentSection>
+            <SummaryBar>
+              <SummaryText>총 {articles?.totalElements ?? 0}개</SummaryText>
+              <Select
+                options={[
+                  { value: 'DESC', label: '최신순' },
+                  { value: 'ASC', label: '오래된순' },
+                ]}
+                selectedValue={sortFilter}
+                onSelectOption={handleSortChange}
+              />
+            </SummaryBar>
+            {isLoadingOrHaveContent ? (
+              <>
+                <ArticleList>
+                  {articles?.content?.map((article) => (
+                    <li key={article.articleId}>
+                      <ArticleCard data={article} readVariant="badge" />
+                    </li>
+                  ))}
+                </ArticleList>
+                <Pagination
+                  currentPage={currentPage}
+                  totalPages={articles?.totalPages ?? 1}
+                  onPageChange={handlePageChange}
+                />
+              </>
+            ) : (
+              <EmptyLetterCard title="보관된 뉴스레터가 없어요" />
+            )}
+          </MainContentSection>
+        </ContentWrapper>
       </MainSection>
     </Container>
   );
@@ -178,6 +184,43 @@ const TitleIconBox = styled.div`
 
 const Title = styled.h1`
   font: ${({ theme }) => theme.fonts.heading2};
+`;
+
+const ContentWrapper = styled.div`
+  width: 100%;
+
+  display: flex;
+  gap: 32px;
+  align-items: flex-start;
+
+  @media (width <= 1024px) {
+    gap: 20px;
+    flex-direction: column;
+  }
+`;
+
+const SidebarSection = styled.div`
+  width: 320px;
+
+  display: flex;
+  gap: 20px;
+  flex-direction: column;
+
+  @media (width <= 1024px) {
+    min-width: 100%;
+    order: 1;
+  }
+`;
+
+const MainContentSection = styled.div`
+  display: flex;
+  gap: 20px;
+  flex: 1;
+  flex-direction: column;
+
+  @media (width <= 1024px) {
+    order: 2;
+  }
 `;
 
 const CategoryFilterWrapper = styled.div`

--- a/frontend/src/routes/_bombom/storage.tsx
+++ b/frontend/src/routes/_bombom/storage.tsx
@@ -80,11 +80,7 @@ function Storage() {
           </TitleIconBox>
           <Title>뉴스레터 보관함</Title>
         </TitleWrapper>
-        <SearchInput
-          placeholder="뉴스레터 제목으로 검색하세요..."
-          value={searchInput}
-          onChange={handleSearchChange}
-        />
+
         <ContentWrapper>
           <SidebarSection>
             <CategoryFilterWrapper>
@@ -108,6 +104,11 @@ function Storage() {
             <QuickMenu />
           </SidebarSection>
           <MainContentSection>
+            <SearchInput
+              placeholder="뉴스레터 제목으로 검색하세요..."
+              value={searchInput}
+              onChange={handleSearchChange}
+            />
             <SummaryBar>
               <SummaryText>총 {articles?.totalElements ?? 0}개</SummaryText>
               <Select
@@ -119,6 +120,7 @@ function Storage() {
                 onSelectOption={handleSortChange}
               />
             </SummaryBar>
+
             {isLoadingOrHaveContent ? (
               <>
                 <ArticleList>

--- a/frontend/src/routes/_bombom/storage.tsx
+++ b/frontend/src/routes/_bombom/storage.tsx
@@ -74,22 +74,6 @@ function Storage() {
   return (
     <Container>
       <SideSection>
-        <CategoryFilter
-          categoryList={[
-            {
-              value: '전체',
-              label: '전체',
-              quantity: categoryCounts?.totalCount ?? 0,
-            },
-            ...(existCategories?.map(({ category, count }) => ({
-              value: category as CategoryType,
-              label: category ?? '',
-              quantity: count ?? 0,
-            })) ?? []),
-          ]}
-          selectedValue={selectedCategory}
-          onSelectCategory={handleCategoryChange}
-        />
         <QuickMenu />
       </SideSection>
       <MainSection>
@@ -104,6 +88,24 @@ function Storage() {
           value={searchInput}
           onChange={handleSearchChange}
         />
+        <CategoryFilterWrapper>
+          <CategoryFilter
+            categoryList={[
+              {
+                value: '전체',
+                label: '전체',
+                quantity: categoryCounts?.totalCount ?? 0,
+              },
+              ...(existCategories?.map(({ category, count }) => ({
+                value: category as CategoryType,
+                label: category ?? '',
+                quantity: count ?? 0,
+              })) ?? []),
+            ]}
+            selectedValue={selectedCategory}
+            onSelectCategory={handleCategoryChange}
+          />
+        </CategoryFilterWrapper>
         <SummaryBar>
           <SummaryText>총 {articles?.totalElements ?? 0}개</SummaryText>
           <Select
@@ -187,6 +189,11 @@ const TitleIconBox = styled.div`
 
 const Title = styled.h1`
   font: ${({ theme }) => theme.fonts.heading2};
+`;
+
+const CategoryFilterWrapper = styled.div`
+  width: 100%;
+  margin-bottom: 8px;
 `;
 
 const SummaryBar = styled.div`


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

- 모바일 디바이스에서 카테고리 세로로 보여주는 건 `useMediaQuery` 머지되면 수정하도록 하겠습니다.

<img width="486" height="859" alt="image" src="https://github.com/user-attachments/assets/4fbf1118-2864-47a1-9f5c-da7a0168c9e3" />

- 현재는 하드코딩해서 `1024px`을 기준으로 배치가 바뀌는데, theme에 breakpoint가 추가되면 수정하겠습니다.
- 1024px 기준으로 작다면(모바일~태블릿) 이미지와 같이 좌우배치 & 상단에 올라오고, 크다면(PC) 상하배치 & 왼쪽에 배치됩니다.


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
