### PR TITLE
[FE][BOM-405] 로그인 안되어 있을 때 구독하기 버튼 막기

### DIFF
--- a/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
+++ b/frontend/src/pages/recommend/components/NewsletterDetail/NewsletterDetail.tsx
@@ -25,15 +25,17 @@ const NewsletterDetail = ({
     enabled: Boolean(newsletterId),
   });
   const deviceType = useDeviceType();
+
   const isMobile = deviceType === 'mobile';
+  const isLoggedIn = Boolean(userInfo);
 
   if (!newsletterId || !newsletterDetail) return null;
 
   const openSubscribe = () => {
-    if (userInfo?.email) {
-      copyToClipboard(userInfo.email);
-      alert('이메일이 복사되었습니다. 이 이메일로 뉴스레터를 구독해주세요.');
-    }
+    if (!isLoggedIn || !userInfo) return;
+
+    copyToClipboard(userInfo.email);
+    alert('이메일이 복사되었습니다. 이 이메일로 뉴스레터를 구독해주세요.');
 
     openExternalLink(newsletterDetail.subscribeUrl);
   };
@@ -46,6 +48,8 @@ const NewsletterDetail = ({
     if (!newsletterDetail.previousNewsletterUrl) return;
     openExternalLink(newsletterDetail.previousNewsletterUrl);
   };
+
+  console.log(userInfo, isLoggedIn);
 
   return (
     <Container>
@@ -74,8 +78,9 @@ const NewsletterDetail = ({
         </InfoWrapper>
 
         <SubscribeButton
-          text="구독하기"
+          text={isLoggedIn ? '구독하기' : '로그인 후 구독할 수 있어요'}
           onClick={openSubscribe}
+          disabled={!isLoggedIn}
           isMobile={isMobile}
         />
       </FixedWrapper>


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 로그인 되어 있지 않을 경우, 구독하기 버튼을 비활성화하는 방향으로 진행하였습니다.

<img width="828" height="703" alt="image" src="https://github.com/user-attachments/assets/4d655f61-3e66-46b8-947d-be54057c0733" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
