### PR TITLE
[BE][BOM-509] fix: 탈퇴한 멤버의 email 컬럼 길이 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/controller/AuthController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/controller/AuthController.java
@@ -158,7 +158,7 @@ public class AuthController implements AuthControllerApi{
             }
         }
 
-        memberService.revoke(member.getId());
+        memberService.withdraw(member.getId());
         session.invalidate();
         expireSessionCookie(response);
         SecurityContextHolder.clearContext();

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/handler/OAuth2LoginSuccessHandler.java
@@ -78,7 +78,7 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
 
     private void handleWithdrawAfterReAuth(Long withdrawMemberId, HttpServletRequest request, HttpServletResponse response) throws IOException {
         try {
-            memberService.revoke(withdrawMemberId);
+            memberService.withdraw(withdrawMemberId);
         } catch (Exception e) {
             log.error("재인증 후 탈퇴 처리 중 예외 발생 - memberId: {}", withdrawMemberId, e);
         } finally {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MemberService.java
@@ -72,7 +72,7 @@ public class MemberService {
     }
 
     @Transactional
-    public void revoke(Long memberId) {
+    public void withdraw(Long memberId) {
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                 .addContext(ErrorContextKeys.MEMBER_ID, memberId)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/withdraw/domain/WithdrawnMember.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/withdraw/domain/WithdrawnMember.java
@@ -29,7 +29,7 @@ public class WithdrawnMember extends BaseEntity {
     @Column(nullable = false)
     private Long memberId;
 
-    @Column(nullable = false, length = 30)
+    @Column(nullable = false, length = 50)
     private String email;
 
     private LocalDate birthDate;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V6.6.0__fix_email_length_withdrawn_member.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V6.6.0__fix_email_length_withdrawn_member.sql
@@ -1,0 +1,3 @@
+-- 탈퇴한 회원에 대한 email 컬럼 길이 50으로 수정
+ALTER TABLE withdrawn_member
+    MODIFY COLUMN email VARCHAR(50) NOT NULL;


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
탈퇴한 멤버의 email 컬럼 길이를 수정했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
멤버의 email 길이는 50인데, 탈퇴한 멤버의 email 길이는 30이라서 길이가 30을 넘는 경우 제대로 탈퇴가 진행되지 않습니다.
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
