### PR TITLE
[FE][BOM-311] fix: 모바일 하단 nav 버튼 패딩 벗어나는 문제 해결

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -102,7 +102,7 @@ const BottomNavWrapper = styled.nav`
   bottom: 0;
   left: 0;
   z-index: 100;
-  height: 64px;
+  height: calc(64px + env(safe-area-inset-bottom));
   padding: 8px 12px calc(8px + env(safe-area-inset-bottom));
   border-top: 1px solid ${({ theme }) => theme.colors.stroke};
   box-shadow: 0 -8px 12px -6px rgb(0 0 0 / 10%);


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

<img width="1170" height="656" alt="image" src="https://github.com/user-attachments/assets/7dc3ab0d-b9b4-49bb-89fd-8e6b99afe01f" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
