### PR TITLE
[BE][BOM-334] feat: 아티클 하이라이트 목록 조회 swagger 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleController.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.article.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -76,6 +77,7 @@ public class ArticleController implements ArticleControllerApi{
         return articleService.getArticleNewsletterStatistics(member, keyword);
     }
 
+    @Override
     @GetMapping("/{articleId}/highlights")
     public List<ArticleHighlightResponse> getHighlights(
             @LoginMember Member member,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/controller/ArticleControllerApi.java
@@ -7,13 +7,17 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import me.bombom.api.v1.article.dto.ArticleDetailResponse;
 import me.bombom.api.v1.article.dto.ArticleResponse;
 import me.bombom.api.v1.article.dto.GetArticleNewsletterStatisticsResponse;
 import me.bombom.api.v1.article.dto.GetArticlesOptions;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.highlight.dto.response.ArticleHighlightResponse;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -77,5 +81,17 @@ public interface ArticleControllerApi {
     GetArticleNewsletterStatisticsResponse getArticleNewsletterStatistics(
         @Parameter(hidden = true) Member member,
         @Parameter(description = "검색 키워드 (선택)") @RequestParam(required = false) String keyword
+    );
+
+    @Operation(
+            summary = "아티클의 하이라이트 목록 조회",
+            description = "특정 아티클의 하이라이트 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "아티클의 하이라이트 목록 조회 성공")
+    })
+    List<ArticleHighlightResponse> getHighlights(
+            @Parameter(hidden = true) Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long articleId
     );
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
특정 아티클의 하이라이트 목록을 조회하는 API에 swagger 설정을 추가합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
프론트에게 정보를 제공하기 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
아티클 하이라이트 목록 조회 API에 대해 Api 인터페이스 추가 및 override를 추가했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
