### PR TITLE
[BE][BOM-440] fix: 회원가입시 받는 nickname, email 정규식 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/request/MemberSignupRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/request/MemberSignupRequest.java
@@ -3,7 +3,6 @@ package me.bombom.api.v1.member.dto.request;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Past;
 import jakarta.validation.constraints.Pattern;
 import java.time.LocalDate;
 import me.bombom.api.v1.member.enums.Gender;
@@ -13,13 +12,13 @@ public record MemberSignupRequest(
 
         @NotNull
         @Length(min = 2, max = 12)
-        @Pattern(regexp = "^[a-zA-Z0-9가-힣]*$")
+        @Pattern(regexp = "^(?!.*\\.\\.)[A-Za-z0-9][A-Za-z0-9._]*[A-Za-z0-9]$")
         String nickname,
 
         @Email
         @NotNull
         @Length(min = 15, max = 42)
-        @Pattern(regexp = "[a-zA-Z0-9]+@bombom\\.news$")
+        @Pattern(regexp = "^[a-zA-Z0-9](?:[a-zA-Z0-9+._-]*[a-zA-Z0-9])?@bombom\\.news$")
         String email,
 
         @JsonFormat(pattern = "yyyy-MM-dd")

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/request/MemberSignupRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/request/MemberSignupRequest.java
@@ -18,7 +18,7 @@ public record MemberSignupRequest(
         @Email
         @NotNull
         @Length(min = 15, max = 42)
-        @Pattern(regexp = "^[a-zA-Z0-9](?:[a-zA-Z0-9+._-]*[a-zA-Z0-9])?@bombom\\.news$")
+        @Pattern(regexp = "^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?@bombom\\.news$")
         String email,
 
         @JsonFormat(pattern = "yyyy-MM-dd")

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/request/MemberSignupRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/request/MemberSignupRequest.java
@@ -12,7 +12,7 @@ public record MemberSignupRequest(
 
         @NotNull
         @Length(min = 2, max = 12)
-        @Pattern(regexp = "^(?!.*\\.\\.)[A-Za-z0-9][A-Za-z0-9._]*[A-Za-z0-9]$")
+        @Pattern(regexp = "^(?!.*\\.\\.)[A-Za-z0-9가-힣][A-Za-z0-9가-힣._]*[A-Za-z0-9가-힣]$")
         String nickname,
 
         @Email


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
회원가입시 받는 nickname, email 정규식을 수정했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
사용자 요청으로 인해
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
닉네임은 인스타그램 스타일로, 이메일은 Gmail 스타일로 했습니다.

닉네임 검증
	•	인스타그램 스타일을 참고하여 정규식을 설계했습니다.
	•	규칙: 영문자와 숫자로 시작/끝나야 하고, 중간에는 영문자, 숫자, _, .만 허용합니다.
	•	연속된 점(..)은 허용하지 않도록 조건을 추가했습니다.
이메일 검증
	•	Gmail 스타일을 참고했지만, + 문자는 허용하지 않았습니다.
	•	규칙: 영문자/숫자로 시작하고 끝나야 하며, 중간에는 영문자, 숫자, ., _, -만 허용합니다.
	•	연속된 점(..)은 허용하지 않도록 조건을 추가했습니다.
	•	도메인은 @bombom.news 로 고정했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
