### PR TITLE
[BE][BOM-482] fix: html 파싱 오류 해결

### DIFF
--- a/backend/mail-server/src/main/java/news/bombomemail/email/extractor/HtmlTextExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/email/extractor/HtmlTextExtractor.java
@@ -43,7 +43,6 @@ public class HtmlTextExtractor implements ContentExtractor{
      * @throws IOException
      */
     private String readBody(Part part) throws MessagingException, IOException {
-
         Charset charset = resolveCharset(part.getContentType());
         try (InputStream input = part.getInputStream()) {
             byte[] bytes = input.readAllBytes();

--- a/backend/mail-server/src/main/java/news/bombomemail/email/extractor/HtmlTextExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/email/extractor/HtmlTextExtractor.java
@@ -2,11 +2,18 @@ package news.bombomemail.email.extractor;
 
 import jakarta.mail.MessagingException;
 import jakarta.mail.Part;
+import jakarta.mail.internet.ContentType;
+import jakarta.mail.internet.ParseException;
 import java.io.IOException;
-import org.jsoup.Jsoup;
-import org.jsoup.safety.Safelist;
+import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 public class HtmlTextExtractor implements ContentExtractor{
+
+    private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
 
     @Override
     public boolean supports(Part part) throws MessagingException {
@@ -20,6 +27,44 @@ public class HtmlTextExtractor implements ContentExtractor{
 
     @Override
     public String extract(Part part) throws MessagingException, IOException {
-        return Jsoup.clean((String) part.getContent(), Safelist.basic());
+        Object content = part.getContent();
+        if (content instanceof String text) {
+            return text; // 이미 문자열이면 그대로 반환 (CSS 포함)
+        }
+        return readBody(part);
+    }
+
+    /**
+     *  대부분 content는 text로 나오지만 가끔 InputStream으로만 전달되는 본문을 파싱하기 위해서 필요
+     *  문자셋을 직접 판별해 문자열로 복원한다.
+     * @param part
+     * @return
+     * @throws MessagingException
+     * @throws IOException
+     */
+    private String readBody(Part part) throws MessagingException, IOException {
+
+        Charset charset = resolveCharset(part.getContentType());
+        try (InputStream input = part.getInputStream()) {
+            byte[] bytes = input.readAllBytes();
+            return new String(bytes, charset);
+        }
+    }
+
+    private Charset resolveCharset(String rawContentType) {
+        if (rawContentType == null) {
+            return DEFAULT_CHARSET;
+        }
+        try {
+            ContentType contentType = new ContentType(rawContentType);
+            String charsetName = contentType.getParameter("charset");
+            if (charsetName == null || charsetName.isBlank()) {
+                return DEFAULT_CHARSET;
+            }
+            return Charset.forName(charsetName);
+        } catch (IllegalArgumentException | ParseException ex) {
+            log.debug("알 수 없는 charset [{}], 기본값({}) 사용", rawContentType, DEFAULT_CHARSET);
+            return DEFAULT_CHARSET;
+        }
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- style 태크가 전체 삭제되는 에러 수정


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
`Jsoup.clean()` 메서드를 잘 못 사용함


## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

기존 코드
```java
Jsoup.clean((String) part.getContent(), Safelist.basic());
```
- `Jsoup.clean(html, safelist)`은 입력 HTML을 파싱한 뒤, safelist에 허용된 태그·속성만 남기고 나머지를 모두 제거합니다. 즉 HTML을 “살균”해서 XSS나 악성 스크립트를 막는 용도
- `Safelist.basic()`은 기본적인 문단/링크/리스트 정도만 허용하고 <style> 태그, style 속성은 전부 잘라냅니다. 그래서 이전 코드에서 `Jsoup.clean(..., Safelist.basic())`을 쓰면 CSS가 다 사졌던 것 입니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
