### PR TITLE
[BE][BOM-389] fix: MonthlyReading의 rank 컬럼명 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/MonthlyReading.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/MonthlyReading.java
@@ -31,7 +31,7 @@ public class MonthlyReading {
     private int currentCount;
 
     @Column(nullable = false)
-    private long rank;
+    private long rankOrder;
 
     @Column(nullable = false, columnDefinition = "SMALLINT")
     private long nextRankDifference;
@@ -41,13 +41,13 @@ public class MonthlyReading {
             Long id,
             @NonNull Long memberId,
             int currentCount,
-            long rank,
+            long rankOrder,
             long nextRankDifference
     ) {
         this.id = id;
         this.memberId = memberId;
         this.currentCount = currentCount;
-        this.rank = rank;
+        this.rankOrder = rankOrder;
         this.nextRankDifference = nextRankDifference;
     }
 
@@ -55,7 +55,7 @@ public class MonthlyReading {
         return MonthlyReading.builder()
                 .memberId(memberId)
                 .currentCount(INITIAL_CURRENT_COUNT)
-                .rank(lowestRank)
+                .rankOrder(lowestRank)
                 .nextRankDifference(lowestDifference)
                 .build();
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingRepository.java
@@ -17,12 +17,12 @@ public interface MonthlyReadingRepository extends JpaRepository<MonthlyReading, 
 	@Query(value = """
 		SELECT
 			m.nickname AS nickname,
-			mr.`rank` AS `rank`,
+			mr.rank_order AS `rank`,
 			mr.current_count AS monthlyReadCount
 		FROM monthly_reading mr
 		JOIN member m ON mr.member_id = m.id
-		WHERE mr.`rank` IS NOT NULL
-		ORDER BY mr.`rank` ASC, m.nickname ASC
+		WHERE mr.rank_order IS NOT NULL
+		ORDER BY mr.rank_order ASC, m.nickname ASC
 		LIMIT :limit
 	""", nativeQuery = true)
 	List<MonthlyReadingRankResponse> findMonthlyRanking(@Param("limit") int limit);
@@ -30,7 +30,7 @@ public interface MonthlyReadingRepository extends JpaRepository<MonthlyReading, 
 	@Modifying(clearAutomatically = true, flushAutomatically = true)
 	@Query(value = """
 		UPDATE monthly_reading mr
-		SET mr.`rank` = 
+		SET mr.rank_order = 
 			    (SELECT r.rnk
 				 FROM (SELECT m.member_id, RANK() OVER (ORDER BY m.current_count DESC) AS rnk
 				 FROM monthly_reading m) r
@@ -44,7 +44,7 @@ public interface MonthlyReadingRepository extends JpaRepository<MonthlyReading, 
 
 	@Query("""
 		SELECT new me.bombom.api.v1.reading.dto.response.MemberMonthlyReadingRankResponse(
-		  mr.rank AS rank,
+		  mr.rankOrder AS rank,
 		  mr.currentCount AS readCount,
 		  mr.nextRankDifference AS nextRankDifference
 		)
@@ -53,5 +53,5 @@ public interface MonthlyReadingRepository extends JpaRepository<MonthlyReading, 
 	""")
 	MemberMonthlyReadingRankResponse findMemberRankAndGap(@Param("memberId") Long memberId);
 
-	MonthlyReading findTopByOrderByRankDesc();
+	MonthlyReading findTopByOrderByRankOrderDesc();
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -176,15 +176,15 @@ public class ReadingService {
     }
 
     private LowestRankWithDifference computeLowestRankWithDifference() {
-        MonthlyReading lowestRankMonthlyReading = monthlyReadingRepository.findTopByOrderByRankDesc();
+        MonthlyReading lowestRankMonthlyReading = monthlyReadingRepository.findTopByOrderByRankOrderDesc();
         if (lowestRankMonthlyReading.getCurrentCount() == 0) {
             return LowestRankWithDifference.of(
-                    lowestRankMonthlyReading.getRank(),
+                    lowestRankMonthlyReading.getRankOrder(),
                     lowestRankMonthlyReading.getNextRankDifference()
             );
         }
         return LowestRankWithDifference.of(
-                lowestRankMonthlyReading.getRank() + 1,
+                lowestRankMonthlyReading.getRankOrder() + 1,
                 lowestRankMonthlyReading.getCurrentCount()
         );
     }

--- a/backend/bom-bom-server/src/main/resources/db/migration/V1.21__monthly_reading_change_column_name.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V1.21__monthly_reading_change_column_name.sql
@@ -1,0 +1,3 @@
+-- monthly_reading 테이블의 rank 컬럼을 rankOrder로 수정
+ALTER TABLE monthly_reading
+  CHANGE COLUMN `rank` rank_order INT NOT NULL;


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
MonthlyReading의 rank 컬럼명을 rankOrder로 수정했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
rank가 예약어인데도 불구하고 백틱으로 회피해서 쓰고 있었는데, 문제가 계속 생겼습니다.
그래서 아예 rankOrder로 수정했습니다.
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
테이블의 컬럼명만 변경하고, 프론트에게 주는 컬럼명은 그대로 rank입니다.
## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

<img width="1512" height="93" alt="image" src="https://github.com/user-attachments/assets/cabf0615-c457-40a4-b9d6-c424b7e999a0" />

<img width="992" height="239" alt="image" src="https://github.com/user-attachments/assets/fca3fd3c-ffa4-44d6-99cb-dead2157bab3" />
