### PR TITLE
[BE][BOM-327] fix: 뉴스레터 조회 API 인터페이스에도 @Positive 어노테이션 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/controller/NewsletterControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/controller/NewsletterControllerApi.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
 import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
 import me.bombom.api.v1.newsletter.dto.NewsletterWithDetailResponse;
 
@@ -33,6 +34,7 @@ public interface NewsletterControllerApi {
             @ApiResponse(responseCode = "404", description = "뉴스레터를 찾을 수 없음", content = @Content)
     })
     NewsletterWithDetailResponse getNewsletterWithDetail(
+            @Positive(message = "id는 1 이상의 값이어야 합니다.")
             @Parameter(description = "뉴스레터 ID") Long id
     );
 } 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
인터페이스에 선언한 파라미터 검증 어노테이션과 구현체 메서드의 검증 어노테이션이 서로 달라서 발생한 예외 해결

`ConstraintDeclarationException: HV000151: A method overriding another method must not redefine the parameter constraint configuration`

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
예외가 발생해서 로직이 동작하지 않음

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
해결방법은 두 가지이다.  
1. 인터페이스에만 검증 어노테이션을 붙이기
2. 구현체, 인터페이스 모두 검증 어노테이션 붙이기

필자는 두 번째 방법 선택

- 인터페이스와 구현체의 검증(ex `@Positive`)이 다르면 Hibernate Validator는 이걸 보고 "오버라이딩하면서 파라미터 제약을 바꾸면 안 돼"라면서 ConstraintDeclarationException(HV000151)을 던진다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

