### PR TITLE
[FE][BOM-437] 첫 페이지에서만 인증 확인

### DIFF
--- a/frontend/src/routes/_bombom.tsx
+++ b/frontend/src/routes/_bombom.tsx
@@ -11,19 +11,26 @@ export const Route = createFileRoute('/_bombom')({
   beforeLoad: async ({ context, location }) => {
     const { queryClient } = context;
 
+    if (location.pathname === '/recommend') {
+      isFirstVisit = false;
+      return;
+    }
+
+    const data = queryClient.getQueryData(queries.me().queryKey);
+    if (data) return;
+
     try {
-      if (isFirstVisit) await queryClient.fetchQuery(queries.me());
-      else isFirstVisit = false;
+      await queryClient.fetchQuery(queries.me());
     } catch {
-      if (location.pathname !== '/recommend') {
-        if (isFirstVisit) {
-          return redirect({ to: '/recommend' });
-        }
-        throw new Response(DEFAULT_ERROR_MESSAGES[401], { status: 401 });
-      }
+      if (isFirstVisit) return redirect({ to: '/recommend' });
+
+      throw new Response(DEFAULT_ERROR_MESSAGES[401], { status: 401 });
+    } finally {
+      isFirstVisit = false;
     }
   },
   errorComponent: ({ error }) => {
+    console.log(error);
     if (error instanceof Response && error.status === 401) {
       return (
         <PageLayout>

--- a/frontend/src/routes/_bombom.tsx
+++ b/frontend/src/routes/_bombom.tsx
@@ -12,7 +12,8 @@ export const Route = createFileRoute('/_bombom')({
     const { queryClient } = context;
 
     try {
-      await queryClient.fetchQuery(queries.me());
+      if (isFirstVisit) await queryClient.fetchQuery(queries.me());
+      else isFirstVisit = false;
     } catch {
       if (location.pathname !== '/recommend') {
         if (isFirstVisit) {
@@ -20,8 +21,6 @@ export const Route = createFileRoute('/_bombom')({
         }
         throw new Response(DEFAULT_ERROR_MESSAGES[401], { status: 401 });
       }
-    } finally {
-      isFirstVisit = false;
     }
   },
   errorComponent: ({ error }) => {


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

첫 페이지에서만 인증을 확인합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

기존에 `await queryClient.fetchQuery(queries.me());` 앞에 if문으로 `isFirstVisit`을 넣으려했지만, 그러한 경우 첫 방문 이외에 recommend이외의 페이지에 이동하면 더이상 errorComponent(RequireLoginCard 컴포넌트)를 보여주지 못합니다. 그래서 `queryClient.getQueryData(queries.me().queryKey)`로 캐싱된 쿼리에 있는 사용자 정보를 불러오도록 수정했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
