### PR TITLE
[BE][BOM-343] feat: 회원 탈퇴 및 soft delete 기능 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/CustomOAuth2UserService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/CustomOAuth2UserService.java
@@ -32,7 +32,7 @@
             String providerId = oAuth2User.getAttribute(oAuth2Provider.getIdKey());
             String profileUrl = oAuth2User.getAttribute(oAuth2Provider.getProfileImageKey());
 
-            Optional<Member> member = memberRepository.findByProviderAndProviderId(provider, providerId);
+            Optional<Member> member = memberRepository.findByProviderAndProviderIdIncludeDeleted(provider, providerId);
 
             if (member.isPresent() && member.get().isWithdrawnMember()) {
                 throw new UnauthorizedException(ErrorDetail.WITHDRAWN_MEMBER);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/CustomOAuth2UserService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/CustomOAuth2UserService.java
@@ -6,6 +6,8 @@
     import me.bombom.api.v1.auth.dto.CustomOAuth2User;
     import me.bombom.api.v1.auth.dto.PendingOAuth2Member;
     import me.bombom.api.v1.auth.enums.OAuth2Provider;
+    import me.bombom.api.v1.common.exception.ErrorDetail;
+    import me.bombom.api.v1.common.exception.UnauthorizedException;
     import me.bombom.api.v1.member.domain.Member;
     import me.bombom.api.v1.member.repository.MemberRepository;
     import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -31,6 +33,10 @@
             String profileUrl = oAuth2User.getAttribute(oAuth2Provider.getProfileImageKey());
 
             Optional<Member> member = memberRepository.findByProviderAndProviderId(provider, providerId);
+
+            if (member.isPresent() && member.get().isWithdrawnMember()) {
+                throw new UnauthorizedException(ErrorDetail.WITHDRAWN_MEMBER);
+            }
 
             if (member.isEmpty()) {
                 PendingOAuth2Member pendingMember = PendingOAuth2Member.builder()

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/ErrorDetail.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/ErrorDetail.java
@@ -31,6 +31,7 @@ public enum ErrorDetail {
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "J005", "이미 사용 중인 닉네임입니다."),
     UNSUPPORTED_OAUTH2_PROVIDER(HttpStatus.BAD_REQUEST, "J006", "지원하지 않는 소셜 로그인 입니다."),
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "J007", "이미 사용 중인 이메일입니다."),
+    WITHDRAWN_MEMBER(HttpStatus.BAD_REQUEST, "J008", "이미 탈퇴한 회원입니다."),
 
     /*
     * G : 인가

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -41,6 +41,6 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             }
             return member;
         }
-        throw new  UnauthorizedException(ErrorDetail.INVALID_TOKEN);
+        throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import me.bombom.api.v1.common.BaseEntity;
 import me.bombom.api.v1.member.enums.Gender;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
@@ -25,6 +27,7 @@ import me.bombom.api.v1.member.enums.Gender;
         name = "member",
         uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "providerId"})
 )
+@SQLRestriction("deleted_at IS NULL")
 public class Member extends BaseEntity {
 
     @Id
@@ -55,6 +58,8 @@ public class Member extends BaseEntity {
     @Column(nullable = false, columnDefinition = "BIGINT")
     private Long roleId = 0L;
 
+    private LocalDateTime deletedAt;
+
     @Builder
     public Member(
             Long id,
@@ -77,5 +82,12 @@ public class Member extends BaseEntity {
         this.gender = gender;
         this.roleId = roleId;
     }
-}
 
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isWithdrawnMember() {
+        return this.deletedAt != null;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
@@ -18,16 +18,18 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import me.bombom.api.v1.common.BaseEntity;
 import me.bombom.api.v1.member.enums.Gender;
+import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
+@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE member SET deleted_at = now() WHERE id = ?")
 @Table(
         name = "member",
         uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "providerId"})
 )
-@SQLRestriction("deleted_at IS NULL")
 public class Member extends BaseEntity {
 
     @Id
@@ -83,11 +85,8 @@ public class Member extends BaseEntity {
         this.roleId = roleId;
     }
 
-    public void softDelete() {
-        this.deletedAt = LocalDateTime.now();
-    }
-
     public boolean isWithdrawnMember() {
         return this.deletedAt != null;
     }
 }
+

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
@@ -4,10 +4,19 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByProviderAndProviderId(String provider, String providerId);
+    @Query(value = """
+                SELECT * FROM member
+                WHERE provider = :provider AND provider_id = :providerId
+            """, nativeQuery = true)
+    Optional<Member> findByProviderAndProviderIdIncludeDeleted(
+            @Param("provider") String provider,
+            @Param("providerId") String providerId
+    );
 
     boolean existsByEmail(String email);
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.member.repository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +12,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    void deleteByDeletedAtBefore(LocalDateTime threshold);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/scheduler/MemberCleanupScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/scheduler/MemberCleanupScheduler.java
@@ -18,8 +18,8 @@ public class MemberCleanupScheduler {
 
     private final MemberRepository memberRepository;
 
-    @Scheduled(cron = DAILY_CRON,  zone = TIME_ZONE)
     @Transactional
+    @Scheduled(cron = DAILY_CRON,  zone = TIME_ZONE)
     public void cleanupDeletedMembers() {
         log.info("탈퇴 후 1년 지난 회원 삭제");
         LocalDateTime oneYearAgo = LocalDateTime.now().minusYears(1);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/scheduler/MemberCleanupScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/scheduler/MemberCleanupScheduler.java
@@ -1,0 +1,28 @@
+package me.bombom.api.v1.member.scheduler;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MemberCleanupScheduler {
+
+    private static final String DAILY_CRON = "0 0 0 * * *";
+    private static final String TIME_ZONE = "Asia/Seoul";
+
+    private final MemberRepository memberRepository;
+
+    @Scheduled(cron = DAILY_CRON,  zone = TIME_ZONE)
+    @Transactional
+    public void cleanupDeletedMembers() {
+        log.info("탈퇴 후 1년 지난 회원 삭제");
+        LocalDateTime oneYearAgo = LocalDateTime.now().minusYears(1);
+        memberRepository.deleteByDeletedAtBefore(oneYearAgo);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -52,6 +52,16 @@ public class MemberService {
         return MemberProfileResponse.from(member);
     }
 
+    @Transactional
+    public void withdraw(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                .addContext(ErrorContextKeys.ENTITY_TYPE, "member")
+            );
+        member.softDelete();
+    }
+
     private void validateDuplicateEmail(String email) {
         if (memberRepository.existsByEmail(email)) {
             throw new CIllegalArgumentException(ErrorDetail.DUPLICATE_EMAIL)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -59,7 +59,7 @@ public class MemberService {
                 .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                 .addContext(ErrorContextKeys.ENTITY_TYPE, "member")
             );
-        member.softDelete();
+        memberRepository.delete(member);
     }
 
     private void validateDuplicateEmail(String email) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MemberServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MemberServiceTest.java
@@ -1,8 +1,10 @@
 package me.bombom.api.v1.member.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.LocalDate;
+import java.util.Optional;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.auth.dto.PendingOAuth2Member;
 import me.bombom.api.v1.common.config.QuerydslConfig;
@@ -15,6 +17,7 @@ import me.bombom.api.v1.member.repository.MemberRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.context.annotation.Import;
 
 @DataJpaTest
@@ -26,6 +29,9 @@ class MemberServiceTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
 
     @Test
     void 회원가입_중_이미_존재하는_닉네임이면_예외_발생() {
@@ -77,5 +83,36 @@ class MemberServiceTest {
         assertThatThrownBy(() -> memberService.signup(oAuth2Member, memberSignupRequest))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.DUPLICATE_EMAIL);
+    }
+
+    @Test
+    void 회원_탈퇴_성공() {
+        // given
+        Member member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+        Long memberId = member.getId();
+
+        // when
+        memberService.withdraw(memberId);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        // then
+        Optional<Member> foundMemberOptional = memberRepository.findById(memberId);
+        assertThat(foundMemberOptional).isEmpty();
+    }
+
+    @Test
+    void 존재하지_않는_회원_탈퇴_시_예외_발생() {
+        // given
+        Long nonExistentMemberId = 0L;
+
+        // when & then
+        assertThatThrownBy(() -> memberService.withdraw(nonExistentMemberId))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.ENTITY_NOT_FOUND)
+                .hasFieldOrPropertyWithValue("context.memberId", nonExistentMemberId)
+                .hasFieldOrPropertyWithValue("context.entityType", "member");
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 회원 탈퇴 기능
- 탈퇴시 soft delete
- 탈퇴 후 1년 지난 회원은 DB에서 삭제

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 민감한 데이터 보관

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- `Member` 엔티티에 `deletedAt` 필드 추가
- `@SQLRestriction("deleted_at IS NULL")` 어노테이션을 통해 DB 조회 시에 deleted_at이 NULL인 회원(탈퇴 x) 만 조회하도록 함
- 스케줄러를 통해 매일 자정에 탈퇴 후 1년 지난 회원 hard delete 함

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 탈퇴를 `Withdraw`로 사용하고, 있는데 더 적절한 네이밍 있을까요
- `deletedAt`을 `BaseEntity`나 다른 상위 엔티티의 필드로 만들지 않아도 될까요