### PR TITLE
[BE][BOM-517] fix: 회원 테이블 deleted_at 필드 제거

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
@@ -24,9 +24,7 @@ import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
-@SQLRestriction("deleted_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE member SET deleted_at = now() WHERE id = ?")
 @Table(
         name = "member",
         uniqueConstraints = @UniqueConstraint(columnNames = {"provider", "providerId"})
@@ -63,9 +61,6 @@ public class Member extends BaseEntity implements Serializable {
     @Column(nullable = false, columnDefinition = "BIGINT")
     private Long roleId = 0L;
 
-
-    private LocalDateTime deletedAt;
-
     @Builder
     public Member(
             Long id,
@@ -87,9 +82,5 @@ public class Member extends BaseEntity implements Serializable {
         this.birthDate = birthDate;
         this.gender = gender;
         this.roleId = roleId;
-    }
-
-    public boolean isWithdrawnMember() {
-        return this.deletedAt != null;
     }
 }

--- a/backend/bom-bom-server/src/main/resources/db/migration/V6.7.0__remove_member_deleted_at_field.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V6.7.0__remove_member_deleted_at_field.sql
@@ -1,0 +1,5 @@
+-- 탈퇴 되어있던 데이터들 모두 제거
+DELETE FROM member WHERE deleted_at IS NOT NULL;
+
+-- member 테이블에서 deleted_at 필드 제거
+ALTER TABLE member DROP COLUMN deleted_at;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V6.7.0__remove_member_deleted_at_field.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V6.7.0__remove_member_deleted_at_field.sql
@@ -1,5 +1,6 @@
+START TRANSACTION;
 -- 탈퇴 되어있던 데이터들 모두 제거
 DELETE FROM member WHERE deleted_at IS NOT NULL;
-
 -- member 테이블에서 deleted_at 필드 제거
 ALTER TABLE member DROP COLUMN deleted_at;
+COMMIT;


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
회원 테이블의 deleted_at 필드를 제거합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
`withdrawn_member`로 데이터가 이전되고, `member` 테이블에 `deleted_at` 필드가 필요없어지게 되기 때문입니다. 

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 기존에 `@SQLRestriction`이랑 `@SQLDelete`를 쓰고 있었어서, 단순히 필드만 제거해줘도 처리 가능했습니다. 
- flyway는 기존에 `deleted_at`이 NULL이 아닌 회원 (탈퇴처리 되어있던 회원)들은 `member` 테이블에서 delete 합니다.
- 이후에 `member` 테이블에서 `deleted_at` 필드를 제거합니다. 

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 현재 탈퇴되어 있던 데이터들을 `WithdrawnMember`로 이전하는 flyway도 작성해야할까 고민입니다.
- DB 확인해보니까 탈퇴한 계정들이 다 내부 개발자들 계정이라 이번에 굳이 이전할 필요가 있을까 싶어서 작성 안했습니다..!
- delete 쿼리라 무섭습니다.. 간단하지만 쿼리 확인 꼭 부탁드려요..