### PR TITLE
[BE][BOM-423] feat: 모바일 앱에서 애플 원탭 로그인 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/controller/AuthControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/controller/AuthControllerApi.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import me.bombom.api.v1.auth.dto.request.DuplicateCheckRequest;
+import me.bombom.api.v1.auth.dto.request.NativeLoginRequest;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.dto.request.MemberSignupRequest;
@@ -60,6 +61,21 @@ public interface AuthControllerApi {
         @RequestParam(defaultValue = "deploy") String env,
         HttpServletResponse response,
         HttpSession httpSession
+    ) throws IOException;
+
+    @Operation(
+        summary = "네이티브 OAuth2 로그인",
+        description = "모바일 앱에서 받은 id_token과 authorization_code로 서버에서 토큰 교환 및 로그인 분기를 수행합니다. 기존 회원이면 '/'로, 신규면 '/signup'으로 리다이렉트합니다."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "302", description = "리다이렉트 수행 (기존: '/', 신규: '/signup')"),
+        @ApiResponse(responseCode = "400", description = "지원하지 않는 제공자"),
+        @ApiResponse(responseCode = "401", description = "토큰 검증 실패 또는 교환 실패")
+    })
+    void nativeLogin(
+        @PathVariable("provider") String provider,
+        @RequestBody NativeLoginRequest request,
+        HttpServletResponse response
     ) throws IOException;
 
     @Operation(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/dto/request/NativeLoginRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/dto/request/NativeLoginRequest.java
@@ -1,0 +1,8 @@
+package me.bombom.api.v1.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record NativeLoginRequest(
+        @NotBlank String identityToken,
+        @NotBlank String authorizationCode
+) {}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/AppleOAuth2Service.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/AppleOAuth2Service.java
@@ -1,20 +1,22 @@
 package me.bombom.api.v1.auth.service;
 
 import jakarta.servlet.http.HttpSession;
+import java.util.Map;
 import java.util.Optional;
-import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.auth.AppleClientSecretSupplier;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.auth.dto.PendingOAuth2Member;
+import me.bombom.api.v1.auth.dto.request.NativeLoginRequest;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
-import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.stereotype.Service;
@@ -38,10 +40,16 @@ public class AppleOAuth2Service extends OidcUserService {
     private final MemberRepository memberRepository;
     private final HttpSession session;
     private final RestClient.Builder restClientBuilder;
-    private final Supplier<String> appleClientSecretSupplier;
-    
+    private final AppleClientSecretSupplier appleClientSecretSupplier;
+    private final IdTokenValidator idTokenValidator;
+
+    //웹 로그인에서 사용
     @Value("${oauth2.apple.client-id}")
     private String clientId;
+
+    //앱 로그인에서 사용
+    @Value("${oauth2.apple.bundle-id:}")
+    private String bundleId;
 
     @Override
     public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
@@ -58,28 +66,15 @@ public class AppleOAuth2Service extends OidcUserService {
             String accessToken = extractAccessTokenFromOidcRequest(userRequest);
             if (accessToken != null) {
                 session.setAttribute("appleAccessToken", accessToken);
+                session.setAttribute("appleClientId", clientId);
                 log.info("Apple Access Token 세션에 저장 완료");
             } else {
                 log.warn("Apple Access Token 추출 실패");
             }
             
             // 기존 회원 확인
-            Optional<Member> member = memberRepository.findByProviderAndProviderId("apple", providerId);
-            if (member.isEmpty()) {
-                // Apple OIDC 신규 사용자 - PendingOAuth2Member를 세션에 저장
-                PendingOAuth2Member pendingMember = PendingOAuth2Member.builder()
-                        .provider("apple")
-                        .providerId(providerId)
-                        .profileUrl(null) // Apple은 profileUrl이 없음
-                        .build();
-                session.setAttribute("pendingMember", pendingMember);
-                log.info("Apple OIDC 신규 사용자 - 회원가입 대기 상태로 설정, providerId: {}", providerId);
-                log.info("세션에 pendingMember 저장 완료 - sessionId: {}, pendingMember: {}", session.getId(), pendingMember);
-                return new CustomOAuth2User(oidcUser.getAttributes(), null, oidcUser.getIdToken(), oidcUser.getUserInfo());
-            }
-            
-            log.info("Apple OIDC 기존 사용자 - memberId: {}", member.get().getId());
-            return new CustomOAuth2User(oidcUser.getAttributes(), member.get(), oidcUser.getIdToken(), oidcUser.getUserInfo());
+            Optional<Member> member = findMemberAndSetPendingIfNew(providerId);
+            return new CustomOAuth2User(oidcUser.getAttributes(), member.orElse(null), oidcUser.getIdToken(), oidcUser.getUserInfo());
         } catch (Exception e) {
             log.error("Apple OIDC 로그인 처리 실패 - error: {}", e.getMessage(), e);
             throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
@@ -99,16 +94,22 @@ public class AppleOAuth2Service extends OidcUserService {
             return false;
         }
         try {
-            log.info("Apple Token Revoke 시작 - clientId: {}", clientId);
+            String revokeClientId = (String) session.getAttribute("appleClientId");
+            if (revokeClientId == null || revokeClientId.isBlank()) {
+                revokeClientId = clientId;
+            }
+            log.info("Apple Token Revoke 시작 - clientId: {}", revokeClientId);
 
             MultiValueMap<String, String> requestBody = new LinkedMultiValueMap<>();
             requestBody.add("token", accessToken);
-            requestBody.add("client_id", clientId);
-            requestBody.add("client_secret", appleClientSecretSupplier.get());
+            requestBody.add("client_id", revokeClientId);
+            String revokeClientSecret = revokeClientId.equals(this.clientId) ? appleClientSecretSupplier.get() : appleClientSecretSupplier.generateFor(revokeClientId);
+            requestBody.add("client_secret", revokeClientSecret);
             requestBody.add("token_type_hint", "access_token");
 
             restClientBuilder.build().post()
                 .uri(APPLE_REVOKE_URL)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .body(requestBody)
                 .retrieve()
                 .toBodilessEntity();
@@ -121,7 +122,28 @@ public class AppleOAuth2Service extends OidcUserService {
             return false;
         }
     }
-    
+
+    /**
+     *  iOS 네이티브 로그인 처리: 번들 ID로 client_secret 생성하여 코드 교환
+     */
+    public Optional<Member> loginWithNative(NativeLoginRequest request) {
+        try {
+            if (bundleId == null || bundleId.isBlank()) {
+                throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
+                        .addContext("reason", "bundleId_not_configured");
+            }
+            // id_token 서명/iss/aud 검증 후 sub 획득 (aud는 번들 ID)
+            String subject = idTokenValidator.validateAppleAndGetSubject(request.identityToken(), bundleId);
+            Map<String, Object> token = requestAppleToken(request.authorizationCode(), bundleId, null);
+            session.setAttribute("appleAccessToken", token != null ? token.get("access_token") : null);
+            session.setAttribute("appleClientId", bundleId);
+            return findMemberAndSetPendingIfNew(subject);
+        } catch (Exception e) {
+            throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
+                    .addContext("reason", "apple_native_exchange_failed");
+        }
+    }
+
     /**
      * Apple Access Token을 추출합니다 (OidcUserRequest용)
      * @param userRequest OIDC 사용자 요청
@@ -141,22 +163,40 @@ public class AppleOAuth2Service extends OidcUserService {
         }
     }
 
-    /**
-     * Apple Access Token을 추출합니다 (OAuth2UserRequest용)
-     * @param userRequest OAuth2 사용자 요청
-     * @return Access Token 또는 null
-     */
-    private String extractAccessToken(OAuth2UserRequest userRequest) {
-        try {
-            Object accessTokenObj = userRequest.getAdditionalParameters().get(ACCESS_TOKEN_KEY);
-            if (accessTokenObj != null) {
-                log.info("Apple Access Token 추출 성공");
-                return accessTokenObj.toString();
-            }
-            return null;
-        } catch (Exception e) {
-            log.warn("Apple Access Token 추출 실패 - error: {}", e.getMessage());
-            return null;
+    private Map<String, Object> requestAppleToken(String code, String clientIdForExchange, String redirectUri) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "authorization_code");
+        body.add("code", code);
+        body.add("client_id", clientIdForExchange);
+        String clientSecret = clientIdForExchange != null && !clientIdForExchange.equals(this.clientId)
+                ? appleClientSecretSupplier.generateFor(clientIdForExchange)
+                : appleClientSecretSupplier.get();
+        body.add("client_secret", clientSecret);
+        if (redirectUri != null) {
+            body.add("redirect_uri", redirectUri);
         }
+        return restClientBuilder.build().post()
+                .uri("https://appleid.apple.com/auth/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .body(Map.class);
+    }
+
+    // 공통: 기존 회원 조회 + 신규면 pendingMember 세션 저장
+    private Optional<Member> findMemberAndSetPendingIfNew(String providerId) {
+        Optional<Member> member = memberRepository.findByProviderAndProviderId("apple", providerId);
+        if (member.isEmpty()) {
+            PendingOAuth2Member pendingMember = PendingOAuth2Member.builder()
+                    .provider("apple")
+                    .providerId(providerId)
+                    .profileUrl(null)
+                    .build();
+            session.setAttribute("pendingMember", pendingMember);
+            log.info("Apple 신규 사용자 - 회원가입 대기 상태로 설정, providerId: {}", providerId);
+        } else {
+            log.info("Apple 기존 사용자 - memberId: {}", member.get().getId());
+        }
+        return member;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/CustomOAuth2UserService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/CustomOAuth2UserService.java
@@ -1,10 +1,13 @@
 package me.bombom.api.v1.auth.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.auth.dto.request.NativeLoginRequest;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
+import me.bombom.api.v1.member.domain.Member;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
@@ -38,5 +41,15 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 });
 
         return loginService.loadUser(userRequest);
+    }
+
+    @Transactional
+    public Optional<Member> loginWithNative(String provider, NativeLoginRequest request) {
+        OAuth2LoginService loginService = loginServices.stream()
+                .filter(service -> service.supports(provider))
+                .findFirst()
+                .orElseThrow(() -> new UnauthorizedException(ErrorDetail.UNSUPPORTED_OAUTH2_PROVIDER)
+                        .addContext("provider", provider));
+        return loginService.loginWithNative(request);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/GoogleOAuth2LoginService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/GoogleOAuth2LoginService.java
@@ -6,14 +6,20 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.auth.dto.PendingOAuth2Member;
+import me.bombom.api.v1.auth.dto.request.NativeLoginRequest;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.LinkedMultiValueMap;
 
 /**
  * Google OAuth2 로그인 서비스
@@ -28,6 +34,14 @@ public class GoogleOAuth2LoginService implements OAuth2LoginService {
     private final DefaultOAuth2UserService defaultOAuth2UserService = new DefaultOAuth2UserService();
     private final MemberRepository memberRepository;
     private final HttpSession session;
+    private final org.springframework.web.client.RestClient.Builder restClientBuilder;
+    private final IdTokenValidator idTokenValidator;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-id}")
+    private String googleClientId;
+
+    @Value("${spring.security.oauth2.client.registration.google.client-secret}")
+    private String googleClientSecret;
 
     @Override
     @Transactional
@@ -53,6 +67,51 @@ public class GoogleOAuth2LoginService implements OAuth2LoginService {
             log.info("Google 기존 회원 - 로그인 성공, memberId: {}", member.get().getId());
         }
         return new CustomOAuth2User(oAuth2User.getAttributes(), member.orElse(null), null, null);
+    }
+
+    // 네이티브: idToken + authorizationCode를 받아 서버에서 토큰 교환 후 기존/신규 분기
+    @Transactional
+    public Optional<Member> loginWithNative(NativeLoginRequest request) {
+        try {
+            // 코드 교환
+            var body = new LinkedMultiValueMap<String, String>();
+            body.add("grant_type", "authorization_code");
+            body.add("code", request.authorizationCode());
+            body.add("client_id", googleClientId);
+            body.add("client_secret", googleClientSecret);
+            body.add("redirect_uri", "postmessage");
+
+            java.util.Map<String, Object> token = restClientBuilder.build().post()
+                    .uri("https://oauth2.googleapis.com/token")
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(body)
+                    .retrieve()
+                    .body(java.util.Map.class);
+
+            session.setAttribute("googleAccessToken", token != null ? token.get("access_token") : null);
+
+            // id_token에서 sub 추출
+            String idToken = request.identityToken();
+            String sub = idTokenValidator.validateGoogleAndGetSubject(idToken, googleClientId);
+            return findMemberAndSetPendingIfNew(sub);
+        } catch (Exception e) {
+            throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
+                    .addContext("reason", "google_native_exchange_failed");
+        }
+    }
+
+    private Optional<Member> findMemberAndSetPendingIfNew(String sub) {
+        Optional<Member> member = memberRepository.findByProviderAndProviderId("google", sub);
+        if (member.isEmpty()) {
+            PendingOAuth2Member pending = PendingOAuth2Member.builder()
+                    .provider("google")
+                    .providerId(sub)
+                    .profileUrl(null)
+                    .build();
+            session.setAttribute("pendingMember", pending);
+            return Optional.empty();
+        }
+        return member;
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/GoogleOAuth2LoginService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/GoogleOAuth2LoginService.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.auth.service;
 
 import jakarta.servlet.http.HttpSession;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,6 +13,7 @@ import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -20,6 +22,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.RestClient;
 
 /**
  * Google OAuth2 로그인 서비스
@@ -34,7 +37,7 @@ public class GoogleOAuth2LoginService implements OAuth2LoginService {
     private final DefaultOAuth2UserService defaultOAuth2UserService = new DefaultOAuth2UserService();
     private final MemberRepository memberRepository;
     private final HttpSession session;
-    private final org.springframework.web.client.RestClient.Builder restClientBuilder;
+    private final RestClient.Builder restClientBuilder;
     private final IdTokenValidator idTokenValidator;
 
     @Value("${spring.security.oauth2.client.registration.google.client-id}")
@@ -69,35 +72,59 @@ public class GoogleOAuth2LoginService implements OAuth2LoginService {
         return new CustomOAuth2User(oAuth2User.getAttributes(), member.orElse(null), null, null);
     }
 
-    // 네이티브: idToken + authorizationCode를 받아 서버에서 토큰 교환 후 기존/신규 분기
     @Transactional
     public Optional<Member> loginWithNative(NativeLoginRequest request) {
         try {
-            // 코드 교환
-            var body = new LinkedMultiValueMap<String, String>();
-            body.add("grant_type", "authorization_code");
-            body.add("code", request.authorizationCode());
-            body.add("client_id", googleClientId);
-            body.add("client_secret", googleClientSecret);
-            body.add("redirect_uri", "postmessage");
+            Map<String, Object> tokenResponse = exchangeGoogleToken(request.authorizationCode());
+            saveGoogleAccessToken(tokenResponse);
 
-            java.util.Map<String, Object> token = restClientBuilder.build().post()
-                    .uri("https://oauth2.googleapis.com/token")
-                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                    .body(body)
-                    .retrieve()
-                    .body(java.util.Map.class);
-
-            session.setAttribute("googleAccessToken", token != null ? token.get("access_token") : null);
-
-            // id_token에서 sub 추출
-            String idToken = request.identityToken();
-            String sub = idTokenValidator.validateGoogleAndGetSubject(idToken, googleClientId);
+            String sub = validateAndExtractGoogleSubject(request.identityToken());
             return findMemberAndSetPendingIfNew(sub);
+        } catch (UnauthorizedException e) {
+            throw e;
         } catch (Exception e) {
             throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
                     .addContext("reason", "google_native_exchange_failed");
         }
+    }
+
+    private java.util.Map<String, Object> exchangeGoogleToken(String authorizationCode) {
+        var body = new LinkedMultiValueMap<String, String>();
+        body.add("grant_type", "authorization_code");
+        body.add("code", authorizationCode);
+        body.add("client_id", googleClientId);
+        body.add("client_secret", googleClientSecret);
+        body.add("redirect_uri", "postmessage");
+
+        java.util.Map<String, Object> tokenResponse = restClientBuilder.build().post()
+                .uri("https://oauth2.googleapis.com/token")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(body)
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {});
+
+        if (tokenResponse == null) {
+            throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
+                    .addContext("reason", "google_token_response_is_null");
+        }
+        if (tokenResponse.containsKey("error")) {
+            Object err = tokenResponse.get("error");
+            Object desc = tokenResponse.get("error_description");
+            log.error("Google 토큰 교환 실패 - error: {}, description: {}", err, desc);
+            throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
+                    .addContext("reason", String.valueOf(desc));
+        }
+        return tokenResponse;
+    }
+
+    private void saveGoogleAccessToken(java.util.Map<String, Object> tokenResponse) {
+        Object accessToken = tokenResponse.get("access_token");
+        session.setAttribute("googleAccessToken", accessToken);
+        log.info("Google 네이티브 Access Token 세션에 저장 완료");
+    }
+
+    private String validateAndExtractGoogleSubject(String idToken) {
+        return idTokenValidator.validateGoogleAndGetSubject(idToken, googleClientId);
     }
 
     private Optional<Member> findMemberAndSetPendingIfNew(String sub) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/IdTokenValidator.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/IdTokenValidator.java
@@ -1,0 +1,70 @@
+package me.bombom.api.v1.auth.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.common.exception.UnauthorizedException;
+import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtIssuerValidator;
+import org.springframework.security.oauth2.jwt.JwtTimestampValidator;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+/**
+ * 네이티브 로그인용 id_token 서명/iss/aud 검증기
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IdTokenValidator {
+
+    private static final String APPLE_JWKS = "https://appleid.apple.com/auth/keys";
+    private static final String APPLE_ISS = "https://appleid.apple.com";
+
+    private static final String GOOGLE_JWKS = "https://www.googleapis.com/oauth2/v3/certs";
+    private static final String GOOGLE_ISS = "https://accounts.google.com";
+
+    private final JwtDecoder appleDecoder = buildDecoder(APPLE_JWKS, APPLE_ISS);
+    private final JwtDecoder googleDecoder = buildDecoder(GOOGLE_JWKS, GOOGLE_ISS);
+
+    public String validateAppleAndGetSubject(String idToken, String expectedAudience) {
+        return validateAndGetSub(appleDecoder, APPLE_ISS, idToken, expectedAudience, "apple");
+    }
+
+    public String validateGoogleAndGetSubject(String idToken, String expectedAudience) {
+        return validateAndGetSub(googleDecoder, GOOGLE_ISS, idToken, expectedAudience, "google");
+    }
+
+    private static JwtDecoder buildDecoder(String jwks, String issuer) {
+        NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(jwks).build();
+        decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(
+                new JwtTimestampValidator(),
+                new JwtIssuerValidator(issuer)
+        ));
+        return decoder;
+    }
+
+    private String validateAndGetSub(JwtDecoder decoder, String issuer, String idToken, String expectedAudience, String provider) {
+        try {
+            Jwt jwt = decoder.decode(idToken);
+            if (jwt.getAudience() == null || jwt.getAudience().isEmpty() || !jwt.getAudience().contains(expectedAudience)) {
+                throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
+                        .addContext("provider", provider)
+                        .addContext("reason", "invalid_audience")
+                        .addContext("expectedAud", expectedAudience);
+            }
+            return jwt.getSubject();
+        } catch (UnauthorizedException e) {
+            throw e;
+        } catch (Exception e) {
+            log.warn("id_token 검증 실패 - provider: {}, reason: {}", provider, e.getMessage());
+            throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
+                    .addContext("provider", provider)
+                    .addContext("reason", "invalid_id_token");
+        }
+    }
+}
+
+

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/OAuth2LoginService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/service/OAuth2LoginService.java
@@ -1,5 +1,8 @@
 package me.bombom.api.v1.auth.service;
 
+import java.util.Optional;
+import me.bombom.api.v1.auth.dto.request.NativeLoginRequest;
+import me.bombom.api.v1.member.domain.Member;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
@@ -9,4 +12,9 @@ public interface OAuth2LoginService {
     OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException;
     String getProviderType();
     boolean supports(String provider);
+
+    // 네이티브: idToken + authorizationCode 기반 로그인(선택 구현)
+    default Optional<Member> loginWithNative(NativeLoginRequest request) {
+        throw new UnsupportedOperationException("Native login is not supported by this provider");
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/SecurityConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/SecurityConfig.java
@@ -23,9 +23,9 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AccessTokenResponseClient;
 import org.springframework.security.oauth2.client.endpoint.OAuth2AuthorizationCodeGrantRequest;
+import org.springframework.security.oauth2.client.endpoint.RestClientAuthorizationCodeTokenResponseClient;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
@@ -114,7 +114,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public Supplier<String> appleClientSecretSupplier(
+    public AppleClientSecretSupplier appleClientSecretSupplier(
             @Value("${oauth2.apple.team-id}") String teamId,
             @Value("${oauth2.apple.key-id}") String keyId,
             @Value("${oauth2.apple.client-id}") String clientId,
@@ -135,7 +135,7 @@ public class SecurityConfig {
     public OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> delegatingAccessTokenClient(
             AppleOAuth2AccessTokenResponseClient appleClient
     ) {
-        DefaultAuthorizationCodeTokenResponseClient defaultClient = new DefaultAuthorizationCodeTokenResponseClient();
+        var defaultClient = new RestClientAuthorizationCodeTokenResponseClient();
         return request -> {
             String registrationId = request.getClientRegistration().getRegistrationId();
             if ("apple".equals(registrationId)) {


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
모바일 앱에서 애플 원탭 로그인 API를 구현했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
모바일 앱에서는 원탭 로그인이 편리하므로.
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
원탭 로그인을 위해서는 기존 방식과는 달리 클라이언트 측에서 애플/구글에 요청을 하고 인증 정보를 서버로 넘겨 받아야 합니다.
그것을 위해 POST api로 인증 정보를 받습니다. 이후에 인증 정보를 통해 애플/구글로 accessToken 발급 요청을 넘기고, 기존 회원일 경우 로그인, 신규 회원일 경우 회원가입을 수행하는 것은 동일합니다.

추가로, 탈퇴 시에 토큰 철회를 위해서는 요청 Token에 client-id가 들어가야 합니다. 그런데, client-id가 웹에서는 Service-ID이지만, 앱에서는 App-ID를 사용합니다, 그래서, 이 부분도 분기처리를 하였습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
