### PR TITLE
[BE][BOM-522] fix: 회원가입 시 랜덤 닉네임 생성, 이메일 검증 정규식 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/util/UniqueUserInfoGenerator.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/util/UniqueUserInfoGenerator.java
@@ -24,7 +24,7 @@ public class UniqueUserInfoGenerator {
     public String getUniqueNickname(String nickname) {
         String normalizedNickname = nickname.strip().toLowerCase();
         if (userInfoValidator.isNicknameAvailable(normalizedNickname)) {
-            return normalizedNickname;
+            return nickname;
         }
         return generateUniqueNickname(normalizedNickname);
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/util/UniqueUserInfoGenerator.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/util/UniqueUserInfoGenerator.java
@@ -4,6 +4,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 /**
  * 고유값 생성 서비스
@@ -18,15 +19,55 @@ public class UniqueUserInfoGenerator {
     private static final String EMAIL_DOMAIN = "@bombom.news"; // 동일 도메인 정책
     private static final int NICKNAME_MAX_LENGTH = 20; // 컬럼/검증과 일치
     private static final int EMAIL_MAX_LENGTH = 50; // 컬럼과 일치 (전체 길이)
+    private static final String[] RANDOM_NICKNAME_ADJECTIVES = {
+        "행복한","즐거운","밝은","따뜻한","귀여운","시원한","새로운","친절한","용감한","강한",
+                "똑똑한","현명한","지혜로운","총명한","영리한","대담한","차분한","평온한","부지런한","성실한",
+                "순수한","맑은","정직한","솔직한","순진한","다정한","상냥한","온화한","따사로운","열정적인",
+                "활기찬","생기있는","에너지넘치는","용의주도한","대범한","강렬한","단호한","차가운","신비로운","호기심많은",
+                "창의적인","독창적인","유쾌한","재미있는","익살스러운","엉뚱한","유머러스한","엉클어진","도전적인","끈기있는",
+                "성공적인","행운의","풍요로운","풍성한","넉넉한","자유로운","독립적인","단단한","견고한","튼튼한",
+                "명랑한","활발한","쾌활한","활짝웃는","열린","긍정적인","낙천적인","유연한","부드러운","온유한",
+                "따뜻미소짓는","용맹한","기운찬","활짝핀","꽃같은","빛나는","눈부신","반짝이는","찬란한","화려한",
+                "차분미소짓는","겸손한","온순한","성숙한","이상적인","현실적인","섬세한","꼼꼼한","철저한","세심한",
+                "날카로운","예리한","날렵한","민첩한","빠른","신속한","재빠른","순발력있는","끈끈한","든든한"
+    };
+    private static final String[] RANDOM_NICKNAME_NOUNS = {
+            "호랑이","사자","늑대","여우","곰","펭귄","토끼","강아지","고양이","원숭이",
+            "기린","코끼리","얼룩말","하마","코뿔소","치타","표범","판다","고래","상어",
+            "돌고래","물개","바다사자","해마","문어","오징어","게","가재","독수리","매",
+            "참새","비둘기","까치","까마귀","앵무새","공작","타조","펠리컨","백조","두루미",
+            "개구리","두꺼비","도마뱀","거북이","뱀","악어","카멜레온","고슴도치","너구리","다람쥐",
+            "햄스터","기니피그","사슴","노루","엘크","순록","바이슨","들소","양","염소",
+            "닭","병아리","오리","거위","칠면조","공룡","티라노","트리케라톱스","브라키오","스테고",
+            "벌","나비","잠자리","메뚜기","사마귀","개미","딱정벌레","풍뎅이","무당벌레","거미",
+            "해바라기","장미","튤립","코스모스","국화","벚꽃","벼","나무","소나무","대나무",
+            "별","달","태양","은하","행성","우주","돌","산","바다","강"
+    };
+
 
     private final UserInfoValidator userInfoValidator;
 
     public String getUniqueNickname(String nickname) {
         String normalizedNickname = nickname.strip().toLowerCase();
+        if (!StringUtils.hasText(nickname)) {
+            return generateRandomNickname();
+        }
         if (userInfoValidator.isNicknameAvailable(normalizedNickname)) {
             return nickname;
         }
         return generateUniqueNickname(normalizedNickname);
+    }
+
+    private String generateRandomNickname() {
+        String adjective = RANDOM_NICKNAME_ADJECTIVES[ThreadLocalRandom.current().nextInt(RANDOM_NICKNAME_ADJECTIVES.length)];
+        String noun = RANDOM_NICKNAME_NOUNS[ThreadLocalRandom.current().nextInt(RANDOM_NICKNAME_NOUNS.length)];
+        String randomValue = getRandomValue();
+        
+        String baseNickname = adjective + noun;
+        String uniqueNickname = baseNickname + NICKNAME_RANDOM_DELIMITER + randomValue;
+
+        log.debug("랜덤 닉네임 생성 - 생성: {}", uniqueNickname);
+        return uniqueNickname;
     }
 
     public String getUniqueEmailLocalPart(String email) {
@@ -65,7 +106,7 @@ public class UniqueUserInfoGenerator {
     }
 
     private String trimNicknameForSuffix(String baseNickname, String random) {
-        // (이메일 최대 길이 - 도메인 길이 - 랜덤값 추가로 붙는 길이)보다 사용자의 이메일이 길면 자름
+        // (닉네임 최대 길이 - 랜덤값 추가로 붙는 길이)보다 사용자의 닉네임이 길면 자름
         int availableLength = NICKNAME_MAX_LENGTH - NICKNAME_RANDOM_DELIMITER.length() - random.length();
         return baseNickname.length() > availableLength && availableLength > 0
                 ? baseNickname.substring(0, availableLength)
@@ -73,7 +114,7 @@ public class UniqueUserInfoGenerator {
     }
 
     private String trimEmailLocalPartForSuffix(String baseLocalPart, String random) {
-        // (닉네임 최대 길이 - 랜덤값 추가로 붙는 길이)보다 사용자의 닉네임이 길면 자름
+        // (이메일 최대 길이 - 도메인 길이 - 랜덤값 추가로 붙는 길이)보다 사용자의 이메일이 길면 자름
         int localPartMaxLength = EMAIL_MAX_LENGTH - EMAIL_DOMAIN.length();
         int availableLength = localPartMaxLength - EMAIL_RANDOM_DELIMITER.length() - random.length();
         return baseLocalPart.length() > availableLength && availableLength > 0

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/util/UserInfoValidator.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/util/UserInfoValidator.java
@@ -91,8 +91,7 @@ public class UserInfoValidator {
     }
 
     public boolean isValidNicknameFormat(String nickname) {
-        return StringUtils.hasText(nickname) &&
-                isValidNicknameLength(nickname) &&
+        return isValidNicknameLength(nickname) &&
                 NICKNAME_PATTERN.matcher(normalize(nickname)).matches();
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/util/UserInfoValidator.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/util/UserInfoValidator.java
@@ -81,15 +81,13 @@ public class UserInfoValidator {
 
     public boolean isNicknameAvailable(String nickname) {
         return isValidNicknameFormat(nickname)
-                && !isDuplicateNickname(nickname)
-                && isValidNicknameLength(nickname);
+                && !isDuplicateNickname(nickname);
     }
 
     public boolean isEmailAvailable(String email) {
         String completeEmail = getCompleteEmail(email);
         return isValidEmailFormat(completeEmail)
-                && !isDuplicateEmail(completeEmail)
-                && isValidEmailLength(completeEmail);
+                && !isDuplicateEmail(completeEmail);
     }
 
     public boolean isValidNicknameFormat(String nickname) {


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
회원가입 시 랜덤 닉네임 생성 기능을 구현했습니다. 이메일 검증 정규식 수정했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
닉네임이 없을 경우를 위해. 무조건 이메일에 랜덤값이 붙는 문제 해결
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
