### PR TITLE
[BE][BOM-358] fix: 이달의 독서왕 쿼리 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/MonthlyReadingRankResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/MonthlyReadingRankResponse.java
@@ -9,7 +9,7 @@ public record MonthlyReadingRankResponse(
         String nickname,
 
         @Schema(required = true)
-        int rank,
+        long rank,
 
         @Schema(required = true)
         int monthlyReadCount

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingRepository.java
@@ -15,7 +15,7 @@ public interface MonthlyReadingRepository extends JpaRepository<MonthlyReading, 
     @Query(value = """
         SELECT
             m.nickname AS nickname,
-            CAST(RANK() OVER (ORDER BY mr.current_count DESC) AS SIGNED) AS rank,
+            RANK() OVER (ORDER BY mr.current_count DESC) AS `rank`,
             mr.current_count AS monthlyReadCount
         FROM monthly_reading mr
         JOIN member m ON mr.member_id = m.id

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingRepository.java
@@ -15,7 +15,7 @@ public interface MonthlyReadingRepository extends JpaRepository<MonthlyReading, 
     @Query(value = """
         SELECT
             m.nickname AS nickname,
-            CAST(RANK() OVER (ORDER BY mr.current_count DESC) AS INT) AS rank,
+            CAST(RANK() OVER (ORDER BY mr.current_count DESC) AS SIGNED) AS rank,
             mr.current_count AS monthlyReadCount
         FROM monthly_reading mr
         JOIN member m ON mr.member_id = m.id


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
이달의 독서왕 쿼리를 수정했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
500 에러가 났습니다.
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
<img width="1138" height="522" alt="image" src="https://github.com/user-attachments/assets/dc7938b2-071c-4758-bee5-2ee62575041a" />

테스트에서는 문제 없어서 괜찮은 줄 알았습니다..
EC2에 직접 들어가서 쿼리를 실행시켜보았는데요.
쿼리에서 CAST가 INT가 H2에서는 가능한데, MySQL에서는 동작하지 않는 문제를 발견했습니다.
MySQL에서는 INT가 아니라, SIGNED, UNSIGNED로 가능하다는 것을 알았습니다.
이 또한, EC2에 들어가서 직접 쿼리를 실행시켜 결과가 제대로 나오는 것을 확인했습니다.
## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
