### PR TITLE
[FE][BOM-354] 뉴스레터 보관함 반응형 디자인 수정

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -43,7 +43,9 @@ const MobileHeaderContainer = styled.header`
   top: 0;
   z-index: ${({ theme }) => theme.zIndex.header};
   width: 100%;
-  height: calc(56px + env(safe-area-inset-top));
+  height: calc(
+    ${({ theme }) => theme.heights.headerMobile} + env(safe-area-inset-top)
+  );
   padding: 8px 12px;
   padding-top: calc(8px + env(safe-area-inset-top));
   box-shadow:
@@ -62,7 +64,7 @@ const HeaderContainer = styled.header`
   top: 0;
   z-index: ${({ theme }) => theme.zIndex.header};
   width: 100%;
-  height: 72px;
+  height: ${({ theme }) => theme.heights.headerPC};
   padding: 8px 16px;
   border-radius: 0 0 8px 8px;
   box-shadow:

--- a/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/frontend/src/components/PageLayout/PageLayout.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 import { useRouterState } from '@tanstack/react-router';
 import { PropsWithChildren, useEffect, useRef } from 'react';
 import Header from '../Header/Header';
+import { useDeviceType } from '@/hooks/useDeviceType';
 import { NavType } from '@/types/nav';
 
 const navMap: Record<string, NavType> = {
@@ -14,6 +15,8 @@ const PageLayout = ({ children }: PropsWithChildren) => {
   const location = useRouterState({
     select: (state) => state.location.pathname,
   });
+  const deviceType = useDeviceType();
+  const isMobile = deviceType === 'mobile';
 
   const previousNavRef = useRef<NavType>('today');
 
@@ -26,7 +29,7 @@ const PageLayout = ({ children }: PropsWithChildren) => {
   const activeNav = navMap[location] || previousNavRef.current;
 
   return (
-    <Container>
+    <Container isMobile={isMobile}>
       <Header activeNav={activeNav} />
       {children}
     </Container>
@@ -35,12 +38,22 @@ const PageLayout = ({ children }: PropsWithChildren) => {
 
 export default PageLayout;
 
-const Container = styled.div`
+const Container = styled.div<{ isMobile: boolean }>`
   width: 100%;
   min-height: 100vh;
-  padding: 72px 0; /* header 높이 */
-  padding-right: 16px;
-  padding-left: 16px;
+  padding: ${({ isMobile, theme }) => {
+    const sidePadding = isMobile ? '12px' : '24px';
+    const headerHeight = isMobile
+      ? theme.heights.headerMobile
+      : theme.heights.headerPC;
+
+    const topPadding = `calc(${headerHeight} + env(safe-area-inset-top) + ${sidePadding})`;
+    const bottomPadding = isMobile
+      ? `calc(${theme.heights.bottomNav} + env(safe-area-inset-bottom) + ${sidePadding})`
+      : `calc(env(safe-area-inset-bottom) + ${sidePadding})`;
+
+    return `${topPadding} ${sidePadding} ${bottomPadding} ${sidePadding}`;
+  }};
 
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/today/components/ArticleCard/ArticleCard.tsx
+++ b/frontend/src/pages/today/components/ArticleCard/ArticleCard.tsx
@@ -73,9 +73,11 @@ function ArticleCard({
           alt="아티클 썸네일"
         />
         {isRead && readVariant === 'badge' && (
-          <BadgeWrapper>
-            <Badge text="읽음" variant="outlinePrimary" />
-          </BadgeWrapper>
+          <ReadingBadge
+            text="읽음"
+            variant="outlinePrimary"
+            isMobile={isMobile}
+          />
         )}
       </ThumbnailWrapper>
     </Container>
@@ -183,8 +185,9 @@ const Thumbnail = styled(ImageWithFallback)<{ isMobile: boolean }>`
   object-fit: cover;
 `;
 
-const BadgeWrapper = styled.div`
+const ReadingBadge = styled(Badge)<{ isMobile: boolean }>`
   position: absolute;
   top: 4px;
   right: 4px;
+  padding: ${({ isMobile }) => (isMobile ? '2px 4px' : '4px 8px')};
 `;

--- a/frontend/src/pages/today/components/ArticleCardList/ArticleCardList.tsx
+++ b/frontend/src/pages/today/components/ArticleCardList/ArticleCardList.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import ArticleCard from '../ArticleCard/ArticleCard';
 import EmptyLetterCard from '../EmptyLetterCard/EmptyLetterCard';
-import { DeviceType, useDeviceType } from '@/hooks/useDeviceType';
+import { useDeviceType } from '@/hooks/useDeviceType';
 import { theme } from '@/styles/theme';
 import { Article } from '@/types/articles';
 import CheckIcon from '#/assets/check.svg';
@@ -17,6 +17,8 @@ interface ArticleCardListProps {
 
 const ArticleCardList = ({ articles }: ArticleCardListProps) => {
   const deviceType = useDeviceType();
+  const isMobile = deviceType === 'mobile';
+
   const grouped = articles.reduce<{
     read: ExtendedArticle[];
     unread: ExtendedArticle[];
@@ -33,51 +35,61 @@ const ArticleCardList = ({ articles }: ArticleCardListProps) => {
     return <EmptyLetterCard title="새로운 뉴스레터가 없어요" />;
 
   return (
-    <Container>
-      <ListTitleBox>
-        <LetterIcon width={32} height={32} color={theme.colors.white} />
-        <ListTitle>새로운 뉴스레터 ({grouped.unread.length}개)</ListTitle>
-      </ListTitleBox>
-      <CardList deviceType={deviceType}>
-        {grouped.unread.map((article) => (
-          <li key={article.articleId}>
-            <ArticleCard
-              data={article}
-              to={
-                article.type === 'guide'
-                  ? `/articles/guide/${article.articleId}`
-                  : `/articles/${article.articleId}`
-              }
-            />
-          </li>
-        ))}
-      </CardList>
-      {grouped.read.length > 0 && (
+    <Container isMobile={isMobile}>
+      <LettersWrapper isMobile={isMobile}>
         <ListTitleBox>
-          <CheckIcon width={32} height={32} color={theme.colors.black} />
-          <ListTitle>읽은 뉴스레터 ({grouped.read.length}개)</ListTitle>
+          <LetterIcon width={32} height={32} color={theme.colors.white} />
+          <ListTitle>새로운 뉴스레터 ({grouped.unread.length}개)</ListTitle>
         </ListTitleBox>
-      )}
-      <CardList deviceType={deviceType}>
-        {grouped.read.map((article) => (
-          <li key={article.articleId}>
-            <ArticleCard data={article} />
-          </li>
-        ))}
-      </CardList>
+        <CardList isMobile={isMobile}>
+          {grouped.unread.map((article) => (
+            <li key={article.articleId}>
+              <ArticleCard
+                data={article}
+                to={
+                  article.type === 'guide'
+                    ? `/articles/guide/${article.articleId}`
+                    : `/articles/${article.articleId}`
+                }
+              />
+            </li>
+          ))}
+        </CardList>
+      </LettersWrapper>
+      <LettersWrapper isMobile={isMobile}>
+        {grouped.read.length > 0 && (
+          <ListTitleBox>
+            <CheckIcon width={32} height={32} color={theme.colors.black} />
+            <ListTitle>읽은 뉴스레터 ({grouped.read.length}개)</ListTitle>
+          </ListTitleBox>
+        )}
+        <CardList isMobile={isMobile}>
+          {grouped.read.map((article) => (
+            <li key={article.articleId}>
+              <ArticleCard data={article} />
+            </li>
+          ))}
+        </CardList>
+      </LettersWrapper>
     </Container>
   );
 };
 
 export default ArticleCardList;
 
-const Container = styled.div`
+const Container = styled.div<{ isMobile: boolean }>`
   width: 100%;
 
   display: flex;
-  gap: 16px;
+  gap: ${({ isMobile }) => (isMobile ? '24px' : '48px')};
   flex-direction: column;
   align-items: flex-start;
+`;
+
+const LettersWrapper = styled.div<{ isMobile: boolean }>`
+  display: flex;
+  gap: ${({ isMobile }) => (isMobile ? '8px' : '24px')};
+  flex-direction: column;
 `;
 
 const ListTitleBox = styled.div`
@@ -91,15 +103,15 @@ const ListTitle = styled.h5`
   font: ${({ theme }) => theme.fonts.heading5};
 `;
 
-const CardList = styled.ul<{ deviceType: DeviceType }>`
+const CardList = styled.ul<{ isMobile: boolean }>`
   width: 100%;
 
   display: flex;
-  gap: ${({ deviceType }) => (deviceType === 'mobile' ? '0' : '16px')};
+  gap: ${({ isMobile }) => (isMobile ? '0' : '16px')};
   flex-direction: column;
 
-  ${({ deviceType, theme }) =>
-    deviceType === 'mobile' &&
+  ${({ isMobile, theme }) =>
+    isMobile &&
     `
     li {
       padding: 8px 0;

--- a/frontend/src/pages/today/components/ArticleCardList/ArticleCardList.tsx
+++ b/frontend/src/pages/today/components/ArticleCardList/ArticleCardList.tsx
@@ -81,7 +81,7 @@ const Container = styled.div<{ isMobile: boolean }>`
   width: 100%;
 
   display: flex;
-  gap: ${({ isMobile }) => (isMobile ? '24px' : '48px')};
+  gap: ${({ isMobile }) => (isMobile ? '24px' : 0)};
   flex-direction: column;
   align-items: flex-start;
 `;

--- a/frontend/src/routes/_bombom/index.tsx
+++ b/frontend/src/routes/_bombom/index.tsx
@@ -47,9 +47,6 @@ function Index() {
             </TitleIconBox>
             <Title>오늘의 뉴스레터</Title>
           </TitleWrapper>
-          <ArticleCountSummary>
-            {mergedArticles.length ?? 0}개의 새로운 뉴스레터가 도착했어요
-          </ArticleCountSummary>
         </>
       )}
 
@@ -98,12 +95,7 @@ const TitleIconBox = styled.div`
 `;
 
 const Title = styled.h1`
-  font: ${({ theme }) => theme.fonts.heading2};
-`;
-
-const ArticleCountSummary = styled.p`
-  color: ${({ theme }) => theme.colors.textSecondary};
-  font: ${({ theme }) => theme.fonts.caption};
+  font: ${({ theme }) => theme.fonts.heading3};
 `;
 
 const ContentWrapper = styled.div<{ deviceType: DeviceType }>`

--- a/frontend/src/routes/_bombom/index.tsx
+++ b/frontend/src/routes/_bombom/index.tsx
@@ -68,9 +68,6 @@ const Container = styled.div<{ deviceType: DeviceType }>`
   width: 100%;
   max-width: 1280px;
   margin: 0 auto;
-  padding: ${({ deviceType }) => (deviceType === 'mobile' ? '0px' : '24px')};
-  padding-top: ${({ deviceType }) =>
-    deviceType === 'mobile' ? '0px' : '64px'};
 
   display: flex;
   gap: 24px;

--- a/frontend/src/routes/_bombom/recommend.tsx
+++ b/frontend/src/routes/_bombom/recommend.tsx
@@ -25,7 +25,6 @@ function Recommend() {
 const Container = styled.div`
   width: 100%;
   max-width: 1280px;
-  padding: 64px 20px 0;
 
   display: flex;
   gap: 24px;

--- a/frontend/src/routes/_bombom/storage.tsx
+++ b/frontend/src/routes/_bombom/storage.tsx
@@ -95,7 +95,6 @@ function Storage() {
 const Container = styled.div`
   width: 100%;
   max-width: 1280px;
-  padding: 64px 24px;
 
   display: flex;
   gap: 24px;

--- a/frontend/src/routes/_bombom/storage.tsx
+++ b/frontend/src/routes/_bombom/storage.tsx
@@ -123,7 +123,7 @@ const TitleIconBox = styled.div`
 `;
 
 const Title = styled.h1`
-  font: ${({ theme }) => theme.fonts.heading2};
+  font: ${({ theme }) => theme.fonts.heading3};
 `;
 
 const ContentWrapper = styled.div<{ isPC: boolean }>`

--- a/frontend/src/routes/_bombom/storage.tsx
+++ b/frontend/src/routes/_bombom/storage.tsx
@@ -150,7 +150,7 @@ const MainContentSection = styled.div<{ isPC: boolean }>`
   width: 100%;
 
   display: flex;
-  gap: 40px;
+  gap: 32px;
   flex: 1;
   flex-direction: column;
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -31,6 +31,8 @@ const colors = {
 };
 
 const heights = {
+  headerPC: '72px',
+  headerMobile: '56px',
   bottomNav: '64px',
 };
 


### PR DESCRIPTION
## 📌 What
- 헤더 및 하단 네비게이션 높이를 전역 스타일로 관리
- 각 페이지의 패딩을 PageLayout에서 일괄적으로 관리하도록 리팩토링 (통일성, 유지보수 용이성 고려)

- 페이지 반응형 디자인 수정

### 오늘의 뉴스레터
[before - after]
<img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/312cd651-435e-46c8-9dec-5507608c0f2d" /><img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/3b2bfb84-d356-4eef-974b-6b6a838c7398" />

<br>

### 뉴스레터 보관함
[before - after]
<img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/0508d344-b32d-480a-992f-5bc555dcbd3b" /><img width="250" height="350" alt="image" src="https://github.com/user-attachments/assets/7167ba74-c9aa-4933-a77c-b6889ae24ae3" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
