### PR TITLE
[FE][BOM-375] 카테고리 필터의 뉴스레터 이미지 크기 조정

### DIFF
--- a/frontend/src/pages/storage/components/NewsletterFilter/NewsletterFilter.tsx
+++ b/frontend/src/pages/storage/components/NewsletterFilter/NewsletterFilter.tsx
@@ -43,13 +43,7 @@ function NewsLetterFilter({
             }
             onTabSelect={onSelectNewsletter}
             StartComponent={
-              imageUrl ? (
-                <NewsLetterImage
-                  src={
-                    'https://the-edit.co.kr/wp-content/themes/theedit-data/resources/images/ccatalog_v3/01_title.png'
-                  }
-                />
-              ) : null
+              imageUrl ? <NewsLetterImage src={imageUrl} /> : null
             }
             EndComponent={<Badge text={String(articleCount)} />}
             textAlign={deviceType === 'pc' ? 'start' : 'center'}

--- a/frontend/src/pages/storage/components/NewsletterFilter/NewsletterFilter.tsx
+++ b/frontend/src/pages/storage/components/NewsletterFilter/NewsletterFilter.tsx
@@ -43,7 +43,13 @@ function NewsLetterFilter({
             }
             onTabSelect={onSelectNewsletter}
             StartComponent={
-              imageUrl ? <NewsLetterImage src={imageUrl} /> : null
+              imageUrl ? (
+                <NewsLetterImage
+                  src={
+                    'https://the-edit.co.kr/wp-content/themes/theedit-data/resources/images/ccatalog_v3/01_title.png'
+                  }
+                />
+              ) : null
             }
             EndComponent={<Badge text={String(articleCount)} />}
             textAlign={deviceType === 'pc' ? 'start' : 'center'}
@@ -94,6 +100,10 @@ const NewsLetterImage = styled.img`
   width: 24px;
   height: 24px;
   border-radius: 50%;
+
+  flex-shrink: 0;
+
+  object-fit: cover;
 `;
 
 const StyledTabs = styled(Tabs)`


### PR DESCRIPTION
## 📌 What
- 뉴스레터 필터에서 찌그러진 로고 이미지를 개선

<img width="611" height="605" alt="image" src="https://github.com/user-attachments/assets/8375dcf9-47d8-415b-8979-9f650af525e4" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
