### PR TITLE
[FE][BOM-366] 펫 카드 레이아웃 조정

### DIFF
--- a/frontend/src/components/PetCard/PetCard.tsx
+++ b/frontend/src/components/PetCard/PetCard.tsx
@@ -5,7 +5,6 @@ import { PET_LEVEL } from './PetCard.constants';
 import { heartAnimation, jumpAnimation } from './PetCard.keyframes';
 import Button from '../Button/Button';
 import ProgressBar from '../ProgressBar/ProgressBar';
-import Spacing from '../Spacing/Spacing';
 import { getPet, postPetAttendance } from '@/apis/pet';
 import { DeviceType, useDeviceType } from '@/hooks/useDeviceType';
 import { queryClient } from '@/main';
@@ -65,8 +64,6 @@ const PetCard = () => {
         </TitleWrapper>
       )}
 
-      <Spacing size={16} />
-
       <PetImageContainer>
         <PetImage
           src={petImages[pet?.level ?? 1]}
@@ -91,8 +88,9 @@ const PetCard = () => {
         레벨 {pet?.level} :{' '}
         {PET_LEVEL[(pet?.level ?? 1) as keyof typeof PET_LEVEL]}
       </Level>
-      <Spacing size={16} />
+
       <ProgressBar rate={levelPercentage} caption={`${levelPercentage}%`} />
+
       <AttendanceButton
         deviceType={deviceType}
         text={pet?.isAttended ? '출석 완료!' : '출석체크하기'}
@@ -110,6 +108,7 @@ const Container = styled.section<{ deviceType: DeviceType }>`
   border-radius: 20px;
 
   display: flex;
+  gap: 16px;
   flex-direction: column;
   flex-shrink: 0;
   align-items: center;


### PR DESCRIPTION
## 📌 What
- 펫 카드의 경험치 바와 출석체크 버튼 사이의 간격 조정

**[before - after]**
<img width="298" height="319" alt="image" src="https://github.com/user-attachments/assets/4941639e-0a52-410f-aa4e-03c00c2593cd" /><img width="327" height="370" alt="image" src="https://github.com/user-attachments/assets/d9b4671c-218d-4793-8b16-d7a354feae6c" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
