### PR TITLE
[FE][BOM-324] 플로팅 버튼 바텀 내부랑 겹치는 문제

### DIFF
--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.tsx
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.tsx
@@ -40,7 +40,10 @@ export default FloatingActionButton;
 const FloatingButton = styled.button<{ deviceType: DeviceType }>`
   position: fixed;
   right: 20px;
-  bottom: calc(84px + env(safe-area-inset-bottom));
+  bottom: calc(
+    ${({ theme }) => theme.heights.bottomNav} + env(safe-area-inset-bottom) +
+      24px
+  );
   z-index: 1000;
   width: 56px;
   height: 56px;
@@ -63,6 +66,10 @@ const FloatingMenu = styled.div<{ deviceType: DeviceType }>`
   position: fixed;
   right: 20px;
   bottom: calc(152px + env(safe-area-inset-bottom));
+  bottom: calc(
+    ${({ theme }) => theme.heights.bottomNav} + env(safe-area-inset-bottom) +
+      92px
+  );
   z-index: 999;
   min-width: 120px;
   padding: 12px;

--- a/frontend/src/components/FloatingActionButton/FloatingActionButton.tsx
+++ b/frontend/src/components/FloatingActionButton/FloatingActionButton.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import { ReactNode, useState } from 'react';
 import { useClickOutsideRef } from '@/hooks/useClickOutsideRef';
+import { DeviceType, useDeviceType } from '@/hooks/useDeviceType';
 
 interface FloatingActionButtonProps {
   icon: ReactNode;
@@ -12,6 +13,7 @@ const FloatingActionButton = ({
   children,
 }: FloatingActionButtonProps) => {
   const [isOpen, setIsOpen] = useState(false);
+  const deviceType = useDeviceType();
 
   const toggleMenu = () => {
     setIsOpen((prev) => !prev);
@@ -23,18 +25,22 @@ const FloatingActionButton = ({
 
   return (
     <div ref={floatingRef}>
-      <FloatingButton onClick={toggleMenu}>{icon}</FloatingButton>
-      {isOpen && <FloatingMenu>{children}</FloatingMenu>}
+      <FloatingButton onClick={toggleMenu} deviceType={deviceType}>
+        {icon}
+      </FloatingButton>
+      {isOpen && (
+        <FloatingMenu deviceType={deviceType}>{children}</FloatingMenu>
+      )}
     </div>
   );
 };
 
 export default FloatingActionButton;
 
-const FloatingButton = styled.button`
+const FloatingButton = styled.button<{ deviceType: DeviceType }>`
   position: fixed;
   right: 20px;
-  bottom: 20px;
+  bottom: calc(84px + env(safe-area-inset-bottom));
   z-index: 1000;
   width: 56px;
   height: 56px;
@@ -53,10 +59,10 @@ const FloatingButton = styled.button`
   }
 `;
 
-const FloatingMenu = styled.div`
+const FloatingMenu = styled.div<{ deviceType: DeviceType }>`
   position: fixed;
   right: 20px;
-  bottom: 88px;
+  bottom: calc(152px + env(safe-area-inset-bottom));
   z-index: 999;
   min-width: 120px;
   padding: 12px;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -102,7 +102,9 @@ const BottomNavWrapper = styled.nav`
   bottom: 0;
   left: 0;
   z-index: 100;
-  height: calc(64px + env(safe-area-inset-bottom));
+  height: calc(
+    ${({ theme }) => theme.heights.bottomNav} + env(safe-area-inset-bottom)
+  );
   padding: 8px 12px calc(8px + env(safe-area-inset-bottom));
   border-top: 1px solid ${({ theme }) => theme.colors.stroke};
   box-shadow: 0 -8px 12px -6px rgb(0 0 0 / 10%);

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -30,9 +30,14 @@ const colors = {
   error: '#FF4D4F',
 };
 
+const heights = {
+  bottomNav: '64px',
+};
+
 export const theme = {
   fonts,
   colors,
+  heights,
 };
 
 export type AppTheme = typeof theme;


### PR DESCRIPTION
## 📌 What
- 태블릿, 모바일 환경에서 플로팅 버튼이 하단 네비게이션과 겹치는 문제 수정

<img width="643" height="849" alt="image" src="https://github.com/user-attachments/assets/a1239161-132a-4778-8cf0-616474008bda" />

## ❓ Why
-  태블릿, 모바일 환경에서 플로팅 버튼이 하단 네비게이션 위로 침범하는 문제가 있었음.

## 🔧 How
- 플로팅 버튼 배치 조정

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
