### PR TITLE
[BE][BOM-322] fix: 아티클/북마크 totalCount 계산 로직 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
@@ -55,19 +55,6 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
     }
 
     @Override
-    public int countAllByMemberId(Long memberId, String keyword) {
-        Long count = jpaQueryFactory.select(article.count())
-                .from(article)
-                .where(createMemberWhereClause(memberId))
-                .where(createKeywordWhereClause(keyword))
-                .fetchOne();
-
-        return Optional.ofNullable(count)
-                .orElse(0L)
-                .intValue();
-    }
-
-    @Override
     public int countAllByNewsletterIdAndMemberId(Long memberId, Long newsletterId, String keyword) {
         Long count = jpaQueryFactory.select(article.count())
                 .from(article)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/CustomArticleRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/CustomArticleRepository.java
@@ -10,8 +10,6 @@ public interface CustomArticleRepository {
 
     Page<ArticleResponse> findByMemberId(Long memberId, GetArticlesOptions options, Pageable pageable);
 
-    int countAllByMemberId(Long memberId, String keyword);
-
     int countAllByNewsletterIdAndMemberId(Long memberId, Long newsletterId, String keyword);
 
     int countByMemberIdAndArrivedDateTimeAndIsRead(Long memberId, LocalDate date, boolean isRead);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/ArticleService.java
@@ -83,7 +83,6 @@ public class ArticleService {
     }
 
     public GetArticleNewsletterStatisticsResponse getArticleNewsletterStatistics(Member member, String keyword) {
-        int totalCount = articleRepository.countAllByMemberId(member.getId(), keyword);
         List<GetArticleCountPerNewsletterResponse> countResponse = newsletterRepository.findAll()
                 .stream()
                 .map(newsletter -> {
@@ -96,6 +95,11 @@ public class ArticleService {
                 })
                 .filter(response -> response.count() > 0)
                 .toList();
+
+        int totalCount = countResponse.stream()
+                .mapToInt(response -> (int) response.count())
+                .sum();
+
         return GetArticleNewsletterStatisticsResponse.of(totalCount, countResponse);
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/bookmark/repository/BookmarkRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/bookmark/repository/BookmarkRepositoryImpl.java
@@ -46,18 +46,6 @@ public class BookmarkRepositoryImpl implements CustomBookmarkRepository {
     }
 
     @Override
-    public int countAllByMemberId(Long memberId) {
-        Long count = jpaQueryFactory.select(bookmark.count())
-                .from(bookmark)
-                .where(createMemberWhereClause(memberId))
-                .fetchOne();
-
-        return Optional.ofNullable(count)
-                .orElse(0L)
-                .intValue();
-    }
-
-    @Override
     public int countAllByMemberIdAndNewsletterId(Long memberId, Long newsletterId) {
         Long count = jpaQueryFactory.select(bookmark.count())
                 .from(bookmark)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/bookmark/repository/CustomBookmarkRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/bookmark/repository/CustomBookmarkRepository.java
@@ -8,7 +8,5 @@ public interface CustomBookmarkRepository {
 
     Page<BookmarkResponse> findByMemberId(Long memberId, Pageable pageable);
 
-    int countAllByMemberId(Long memberId);
-
     int countAllByMemberIdAndNewsletterId(Long memberId, Long newsletterId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/bookmark/service/BookmarkService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/bookmark/service/BookmarkService.java
@@ -11,6 +11,7 @@ import me.bombom.api.v1.bookmark.dto.response.GetBookmarkCountPerNewsletterRespo
 import me.bombom.api.v1.bookmark.dto.response.GetBookmarkNewsletterStatisticsResponse;
 import me.bombom.api.v1.bookmark.repository.BookmarkRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
@@ -18,9 +19,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import me.bombom.api.v1.common.exception.CIllegalArgumentException;
-import me.bombom.api.v1.common.exception.ErrorContextKeys;
-import me.bombom.api.v1.common.exception.ErrorDetail;
 
 @Service
 @RequiredArgsConstructor
@@ -77,7 +75,6 @@ public class BookmarkService {
     }
 
     public GetBookmarkNewsletterStatisticsResponse getBookmarkNewsletterStatistics(Member member) {
-        int totalCount = bookmarkRepository.countAllByMemberId(member.getId());
         List<GetBookmarkCountPerNewsletterResponse> countResponse = newsletterRepository.findAll()
                 .stream()
                 .map(newsletter -> {
@@ -87,6 +84,11 @@ public class BookmarkService {
                 })
                 .filter(response -> response.count() > 0)
                 .toList();
+
+        int totalCount = countResponse.stream()
+                .mapToInt(response -> (int) response.count())
+                .sum();
+
         return GetBookmarkNewsletterStatisticsResponse.of(totalCount, countResponse);
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
북마크의 `totalCount`가 잘못된 값으로 계산되는 문제
(디코 `버그|에러|오작동` 채널 참고)

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
문제 해결과 더불어, DB 조회를 굳이 2번 하지 않고 각 뉴스레터별 갯수 DTO를 통해 전체 갯수를 계산하는게 성능/정합성 측면에서 좋다고 생각해서 수정하였습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 기존 로직: repository에서 각 `memberId`에 대한 전체 갯수를 반환
- 변경 로직: `Get_XXX_CountPerNewsletterResponse` 을 통해 계산


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
사실 기존의 로직에서 어떤 부분 때문에 `totalCount`가 잘못 계산되는지는 모르겠습니다. 혹시 짐작 가시는 분 있을까요 🤔
