### PR TITLE
[FE][BOM-346] 모달 홈페이지 링크 위치 변경

### DIFF
--- a/frontend/src/components/Badge/Badge.tsx
+++ b/frontend/src/components/Badge/Badge.tsx
@@ -1,27 +1,32 @@
 import styled from '@emotion/styled';
+import { ComponentProps } from 'react';
 import type { Theme } from '@emotion/react';
 
 type VariantType = 'default' | 'outlinePrimary';
 
-interface BadgeProps {
+interface BadgeProps extends ComponentProps<'div'> {
   text: string;
   variant?: VariantType;
 }
 
-function Badge({ text, variant = 'default' }: BadgeProps) {
-  return <Container variant={variant}>{text}</Container>;
+function Badge({ text, variant = 'default', className, ...props }: BadgeProps) {
+  return (
+    <Container variant={variant} className={className} {...props}>
+      {text}
+    </Container>
+  );
 }
 
 export default Badge;
 
 const Container = styled.div<{ variant: VariantType }>`
-  display: flex;
-  align-items: center;
-  justify-content: center;
-
   width: fit-content;
   padding: 4px 8px;
   border-radius: 8px;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   font: ${({ theme }) => theme.fonts.caption};
 

--- a/frontend/src/components/Badge/Badge.tsx
+++ b/frontend/src/components/Badge/Badge.tsx
@@ -9,9 +9,9 @@ interface BadgeProps extends ComponentProps<'div'> {
   variant?: VariantType;
 }
 
-function Badge({ text, variant = 'default', className, ...props }: BadgeProps) {
+function Badge({ text, variant = 'default', ...props }: BadgeProps) {
   return (
-    <Container variant={variant} className={className} {...props}>
+    <Container variant={variant} {...props}>
       {text}
     </Container>
   );

--- a/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
+++ b/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
@@ -61,7 +61,7 @@ const NewsletterDetail = ({
               <NewsletterTitle isMobile={isMobile}>
                 {newsletterDetail.name}
               </NewsletterTitle>
-              <DetailLink onClick={openMainSite}>
+              <DetailLink onClick={openMainSite} isMobile={isMobile}>
                 <StyledHomeIcon isMobile={isMobile} />
               </DetailLink>
             </TitleWrapper>
@@ -70,15 +70,6 @@ const NewsletterDetail = ({
               <StyledBadge text={category} isMobile={isMobile} />
               <IssueCycle>{newsletterDetail.issueCycle}</IssueCycle>
             </NewsletterInfo>
-
-            <LinkWrapper isMobile={isMobile}>
-              {newsletterDetail.previousNewsletterUrl && (
-                <DetailLink onClick={openPreviousLetters}>
-                  <ArticleHistoryIcon width={16} height={16} />
-                  지난 소식 보기
-                </DetailLink>
-              )}
-            </LinkWrapper>
           </InfoBox>
         </InfoWrapper>
 
@@ -90,7 +81,16 @@ const NewsletterDetail = ({
       </FixedWrapper>
 
       <ScrollableWrapper isMobile={isMobile}>
-        <Description>{newsletterDetail.description}</Description>
+        <Description isMobile={isMobile}>
+          {newsletterDetail.description}
+        </Description>
+
+        {newsletterDetail.previousNewsletterUrl && (
+          <DetailLink onClick={openPreviousLetters} isMobile={isMobile}>
+            <ArticleHistoryIcon width={16} height={16} />
+            지난 소식 보기
+          </DetailLink>
+        )}
 
         {!isMobile && (
           <SubscribeWrapper>
@@ -251,24 +251,20 @@ const IssueCycle = styled.p`
   text-align: center;
 `;
 
-const LinkWrapper = styled.div<{ isMobile: boolean }>`
+const Description = styled.p<{ isMobile: boolean }>`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  font: ${({ isMobile, theme }) =>
+    isMobile ? theme.fonts.body2 : theme.fonts.body1};
+`;
+
+const DetailLink = styled.a<{ isMobile: boolean }>`
   display: flex;
-  gap: 12px;
+  gap: 4px;
+  align-items: center;
 
   color: ${({ theme }) => theme.colors.textSecondary};
   font: ${({ theme, isMobile }) =>
     isMobile ? theme.fonts.body3 : theme.fonts.body2};
-`;
-
-const Description = styled.p`
-  color: ${({ theme }) => theme.colors.textSecondary};
-  font: ${({ theme }) => theme.fonts.body1};
-`;
-
-const DetailLink = styled.a`
-  display: flex;
-  gap: 4px;
-  align-items: center;
 
   transition: all 0.2s ease;
 

--- a/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
+++ b/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
@@ -57,20 +57,21 @@ const NewsletterDetail = ({
             isMobile={isMobile}
           />
           <InfoBox>
-            <NewsletterTitle isMobile={isMobile}>
-              {newsletterDetail.name}
-            </NewsletterTitle>
+            <TitleWrapper>
+              <NewsletterTitle isMobile={isMobile}>
+                {newsletterDetail.name}
+              </NewsletterTitle>
+              <DetailLink onClick={openMainSite}>
+                <StyledHomeIcon isMobile={isMobile} />
+              </DetailLink>
+            </TitleWrapper>
+
             <NewsletterInfo isMobile={isMobile}>
               <StyledBadge text={category} isMobile={isMobile} />
               <IssueCycle>{newsletterDetail.issueCycle}</IssueCycle>
             </NewsletterInfo>
 
             <LinkWrapper isMobile={isMobile}>
-              <DetailLink onClick={openMainSite}>
-                <HomeIcon width={16} height={16} />
-                홈페이지
-              </DetailLink>
-
               {newsletterDetail.previousNewsletterUrl && (
                 <DetailLink onClick={openPreviousLetters}>
                   <ArticleHistoryIcon width={16} height={16} />
@@ -91,7 +92,7 @@ const NewsletterDetail = ({
       <ScrollableWrapper isMobile={isMobile}>
         <Description>{newsletterDetail.description}</Description>
 
-        {deviceType !== 'mobile' && (
+        {!isMobile && (
           <SubscribeWrapper>
             <SubscribeHeader>
               <SubscribeTitle>구독 방법</SubscribeTitle>
@@ -196,8 +197,8 @@ const InfoWrapper = styled.div<{ isMobile: boolean }>`
 `;
 
 const NewsletterImage = styled(ImageWithFallback)<{ isMobile: boolean }>`
-  width: ${({ isMobile }) => (isMobile ? '88px' : '112px')};
-  height: ${({ isMobile }) => (isMobile ? '88px' : '112px')};
+  width: ${({ isMobile }) => (isMobile ? '88px' : '104px')};
+  height: ${({ isMobile }) => (isMobile ? '88px' : '104px')};
   border-radius: ${({ isMobile }) => (isMobile ? '12px' : '16px')};
 
   flex-shrink: 0;
@@ -213,10 +214,22 @@ const InfoBox = styled.div`
   flex-direction: column;
 `;
 
+const TitleWrapper = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
 const NewsletterTitle = styled.h2<{ isMobile: boolean }>`
   color: ${({ theme }) => theme.colors.textPrimary};
   font: ${({ theme, isMobile }) =>
-    isMobile ? theme.fonts.heading5 : theme.fonts.heading4};
+    isMobile ? theme.fonts.heading4 : theme.fonts.heading3};
+`;
+
+const StyledHomeIcon = styled(HomeIcon)<{ isMobile: boolean }>`
+  width: ${({ isMobile }) => (isMobile ? '8px' : '24px')};
+  height: ${({ isMobile }) => (isMobile ? '8px' : '24px')};
+
+  fill: ${({ theme }) => theme.colors.primary};
 `;
 
 const NewsletterInfo = styled.div<{ isMobile: boolean }>`

--- a/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
+++ b/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
@@ -57,7 +57,7 @@ const NewsletterDetail = ({
             isMobile={isMobile}
           />
           <InfoBox>
-            <TitleWrapper>
+            <TitleWrapper isMobile={isMobile}>
               <NewsletterTitle isMobile={isMobile}>
                 {newsletterDetail.name}
               </NewsletterTitle>
@@ -214,9 +214,9 @@ const InfoBox = styled.div`
   flex-direction: column;
 `;
 
-const TitleWrapper = styled.div`
+const TitleWrapper = styled.div<{ isMobile: boolean }>`
   display: flex;
-  gap: 8px;
+  gap: ${({ isMobile }) => (isMobile ? '4px' : '8px')};
 `;
 
 const NewsletterTitle = styled.h2<{ isMobile: boolean }>`
@@ -226,8 +226,8 @@ const NewsletterTitle = styled.h2<{ isMobile: boolean }>`
 `;
 
 const StyledHomeIcon = styled(HomeIcon)<{ isMobile: boolean }>`
-  width: ${({ isMobile }) => (isMobile ? '8px' : '24px')};
-  height: ${({ isMobile }) => (isMobile ? '8px' : '24px')};
+  width: ${({ isMobile }) => (isMobile ? '20px' : '24px')};
+  height: ${({ isMobile }) => (isMobile ? '20px' : '24px')};
 
   fill: ${({ theme }) => theme.colors.primary};
 `;

--- a/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
+++ b/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
@@ -60,12 +60,24 @@ const NewsletterDetail = ({
             <NewsletterTitle isMobile={isMobile}>
               {newsletterDetail.name}
             </NewsletterTitle>
-            <NewsletterInfo>
-              <Badge text={category} />
-              <IssueCycle isMobile={isMobile}>
-                {newsletterDetail.issueCycle}
-              </IssueCycle>
+            <NewsletterInfo isMobile={isMobile}>
+              <StyledBadge text={category} isMobile={isMobile} />
+              <IssueCycle>{newsletterDetail.issueCycle}</IssueCycle>
             </NewsletterInfo>
+
+            <LinkWrapper isMobile={isMobile}>
+              <DetailLink onClick={openMainSite}>
+                <HomeIcon width={16} height={16} />
+                홈페이지
+              </DetailLink>
+
+              {newsletterDetail.previousNewsletterUrl && (
+                <DetailLink onClick={openPreviousLetters}>
+                  <ArticleHistoryIcon width={16} height={16} />
+                  지난 소식 보기
+                </DetailLink>
+              )}
+            </LinkWrapper>
           </InfoBox>
         </InfoWrapper>
 
@@ -78,20 +90,6 @@ const NewsletterDetail = ({
 
       <ScrollableWrapper isMobile={isMobile}>
         <Description>{newsletterDetail.description}</Description>
-
-        <LinkWrapper>
-          <DetailLink onClick={openMainSite}>
-            <HomeIcon width={18} height={18} />
-            홈페이지
-          </DetailLink>
-
-          {newsletterDetail.previousNewsletterUrl && (
-            <DetailLink onClick={openPreviousLetters}>
-              <ArticleHistoryIcon width={18} height={18} />
-              지난 소식 보기
-            </DetailLink>
-          )}
-        </LinkWrapper>
 
         {deviceType !== 'mobile' && (
           <SubscribeWrapper>
@@ -198,8 +196,8 @@ const InfoWrapper = styled.div<{ isMobile: boolean }>`
 `;
 
 const NewsletterImage = styled(ImageWithFallback)<{ isMobile: boolean }>`
-  width: ${({ isMobile }) => (isMobile ? '60px' : '80px')};
-  height: ${({ isMobile }) => (isMobile ? '60px' : '80px')};
+  width: ${({ isMobile }) => (isMobile ? '88px' : '112px')};
+  height: ${({ isMobile }) => (isMobile ? '88px' : '112px')};
   border-radius: ${({ isMobile }) => (isMobile ? '12px' : '16px')};
 
   flex-shrink: 0;
@@ -221,30 +219,36 @@ const NewsletterTitle = styled.h2<{ isMobile: boolean }>`
     isMobile ? theme.fonts.heading5 : theme.fonts.heading4};
 `;
 
-const NewsletterInfo = styled.div`
+const NewsletterInfo = styled.div<{ isMobile: boolean }>`
   display: flex;
   gap: 12px;
   align-items: center;
+
+  font: ${({ theme, isMobile }) =>
+    isMobile ? theme.fonts.body3 : theme.fonts.body2};
 `;
 
-const IssueCycle = styled.p<{ isMobile: boolean }>`
+const StyledBadge = styled(Badge)<{ isMobile: boolean }>`
+  font: ${({ theme, isMobile }) =>
+    isMobile ? theme.fonts.body3 : theme.fonts.body2};
+`;
+
+const IssueCycle = styled.p`
+  color: ${({ theme }) => theme.colors.textSecondary};
+  text-align: center;
+`;
+
+const LinkWrapper = styled.div<{ isMobile: boolean }>`
+  display: flex;
+  gap: 12px;
+
   color: ${({ theme }) => theme.colors.textSecondary};
   font: ${({ theme, isMobile }) =>
-    isMobile ? theme.fonts.caption : theme.fonts.body2};
-  text-align: center;
+    isMobile ? theme.fonts.body3 : theme.fonts.body2};
 `;
 
 const Description = styled.p`
   color: ${({ theme }) => theme.colors.textSecondary};
-  font: ${({ theme }) => theme.fonts.body1};
-`;
-
-const LinkWrapper = styled.div`
-  display: flex;
-  gap: 8px;
-  flex-direction: column;
-
-  color: ${({ theme }) => theme.colors.textPrimary};
   font: ${({ theme }) => theme.fonts.body1};
 `;
 

--- a/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
+++ b/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
@@ -68,7 +68,7 @@ const NewsletterDetail = ({
 
             <NewsletterInfo isMobile={isMobile}>
               <StyledBadge text={category} isMobile={isMobile} />
-              <IssueCycle>{newsletterDetail.issueCycle}</IssueCycle>
+              <IssueCycle>{`${newsletterDetail.issueCycle} 발행`}</IssueCycle>
             </NewsletterInfo>
           </InfoBox>
         </InfoWrapper>


### PR DESCRIPTION
## 📌 What
- 모달창의 홈페이지 링크 위치 변경
- 홈페이지 링크를 아이콘으로 간소화
- 지난 뉴스레터 링크 위치 변경 (개요 설명 위 → 아래)
  - 추후 링크 대신, 데이터를 직접 패칭해올 것을 고려함
- 기타 전반적인 gap, font size 변경

**[PC, 태블릿]**
<img width="498" height="524" alt="image" src="https://github.com/user-attachments/assets/a62455fd-5d53-4698-b4d3-c92e1d0be866" />


**[모바일]**
<img width="395" height="640" alt="image" src="https://github.com/user-attachments/assets/72c651a5-2297-47e7-ae46-1f8024dde17c" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
