### PR TITLE
[FE][BOM-364] 로그인 요청 카드의 반응형 디자인 추가 

### DIFF
--- a/frontend/src/components/PageLayout/PageLayout.tsx
+++ b/frontend/src/components/PageLayout/PageLayout.tsx
@@ -39,8 +39,7 @@ const PageLayout = ({ children }: PropsWithChildren) => {
 export default PageLayout;
 
 const Container = styled.div<{ isMobile: boolean }>`
-  width: 100%;
-  min-height: 100vh;
+  min-height: 100dvh;
   padding: ${({ isMobile, theme }) => {
     const sidePadding = isMobile ? '12px' : '24px';
     const headerHeight = isMobile
@@ -60,4 +59,6 @@ const Container = styled.div<{ isMobile: boolean }>`
   align-items: center;
 
   background-color: ${({ theme }) => theme.colors.white};
+
+  scrollbar-gutter: stable;
 `;

--- a/frontend/src/components/RequireLoginCard/RequireLoginCard.tsx
+++ b/frontend/src/components/RequireLoginCard/RequireLoginCard.tsx
@@ -89,5 +89,7 @@ const Support = styled.p<{ isMobile: boolean }>`
 
 const GoToLoginButton = styled(Button)`
   width: 100%;
+  max-width: 380px;
+
   font: ${({ theme }) => theme.fonts.heading5};
 `;

--- a/frontend/src/components/RequireLoginCard/RequireLoginCard.tsx
+++ b/frontend/src/components/RequireLoginCard/RequireLoginCard.tsx
@@ -1,18 +1,25 @@
 import styled from '@emotion/styled';
 import { useNavigate } from '@tanstack/react-router';
 import Button from '../Button/Button';
+import { useDeviceType } from '@/hooks/useDeviceType';
 import LockIcon from '#/assets/lock.svg';
 
 const RequireLoginCard = () => {
   const navigate = useNavigate();
+  const deviceType = useDeviceType();
+  const isMobile = deviceType === 'mobile';
 
   return (
-    <Container>
+    <Container isMobile={isMobile}>
       <StyledLockIcon />
       <Title>로그인이 필요해요</Title>
       <DescriptionWrapper>
-        <Lead>현재 페이지를 이용하시려면 먼저 로그인해 주세요</Lead>
-        <Support>봄봄에서 더 많은 특별한 기능들을 만나보실 수 있어요!</Support>
+        <Lead isMobile={isMobile}>
+          현재 페이지를 이용하시려면 먼저 로그인해 주세요
+        </Lead>
+        <Support isMobile={isMobile}>
+          봄봄에서 더 많은 특별한 기능들을 만나보실 수 있어요!
+        </Support>
       </DescriptionWrapper>
       <GoToLoginButton
         text="봄봄 시작하기"
@@ -26,13 +33,11 @@ const RequireLoginCard = () => {
 
 export default RequireLoginCard;
 
-const Container = styled.section`
-  width: 380px;
+const Container = styled.section<{ isMobile: boolean }>`
+  width: ${({ isMobile }) => (isMobile ? '100%' : '380px')};
   height: 500px;
   margin: auto 0;
-  padding: 28px;
-  border-radius: 20px;
-  box-shadow: 0 25px 50px -12px rgb(0 0 0 / 25%);
+  padding: ${({ isMobile }) => (isMobile ? '16px' : '28px')};
 
   display: flex;
   gap: 24px;
@@ -41,6 +46,14 @@ const Container = styled.section`
   justify-content: center;
 
   background-color: ${({ theme }) => theme.colors.white};
+
+  ${({ isMobile }) =>
+    !isMobile &&
+    `
+    border-radius: 20px;
+    box-shadow: 0 25px 50px -12px rgb(0 0 0 / 25%);
+  
+  `}
 `;
 
 const StyledLockIcon = styled(LockIcon)`
@@ -60,15 +73,17 @@ const DescriptionWrapper = styled.div`
   flex-direction: column;
 `;
 
-const Lead = styled.p`
+const Lead = styled.p<{ isMobile: boolean }>`
   color: ${({ theme }) => theme.colors.textSecondary};
-  font: ${({ theme }) => theme.fonts.body1};
+  font: ${({ isMobile, theme }) =>
+    isMobile ? theme.fonts.body2 : theme.fonts.body1};
   text-align: center;
 `;
 
-const Support = styled.p`
+const Support = styled.p<{ isMobile: boolean }>`
   color: ${({ theme }) => theme.colors.textTertiary};
-  font: ${({ theme }) => theme.fonts.body2};
+  font: ${({ isMobile, theme }) =>
+    isMobile ? theme.fonts.body3 : theme.fonts.body2};
   text-align: center;
 `;
 


### PR DESCRIPTION
## 📌 What
- 로그인 요청 카드의 반응형 디자인 추가
- PageLayout의 Container에 100dvh 추가 → 모바일 환경에서 기기 UI의 동적인 변화에 상관없이 레이아웃을 유지할 수 있도록 추가함
  - 100dvh, 100vh, 100% 차이점이 궁금하신 분은 제게 오시면 예시 화면 보여드릴게요

https://github.com/user-attachments/assets/da48bd59-4878-47f6-a5cd-956007a53ae7



## ❓ Why
- 로그인 요청 카드의 모바일 뷰 개선 목적

## 🔧 How
useDeviceType을 이용하여 환경 타입에 따라 조건부로 스타일링 수행

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
