### PR TITLE
[BE][BOM-357] chore: 운영 서버 버저닝 도입

### DIFF
--- a/.github/workflows/prod-deploy.yml
+++ b/.github/workflows/prod-deploy.yml
@@ -1,13 +1,20 @@
-name: Backend Prod Server CI/CD  # ✅ dev → prod 이름 변경
+name: Backend Prod Server CI/CD
 
 on:
   push:
     branches:
-      - server   # ✅ server-dev → server
-  workflow_dispatch:    # ✅ GitHub UI에서 수동 배포
+      - server
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: '배포할 버전 태그 (예: v1.0.0)'
+        required: false
+        type: string
 
 jobs:
   build:
+    outputs:
+      version_tag: ${{ steps.version.outputs.tag }}
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -15,20 +22,62 @@ jobs:
 
     steps:
       - name: 코드 체크아웃
+        id: checkout
         uses: actions/checkout@v4
+        with:
+          # 최소한의 히스토리만 가져오기
+          fetch-depth: 0
+
+      - name: 버전 태그 결정
+        id: version
+        run: |
+          LATEST_SERVER_TAG=$(git tag --list "server-*" --sort=-version:refname | head -1 || echo "server-v0.0.0")
+          echo "최신 서버 태그: $LATEST_SERVER_TAG"
+            
+          if [[ "$LATEST_SERVER_TAG" =~ ^server-v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+            
+            NEW_PATCH=$((PATCH + 1))
+            VERSION_TAG="server-v${MAJOR}.${MINOR}.${NEW_PATCH}"
+            echo "새 서버 버전 생성: $LATEST_SERVER_TAG → $VERSION_TAG"
+          else
+            VERSION_TAG="server-v1.0.0"
+            echo "서버 버전 시작: $VERSION_TAG"
+          fi
+            
+          # 새 태그 생성 및 푸시
+          git tag $VERSION_TAG
+          git push origin $VERSION_TAG
+          echo "새 서버 태그 $VERSION_TAG 생성 및 푸시 완료"
+          
+          echo "tag=$VERSION_TAG" >> $GITHUB_OUTPUT
+          echo "최종 버전: $VERSION_TAG"
 
       - name: JDK 21 설정
         uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
+          # Gradle 캐시 최적화
           cache: gradle
+
+      - name: Gradle 캐시 복원
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
       - name: application.yml 생성 (Prod 환경)
         run: |
           echo "Create application.yml(prod) from secret"
           mkdir -p src/main/resources
-          echo "${{ secrets.APPLICATION_PROD_PROPERTIES }}" > src/main/resources/application.yml  # ✅ DEV → PROD
+          echo "${{ secrets.APPLICATION_PROD_PROPERTIES }}" > src/main/resources/application.yml
           
           echo "Create application.yml(test) from secret"
           mkdir -p src/test/resources
@@ -39,6 +88,11 @@ jobs:
 
       - name: Docker Buildx 설정
         uses: docker/setup-buildx-action@v3
+        with:
+          # 단일 인스턴스 사용으로 CPU 절약
+          driver-opts: |
+            image=moby/buildkit:v0.12.0
+            network=host
 
       - name: DockerHub 로그인
         uses: docker/login-action@v3
@@ -53,28 +107,39 @@ jobs:
           else
             docker buildx use ci-builder
           fi
+          
+          VERSION_TAG="${{ steps.version.outputs.tag }}"
+          
           docker buildx build \
             --platform linux/arm64,linux/amd64 \
             --cache-from=type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/bom-bom:buildcache \
             --cache-to=type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/bom-bom:buildcache,mode=max \
+            -t ${{ secrets.DOCKERHUB_USERNAME }}/bom-bom:${VERSION_TAG} \
             -t ${{ secrets.DOCKERHUB_USERNAME }}/bom-bom:prod \
             --push .
+          
+          echo "이미지 푸시 완료: ${VERSION_TAG}, prod"
 
   deploy:
     name: Production Server 배포
     needs: build
-    runs-on: [ self-hosted, prod ]  # ✅ main → prod (runner에 따라 조정)
+    runs-on: [ self-hosted, prod ]
     defaults:
       run:
         working-directory: ./backend/bom-bom-server
+    # 배포 타임아웃 설정
+    timeout-minutes: 10
 
     environment:
       name: production
-      url: https://api.bombom.news # ✅ 실제 운영 서비스 URL
+      url: https://api.bombom.news
 
     steps:
       - name: 코드 체크아웃
         uses: actions/checkout@v4
+        with:
+          # 배포용으로는 최소한의 코드만
+          fetch-depth: 1
 
       - name: DockerHub 로그인
         uses: docker/login-action@v3
@@ -89,16 +154,39 @@ jobs:
           DATABASE=${{ secrets.PROD_DATABASE }}
           MYSQL_USER=${{ secrets.PROD_MYSQL_USER }}
           MYSQL_PASSWORD=${{ secrets.PROD_MYSQL_PASSWORD }}
+          DOCKER_IMAGE=${{ secrets.DOCKERHUB_USERNAME }}/bom-bom:${{ needs.build.outputs.version_tag }}
           EOF
+          echo "배포할 이미지: ${{ secrets.DOCKERHUB_USERNAME }}/bom-bom:${{ needs.build.outputs.version_tag }}"
 
-      - name: 컨테이너 재실행
+      - name: 컨테이너 재실행 (CPU 최적화)
         run: |
+          # 기존 컨테이너 정리
+          sudo docker compose -f docker-compose-prod.yml down --remove-orphans --timeout 30
+          
+          # 새 컨테이너 시작 (CPU 제한 없이)
           sudo docker compose \
             -f docker-compose-prod.yml \
             --env-file .env \
             up -d --remove-orphans --pull=always
+          echo "배포 완료!"
 
-      - name: Docker 리소스 정리
+      - name: 헬스체크
         run: |
-          sudo docker container prune -f --filter "until=24h"
-          sudo docker image prune     -f --filter "until=24h"
+          echo "서비스 헬스체크 시작..."
+          sleep 10
+          for i in {1..5}; do
+            if curl -f -s http://localhost/actuator/health > /dev/null; then
+              echo "✅ 서비스 정상 동작"
+              break
+            else
+              echo "⏳ 헬스체크 대기 중... ($i/5)"
+              sleep 10
+            fi
+          done
+
+      - name: Docker 리소스 정리 (CPU 절약)
+        run: |
+          # 오래된 리소스만 정리 (CPU 집약적 작업 최소화)
+          sudo docker container prune -f --filter "until=48h"
+          sudo docker image prune -f --filter "until=48h"
+          sudo docker system prune -f --filter "until=24h"

--- a/backend/bom-bom-server/docker-compose-prod.yml
+++ b/backend/bom-bom-server/docker-compose-prod.yml
@@ -1,7 +1,7 @@
 version: "3.8"
 services:
-  bombom-server-dev:
-    image: bombomnewsletter/bom-bom:prod
+  bombom-server-prod:
+    image: ${DOCKER_IMAGE}
     container_name: bombom-server-prod
     ports:
       - 80:8080


### PR DESCRIPTION
⚠️ `server` 브랜치로 직속 merge 되는 PR입니다!

## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
운영 서버에 Semantic Versioning을 도입합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
서비스 버전 관리 및 간편한 롤백 시스템 구축을 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- Semantic Versioning을 도입합니다. (`vX.Y.Z` 형태)
- 우리 repository는 프론트와 함께 관리되므로, `server-`라는 prefix를 붙이도록 구성했습니다.
- 도커 이미지에서 기존에는 `:prod` 태그가 붙었지만, 이제는 `:server-v1.0.1` 형식으로 태그가 생성됩니다.
- 자세한 브랜치 전략 및 버저닝 방식은 [롤백 시스템 구축하기](https://meadow-technician-018.notion.site/254b4854680e80fa8cecfd12571712df)에서 읽어주시면 감사하겠습니다!

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 역시나 이렇게 하는게 맞는지 모르겠습니다.. 많은 피드백 환영입니다!
- 현재는 server 브랜치에 push 되는 것이 deploy 트리거인데, 이렇게 수동으로 버저닝을 관리하게 되면 push 트리거를 제거해야하지 않을까 싶습니다.
  -  지금 `prod-deploy.yml` 파일에서 `버전 태그 결정` job에 자동 버전 설정 로직이 있긴 한데, 이는 `PATCH`에 대한 증가만 가능해서 명확한 버저닝 의미를 담기는 한계가 있을 것 같아보입니다..!
  - 수동 관리를 위해 push 트리거를 제거하고 자동 버전 지정을 제거할까요? 어떻게 생각하시는지 의견이 궁금합니다!
