### PR TITLE
[BE][BOM-503] feat: 아티클 제목 검색에 대해 ngram index 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepository.java
@@ -17,7 +17,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, CustomA
     JOIN Newsletter n ON n.id = a.newsletterId
     WHERE a.memberId = :memberId
       AND (:keyword IS NULL OR :keyword = ''
-           OR LOWER(a.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+           OR a.title LIKE CONCAT('%', :keyword, '%')
            OR LOWER(a.contentsSummary) LIKE LOWER(CONCAT('%', :keyword, '%')))
     GROUP BY n.id, n.name, n.imageUrl
     ORDER BY COUNT(a.id) DESC

--- a/backend/bom-bom-server/src/main/resources/db/migration/V6.3.0__add_ngram_index_for_article_title.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V6.3.0__add_ngram_index_for_article_title.sql
@@ -1,0 +1,5 @@
+-- Article 테이블의 title 컬럼에 ngram 인덱스 추가
+-- MySQL ngram 파서를 사용하여 한글 검색 성능 향상
+
+-- ngram 파서를 사용한 FULLTEXT 인덱스 생성
+ALTER TABLE article ADD FULLTEXT INDEX idx_article_title_ngram (title) WITH PARSER ngram;


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
아티클 제목 검색에 대해 ngram index 추가
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
제목 검색의 효율성을 위해
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
ngram index를 위해서는 제목 검색에 like가 아니라, MATCH AGAINST를 사용해야 합니다.
또한, 해당 기능을 사용하기 위해서는 yml에서

```
jpa:
    hibernate:
      ddl-auto: none
    open-in-view: false
    show-sql: true
    properties:
      hibernate:
        format_sql: true
        **dialect: org.hibernate.dialect.MySQLDialect
        connection:
          charset: utf8mb4
          characterEncoding: utf8mb4**
```
볼드한 부분을 추가해야 합니다.

1. dialect: org.hibernate.dialect.MySQLDialect
- MySQL 전용 기능을 명시적으로 사용하도록 설정
- ngram과 같은 MySQL 특화 기능 사용을 위한 설정
2. charset: utf8mb4 및 characterEncoding: utf8mb4
- UTF-8 4바이트 지원 (이모지, 특수문자 등 완전한 유니코드 지원)
- 한글 검색과 ngram 인덱스가 제대로 동작하도록 문자 인코딩 보장
## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
