### PR TITLE
[BE][BOM-500] fix: 랭킹 업데이트 시 쿼리 오류 해결

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingSnapshotRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingSnapshotRepository.java
@@ -34,7 +34,8 @@ public interface MonthlyReadingSnapshotRepository extends JpaRepository<MonthlyR
         SELECT
           r.member_id,
           RANK() OVER (ORDER BY r.current_count DESC) AS calculated_rank,
-          COALESCE(ds.prev_distinct - r.current_count, 0) AS next_diff
+          COALESCE(ds.prev_distinct - r.current_count, 0) AS next_diff,
+          r.current_count AS current_count
         FROM monthly_reading_realtime r
         JOIN (
           SELECT
@@ -44,6 +45,7 @@ public interface MonthlyReadingSnapshotRepository extends JpaRepository<MonthlyR
         ) ds ON ds.cnt = r.current_count
     ) ranks ON mrs.member_id = ranks.member_id
     SET
+        mrs.current_count = ranks.current_count,
         mrs.rank_order = ranks.calculated_rank,
         mrs.next_rank_difference = ranks.next_diff
 """, nativeQuery = true)


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
랭킹 업데이트 시 current_count가 반영되지 않는 문제를 해결했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 랭킹 업데이트 쿼리에서 `MonthlyReadingSnapshot`의 `currentCount` 업데이트가 누락되어있었습니다.
- dev mysql에서 실행해보니 정상적으로 랭킹 전체 업데이트가 됨을 확인했습니다.
- 근데 trace에서 rollback이 찍힌 이유는 모르겠네요

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
