### PR TITLE
[FE][BOM-445] GA user id 세팅 오류 해결

### DIFF
--- a/frontend/src/routes/_bombom.tsx
+++ b/frontend/src/routes/_bombom.tsx
@@ -14,10 +14,10 @@ export const Route = createFileRoute('/_bombom')({
     try {
       const user = await queryClient.fetchQuery(queries.me());
 
-      window.gtag?.('set', { user_id: user ? user.id : 'guest' });
+      if (user) {
+        window.gtag?.('set', { user_id: user.id });
+      }
     } catch {
-      window.gtag?.('set', { user_id: 'guest' });
-
       if (location.pathname !== '/recommend') {
         console.log('not first visit');
         if (isFirstVisit) {


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- user_id를 로그인 하지 않았을 때도 설정해주었는데,
- 기존 사용자가 서비스에 진입하여 로그인을 하게 될 경우 활성 사용자가 3이 찍히는 문제가 있었습니다.
- 지금 추측하기로는
- 첫 진입 시, user_id 세팅 전이기 때문에 client_id로 잡힘
- 로그인 상태를 확인하고 로그인하지 않았기 때문에, 'guest'라는 user_id로 잡힘
- 로그인을 하게 될 경우, 로그인 사용자의 user_id로 세팅되어 잡힘
- 그래서 로그인하지 않았을 경우는 user_id를 'guest'로 하지 않아 우선 2만 잡히도록 수정하였습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
