### PR TITLE
[BE][BOM-433] fix: 두개의 인스턴스에서 스케줄러가 모두 실행되는 문제 해결

### DIFF
--- a/backend/bom-bom-server/build.gradle.kts
+++ b/backend/bom-bom-server/build.gradle.kts
@@ -72,6 +72,10 @@ dependencies {
     // logging
     implementation(platform("org.springframework.cloud:spring-cloud-dependencies:2025.0.0"))
     implementation("net.logstash.logback:logstash-logback-encoder:8.1")
+
+    //ShedLock
+    implementation("net.javacrumbs.shedlock:shedlock-spring:6.9.2")
+    implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.9.2")
 }
 
 // Querydsl 생성된 파일 정리

--- a/backend/bom-bom-server/src/main/java/me/bombom/BomBomServerApplication.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/BomBomServerApplication.java
@@ -1,14 +1,15 @@
 package me.bombom;
 
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
 public class BomBomServerApplication {
 
     public static void main(String[] args) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/ShedLockConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/ShedLockConfig.java
@@ -1,0 +1,16 @@
+package me.bombom.api.v1.common.config;
+
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ShedLockConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(dataSource);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/scheduler/ReadingScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/scheduler/ReadingScheduler.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.reading.scheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.reading.service.ReadingService;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,13 +21,15 @@ public class ReadingScheduler {
     private final ReadingService readingService;
 
     @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
-    public void dailyResetReadingCount() {
+    @SchedulerLock(name = "daily_reset_reading_count", lockAtLeastFor = "4s", lockAtMostFor = "9s")
+        public void dailyResetReadingCount() {
         log.info("오늘 읽기 초기화 실행");
         readingService.resetContinueReadingCount();
         readingService.resetTodayReadingCount();
     }
 
     @Scheduled(cron = WEEKLY_CRON, zone = TIME_ZONE)
+    @SchedulerLock(name = "weekly_reset_reading_count", lockAtLeastFor = "4s", lockAtMostFor = "9s")
     public void weeklyResetReadingCount() {
         log.info("주간 읽기 초기화 실행");
         readingService.resetWeeklyReadingCount();
@@ -38,13 +41,15 @@ public class ReadingScheduler {
      *     2월 1일 실행 시 → 1월 데이터를 2025년 YearlyReading에 추가
      */
     @Scheduled(cron = MONTHLY_CRON, zone = TIME_ZONE)
+    @SchedulerLock(name = "monthly_reset_reading_count", lockAtLeastFor = "4s", lockAtMostFor = "9s")
     public void monthlyResetReadingCount() {
         log.info("월간 읽기를 연간 읽기에 반영 후 초기화");
         readingService.passMonthlyCountToYearly();
     }
 
     @Scheduled(cron = EVERY_TEN_MINUTES_CRON, zone = TIME_ZONE)
-    public void hourlyCalculateMemberRank() {
+    @SchedulerLock(name = "ten_minutely_calculate_member_rank", lockAtLeastFor = "1.5s", lockAtMostFor = "3s")
+    public void tenMinutelyCalculateMemberRank() {
         log.info("이달의 독서왕 순위 업데이트");
         readingService.updateMonthlyRanking();
     }

--- a/backend/bom-bom-server/src/main/resources/db/migration/V3.00__create_shedlock_table.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V3.00__create_shedlock_table.sql
@@ -1,0 +1,4 @@
+/* 분산 인스턴스 환경에서 scheduler 관리를 위한 shedlock 테이블 생성 */
+
+CREATE TABLE shedlock(name VARCHAR(64) NOT NULL, lock_until TIMESTAMP(3) NOT NULL,
+                      locked_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3), locked_by VARCHAR(255) NOT NULL, PRIMARY KEY (name));


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
ShedLock 라이브러리로, 둘 중 하나의 EC2만 스케줄러를 실행하도록 하였습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
두개의 EC2가 모두 스케줄러를 실행하여 이달의 독서왕 구하는 쿼리에서 데드락이 발생했습니다.
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

[노션에 정리했습니다.](https://luminous-november-24d.notion.site/2712380f6fa58062a0d3f235473ca82b?source=copy_link)

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
