### PR TITLE
[FE][BOM-333] 포커스 트랩 구현

### DIFF
--- a/frontend/src/components/Modal/useModal.ts
+++ b/frontend/src/components/Modal/useModal.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState, useEffect, useMemo } from 'react';
 import { useClickOutsideRef } from '@/hooks/useClickOutsideRef';
+import useFocusTrap from '@/hooks/useFocusTrap';
 import useKeydownEscape from '@/hooks/useKeydownEscape';
 
 const useModal = () => {
@@ -14,8 +15,18 @@ const useModal = () => {
     setIsOpen(false);
   }, []);
 
-  const modalRef = useClickOutsideRef<HTMLDivElement>(closeModal);
-  useKeydownEscape(closeModal);
+  const clickOutsideRef = useClickOutsideRef<HTMLDivElement>(closeModal);
+  const { containerRef: focusTrapRef } = useFocusTrap<HTMLDivElement>({
+    isActive: isOpen,
+  });
+
+  const modalRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      clickOutsideRef.current = node;
+      focusTrapRef.current = node;
+    },
+    [clickOutsideRef, focusTrapRef],
+  );
 
   const toggleScrollLock = useCallback(() => {
     if (isOpen) {
@@ -28,6 +39,8 @@ const useModal = () => {
   useEffect(() => {
     toggleScrollLock();
   }, [isOpen, toggleScrollLock]);
+
+  useKeydownEscape(isOpen ? closeModal : null);
 
   return {
     modalRef,

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -81,30 +81,20 @@ const useFocusTrap = <T extends HTMLElement>({
 
   const keydownTab = useCallback(
     (event: KeyboardEvent) => {
-      if (!isActive || !containerRef.current) return;
-
       if (event.key === 'Tab') {
         keydownShift(event);
       }
     },
-    [isActive, keydownShift],
+    [keydownShift],
   );
-
-  const restoreFocus = useCallback(() => {
-    if (!isActive || !containerRef.current) return;
-
-    if (previousFocusing.current) {
-      previousFocusing.current.focus();
-    }
-  }, [isActive]);
 
   const trackFocus = useCallback(() => {
     const focusableElements = getFocusableElements();
     const activeElement = document.activeElement as HTMLElement;
-    if (isActive && focusableElements.includes(activeElement)) {
+    if (focusableElements.includes(activeElement)) {
       previousFocusing.current = activeElement;
     }
-  }, [getFocusableElements, isActive]);
+  }, [getFocusableElements]);
 
   const focusFirstElement = useCallback(() => {
     const focusableElements = getFocusableElements();
@@ -125,7 +115,7 @@ const useFocusTrap = <T extends HTMLElement>({
       document.removeEventListener('keydown', keydownTab);
       document.removeEventListener('focusin', trackFocus);
     };
-  }, [isActive, focusFirstElement, keydownTab, trackFocus, restoreFocus]);
+  }, [isActive, focusFirstElement, keydownTab, trackFocus]);
 
   return {
     containerRef,

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -18,38 +18,38 @@ const FOCUSABLE_ELEMENTS = [
   'details[open] summary:not(:first-child)',
 ].join(',');
 
+const isElementVisible = (element: HTMLElement): boolean => {
+  const style = window.getComputedStyle(element);
+  return (
+    style.display !== 'none' &&
+    style.visibility !== 'hidden' &&
+    style.opacity !== '0' &&
+    element.offsetWidth > 0 &&
+    element.offsetHeight > 0
+  );
+};
+
+const isElementNotInert = (element: HTMLElement): boolean => {
+  return !element.closest('[inert]');
+};
+
+const isFocusable = (element: HTMLElement) => {
+  return isElementVisible(element) && isElementNotInert(element);
+};
+
 const useFocusTrap = <T extends HTMLElement>({
   isActive,
 }: UseFocusTrapParams) => {
   const containerRef = useRef<T>(null);
 
-  const isElementVisible = useCallback((element: HTMLElement): boolean => {
-    const style = window.getComputedStyle(element);
-    return (
-      style.display !== 'none' &&
-      style.visibility !== 'hidden' &&
-      style.opacity !== '0' &&
-      element.offsetWidth > 0 &&
-      element.offsetHeight > 0
-    );
-  }, []);
-
-  const isElementNotInert = useCallback((element: HTMLElement): boolean => {
-    return !element.closest('[inert]');
-  }, []);
-
   const getFocusableElements = useCallback((): HTMLElement[] => {
-    if (!containerRef.current) return [];
+    const container = containerRef.current;
+    if (!container) return [];
 
-    const elements = containerRef.current.querySelectorAll(FOCUSABLE_ELEMENTS);
-    return Array.from(elements).filter((element) => {
-      return (
-        element instanceof HTMLElement &&
-        isElementVisible(element) &&
-        isElementNotInert(element)
-      );
-    }) as HTMLElement[];
-  }, [isElementNotInert, isElementVisible]);
+    const elements =
+      container.querySelectorAll<HTMLElement>(FOCUSABLE_ELEMENTS);
+    return Array.from(elements).filter(isFocusable);
+  }, []);
 
   const focusFirstElement = useCallback(() => {
     const focusableElements = getFocusableElements();

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+interface UseFocusTrapParams {
+  isActive?: boolean;
+}
+
+const FOCUSABLE_ELEMENTS = [
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'a[href]',
+  'button:not([disabled])',
+  '[tabindex]:not([tabindex="-1"]):not(slot)',
+  'audio[controls]',
+  'video[controls]',
+  '[contenteditable]:not([contenteditable="false"])',
+  'details > summary:first-of-type',
+  'details[open] summary:not(:first-child)',
+].join(',');
+
+const useFocusTrap = <T extends HTMLElement>({
+  isActive,
+}: UseFocusTrapParams) => {
+  const containerRef = useRef<T>(null);
+
+  const isElementVisible = useCallback((element: HTMLElement): boolean => {
+    const style = window.getComputedStyle(element);
+    return (
+      style.display !== 'none' &&
+      style.visibility !== 'hidden' &&
+      style.opacity !== '0' &&
+      element.offsetWidth > 0 &&
+      element.offsetHeight > 0
+    );
+  }, []);
+
+  const isElementNotInert = useCallback((element: HTMLElement): boolean => {
+    return !element.closest('[inert]');
+  }, []);
+
+  const getFocusableElements = useCallback((): HTMLElement[] => {
+    if (!containerRef.current) return [];
+
+    const elements = containerRef.current.querySelectorAll(FOCUSABLE_ELEMENTS);
+    return Array.from(elements).filter((element) => {
+      return (
+        element instanceof HTMLElement &&
+        isElementVisible(element) &&
+        isElementNotInert(element)
+      );
+    }) as HTMLElement[];
+  }, [isElementNotInert, isElementVisible]);
+
+  const focusFirstElement = useCallback(() => {
+    const focusableElements = getFocusableElements();
+    if (focusableElements.length > 0) {
+      focusableElements[0]?.focus();
+    }
+  }, [getFocusableElements]);
+
+  const keydownShift = useCallback(
+    (event: KeyboardEvent) => {
+      const focusableElements = getFocusableElements();
+      if (focusableElements.length === 0) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (document.activeElement === lastElement && !event.shiftKey) {
+        event.preventDefault();
+        firstElement?.focus();
+      } else if (document.activeElement === firstElement && event.shiftKey) {
+        event.preventDefault();
+        lastElement?.focus();
+      }
+    },
+    [getFocusableElements],
+  );
+
+  const keydownTab = useCallback(
+    (event: KeyboardEvent) => {
+      if (!isActive || !containerRef.current) return;
+
+      if (event.key === 'Tab') {
+        keydownShift(event);
+      }
+    },
+    [isActive, keydownShift],
+  );
+
+  const handleClick = useCallback(
+    (event: Event) => {
+      if (!isActive || !containerRef.current) return;
+
+      if (!containerRef.current.contains(event.target as Node)) {
+        event.preventDefault();
+        focusFirstElement();
+      }
+    },
+    [isActive, focusFirstElement],
+  );
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    focusFirstElement();
+
+    document.addEventListener('keydown', keydownTab);
+    document.addEventListener('click', handleClick);
+
+    return () => {
+      document.removeEventListener('keydown', keydownTab);
+      document.removeEventListener('click', handleClick);
+    };
+  }, [isActive, focusFirstElement, keydownTab, handleClick]);
+
+  return {
+    containerRef,
+  };
+};
+
+export default useFocusTrap;

--- a/frontend/src/hooks/useFocusTrap.ts
+++ b/frontend/src/hooks/useFocusTrap.ts
@@ -38,7 +38,7 @@ const isFocusable = (element: HTMLElement) => {
 };
 
 const useFocusTrap = <T extends HTMLElement>({
-  isActive,
+  isActive = true,
 }: UseFocusTrapParams) => {
   const containerRef = useRef<T>(null);
   const previousFocusing = useRef<HTMLElement>(null);

--- a/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
+++ b/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
@@ -257,7 +257,7 @@ const Description = styled.p<{ isMobile: boolean }>`
     isMobile ? theme.fonts.body2 : theme.fonts.body1};
 `;
 
-const DetailLink = styled.a<{ isMobile: boolean }>`
+const DetailLink = styled.button<{ isMobile: boolean }>`
   display: flex;
   gap: 4px;
   align-items: center;


### PR DESCRIPTION
## 📌 What
- 포커스 트랩 커스텀 훅 구현

[참고 자료]
https://github.com/user-attachments/assets/959875fb-8f3c-4f33-9534-70f2ec2e6647 (focusable 태그 참고)
https://tarot-story.tistory.com/23 (내부 로직 참고)
https://ianlog.me/blog/modal-atoz/alert-dialog-focus-trap (ref 합성 방식 참고)


## ❓ Why
- 키보드로 서비스를 이용하는 사용자를 고려한, 접근성 향상

## 🔧 How
- ref 객체를 제공하여 특정 엘리먼트 내부에서 포커스가 순환할 수 있도록 함
- 포커싱 가능한 하위 엘리먼트 중 마지막 순서의 엘리먼트에 도달했을 때, Tab을 누르면 첫 번째 엘리먼트로 돌아옴
- 포커싱 가능한 하위 엘리먼트 중 첫 번째 순서의 엘리먼트에 도달했을 때, Tab + Shift를 누르면 마지막 엘리먼트로 돌아옴
- 포커싱 대상이 아닌 엘리먼트와 인터랙션 후, Tab 또는 Tab + Shift를 누르면 가장 마지막에 포커싱되었던 엘리먼트 부터 포커싱을 시작함

## 👀 Review Point (Optional)