### PR TITLE
[FE][BOM-379] 최대 레벨 펫의 경험치 UI 수정

### DIFF
--- a/frontend/src/components/PetCard/PetCard.constants.ts
+++ b/frontend/src/components/PetCard/PetCard.constants.ts
@@ -4,7 +4,7 @@ export const PET_LABEL: Record<number, string> = {
   3: '활발한 봄이',
   4: '든든한 봄이',
   5: '성숙한 봄이',
-};
+} as const;
 
 export const PET_WIDTH: Record<number, number> = {
   1: 80,
@@ -12,9 +12,9 @@ export const PET_WIDTH: Record<number, number> = {
   3: 90,
   4: 120,
   5: 136,
-};
+} as const;
 
 export const LEVEL = {
   min: 1,
   max: 5,
-};
+} as const;

--- a/frontend/src/components/PetCard/PetCard.constants.ts
+++ b/frontend/src/components/PetCard/PetCard.constants.ts
@@ -1,7 +1,15 @@
-export const PET_LEVEL = {
+export const PET_LEVEL: Record<number, string> = {
   1: '아기 봄이',
   2: '호기심 많은 봄이',
   3: '활발한 봄이',
   4: '든든한 봄이',
   5: '성숙한 봄이',
+};
+
+export const PET_WIDTH: Record<number, number> = {
+  1: 80,
+  2: 100,
+  3: 90,
+  4: 120,
+  5: 136,
 };

--- a/frontend/src/components/PetCard/PetCard.constants.ts
+++ b/frontend/src/components/PetCard/PetCard.constants.ts
@@ -1,4 +1,4 @@
-export const PET_LEVEL: Record<number, string> = {
+export const PET_LABEL: Record<number, string> = {
   1: '아기 봄이',
   2: '호기심 많은 봄이',
   3: '활발한 봄이',
@@ -12,4 +12,9 @@ export const PET_WIDTH: Record<number, number> = {
   3: 90,
   4: 120,
   5: 136,
+};
+
+export const LEVEL = {
+  min: 1,
+  max: 5,
 };

--- a/frontend/src/components/PetCard/PetCard.tsx
+++ b/frontend/src/components/PetCard/PetCard.tsx
@@ -44,17 +44,19 @@ const PetCard = () => {
     },
   });
 
+  if (!pet) return null;
+
   const levelPercentage = calculateRate(
-    pet?.currentStageScore ?? 0,
-    pet?.requiredStageScore ?? 1,
+    pet.currentStageScore,
+    pet.requiredStageScore,
   );
 
   const handleAttendanceClick = () => {
     mutatePetAttendance();
   };
 
-  const currentLevel = pet?.level ?? LEVEL.min;
-  const width = PET_WIDTH[currentLevel] ?? PET_WIDTH[LEVEL.min];
+  const currentLevel = pet.level;
+  const width = PET_WIDTH[currentLevel];
 
   return (
     <Container deviceType={deviceType}>
@@ -95,16 +97,16 @@ const PetCard = () => {
         rate={currentLevel === LEVEL.max ? 100 : levelPercentage}
         caption={
           currentLevel === LEVEL.max
-            ? `${pet?.currentStageScore}점`
+            ? `${pet.currentStageScore}점`
             : `${levelPercentage}%`
         }
       />
 
       <AttendanceButton
         deviceType={deviceType}
-        text={pet?.isAttended ? '출석 완료!' : '출석체크하기'}
+        text={pet.isAttended ? '출석 완료!' : '출석체크하기'}
         onClick={handleAttendanceClick}
-        disabled={pet?.isAttended}
+        disabled={pet.isAttended}
       />
     </Container>
   );

--- a/frontend/src/components/PetCard/PetCard.tsx
+++ b/frontend/src/components/PetCard/PetCard.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { PET_LEVEL, PET_WIDTH } from './PetCard.constants';
+import { PET_LABEL, PET_WIDTH, LEVEL } from './PetCard.constants';
 import { heartAnimation, jumpAnimation } from './PetCard.keyframes';
 import Button from '../Button/Button';
 import ProgressBar from '../ProgressBar/ProgressBar';
@@ -53,8 +53,8 @@ const PetCard = () => {
     mutatePetAttendance();
   };
 
-  const currentLevel = pet?.level ?? 1;
-  const width = PET_WIDTH[currentLevel] ?? 80;
+  const currentLevel = pet?.level ?? LEVEL.min;
+  const width = PET_WIDTH[currentLevel] ?? PET_WIDTH[LEVEL.min];
 
   return (
     <Container deviceType={deviceType}>
@@ -88,11 +88,17 @@ const PetCard = () => {
       </PetImageContainer>
 
       <Level>
-        레벨 {currentLevel} :{' '}
-        {PET_LEVEL[(currentLevel ?? 1) as keyof typeof PET_LEVEL]}
+        레벨 {currentLevel} : {PET_LABEL[currentLevel ?? LEVEL.min]}
       </Level>
 
-      <ProgressBar rate={levelPercentage} caption={`${levelPercentage}%`} />
+      <ProgressBar
+        rate={currentLevel === LEVEL.max ? 100 : levelPercentage}
+        caption={
+          currentLevel === LEVEL.max
+            ? `${pet?.currentStageScore}점`
+            : `${levelPercentage}%`
+        }
+      />
 
       <AttendanceButton
         deviceType={deviceType}

--- a/frontend/src/components/PetCard/PetCard.tsx
+++ b/frontend/src/components/PetCard/PetCard.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
-import { PET_LEVEL } from './PetCard.constants';
+import { PET_LEVEL, PET_WIDTH } from './PetCard.constants';
 import { heartAnimation, jumpAnimation } from './PetCard.keyframes';
 import Button from '../Button/Button';
 import ProgressBar from '../ProgressBar/ProgressBar';
@@ -25,14 +25,6 @@ const petImages: Record<number, string> = {
   4: petLv4,
   5: petLv5,
 };
-
-const petWidth = {
-  1: 80,
-  2: 100,
-  3: 90,
-  4: 120,
-  5: 136,
-} as const;
 
 const PetCard = () => {
   const deviceType = useDeviceType();
@@ -62,7 +54,7 @@ const PetCard = () => {
   };
 
   const currentLevel = pet?.level ?? 1;
-  const width = petWidth[currentLevel as keyof typeof petWidth] ?? 80;
+  const width = PET_WIDTH[currentLevel] ?? 80;
 
   return (
     <Container deviceType={deviceType}>

--- a/frontend/src/components/PetCard/PetCard.tsx
+++ b/frontend/src/components/PetCard/PetCard.tsx
@@ -46,17 +46,12 @@ const PetCard = () => {
 
   if (!pet) return null;
 
-  const levelPercentage = calculateRate(
-    pet.currentStageScore,
-    pet.requiredStageScore,
-  );
+  const { level, isAttended, currentStageScore, requiredStageScore } = pet;
+  const levelPercentage = calculateRate(currentStageScore, requiredStageScore);
 
   const handleAttendanceClick = () => {
     mutatePetAttendance();
   };
-
-  const currentLevel = pet.level;
-  const width = PET_WIDTH[currentLevel];
 
   return (
     <Container deviceType={deviceType}>
@@ -71,9 +66,9 @@ const PetCard = () => {
 
       <PetImageContainer>
         <PetImage
-          src={petImages[currentLevel ?? 1]}
+          src={petImages[level ?? 1]}
           alt="pet"
-          width={width}
+          width={PET_WIDTH[level]}
           height={120}
           isAnimating={isAnimating}
           onAnimationEnd={() => setIsAnimating(false)}
@@ -90,23 +85,21 @@ const PetCard = () => {
       </PetImageContainer>
 
       <Level>
-        레벨 {currentLevel} : {PET_LABEL[currentLevel ?? LEVEL.min]}
+        레벨 {level} : {PET_LABEL[level ?? LEVEL.min]}
       </Level>
 
       <ProgressBar
-        rate={currentLevel === LEVEL.max ? 100 : levelPercentage}
+        rate={level === LEVEL.max ? 100 : levelPercentage}
         caption={
-          currentLevel === LEVEL.max
-            ? `${pet.currentStageScore}점`
-            : `${levelPercentage}%`
+          level === LEVEL.max ? `${currentStageScore}점` : `${levelPercentage}%`
         }
       />
 
       <AttendanceButton
         deviceType={deviceType}
-        text={pet.isAttended ? '출석 완료!' : '출석체크하기'}
+        text={isAttended ? '출석 완료!' : '출석체크하기'}
         onClick={handleAttendanceClick}
-        disabled={pet.isAttended}
+        disabled={isAttended}
       />
     </Container>
   );

--- a/frontend/src/components/PetCard/PetCard.tsx
+++ b/frontend/src/components/PetCard/PetCard.tsx
@@ -66,7 +66,7 @@ const PetCard = () => {
 
       <PetImageContainer>
         <PetImage
-          src={petImages[level ?? 1]}
+          src={petImages[level]}
           alt="pet"
           width={PET_WIDTH[level]}
           height={120}
@@ -85,7 +85,7 @@ const PetCard = () => {
       </PetImageContainer>
 
       <Level>
-        레벨 {level} : {PET_LABEL[level ?? LEVEL.min]}
+        레벨 {level} : {PET_LABEL[level]}
       </Level>
 
       <ProgressBar


### PR DESCRIPTION
## 📌 What
- 최대 레벨인 펫의 경험치 UI 변경
  - 경험치 바(progress bar)는 100%로 채워짐
  - 경험치 비율(%) 대신, 점수(점)를 표시
 
<img width="325" height="347" alt="image" src="https://github.com/user-attachments/assets/a2c7d743-6f7b-42db-8268-95a62f39e433" />


## ❓ Why
- 기존에는 펫이 최대 레벨일 때 경험치 UI에 변화가 없었음
  - 출석체크를 하거나 아티클을 읽어도 경험치에 변화가 없어, 혼란 초래
  - 사용자의 동기부여를 유지할 수 있는 요소가 없음

## 🔧 How
최대 레벨 펫의 경험치 UI를 개선

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
