### PR TITLE
[BE][BOM-525] feat: 앱 로그인 시 유니크한 닉네임, 이메일을 클라이언트에게 넘겨주도록 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/controller/AuthController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/controller/AuthController.java
@@ -111,23 +111,13 @@ public class AuthController implements AuthControllerApi{
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "응답 바디가 없습니다.");
             return null;
         }
-        
-        if (OAuth2Provider.APPLE.isEqualProvider(provider)) {
-            return handleNativeResult(
-                    nativeLoginRequest,
-                    appleOAuth2Service.loginWithNative(nativeLoginRequest),
-                    request
-            );
-        } else if (OAuth2Provider.GOOGLE.isEqualProvider(provider)) {
-            return handleNativeResult(
-                    nativeLoginRequest,
-                    googleOAuth2LoginService.loginWithNative(nativeLoginRequest),
-                    request
-            );
-        } else {
+
+        Optional<Member> loginResult = loginWithProvider(provider, nativeLoginRequest);
+        if (loginResult.isEmpty()) {
             response.sendError(HttpServletResponse.SC_BAD_REQUEST, "지원하지 않는 제공자입니다.");
             return null;
         }
+        return handleNativeResult(nativeLoginRequest, loginResult, request);
     }
 
     @Override
@@ -176,6 +166,15 @@ public class AuthController implements AuthControllerApi{
         response.setStatus(HttpServletResponse.SC_NO_CONTENT);
     }
 
+    private Optional<Member> loginWithProvider(String provider, NativeLoginRequest nativeLoginRequest) {
+        if (OAuth2Provider.APPLE.isEqualProvider(provider)) {
+            return appleOAuth2Service.loginWithNative(nativeLoginRequest);
+        } else if (OAuth2Provider.GOOGLE.isEqualProvider(provider)) {
+            return googleOAuth2LoginService.loginWithNative(nativeLoginRequest);
+        }
+        return Optional.empty(); // 미지원 provider
+    }
+
     private NativeLoginResponse handleNativeResult(
             NativeLoginRequest nativeLoginRequest,
             Optional<Member> member,
@@ -183,14 +182,14 @@ public class AuthController implements AuthControllerApi{
     ) {
         // 세션 생성 트리거 (컨테이너가 Set-Cookie: JSESSIONID를 설정)
         request.getSession(true);
-        
+
         if (member.isPresent()) {
             OAuth2AuthenticationToken authentication = createAuthenticationToken(member.get());
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
             HttpSession session = request.getSession();
             session.setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
-            
+
             // 기존 회원 -> 로그인 완료
             return new NativeLoginResponse(true, null, null);
         } else {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/dto/NativeLoginResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/dto/NativeLoginResponse.java
@@ -1,6 +1,8 @@
 package me.bombom.api.v1.auth.dto;
 
 public record NativeLoginResponse(
-        boolean isRegistered
+        boolean isRegistered,
+        String email,
+        String password
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/dto/NativeLoginResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/dto/NativeLoginResponse.java
@@ -1,6 +1,10 @@
 package me.bombom.api.v1.auth.dto;
 
+import jakarta.validation.constraints.NotNull;
+
 public record NativeLoginResponse(
+
+        @NotNull
         boolean isRegistered,
         String email,
         String password

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/dto/request/NativeLoginRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/dto/request/NativeLoginRequest.java
@@ -4,5 +4,7 @@ import jakarta.validation.constraints.NotNull;
 
 public record NativeLoginRequest(
         @NotNull String identityToken,
-        @NotNull String authorizationCode
+        @NotNull String authorizationCode,
+        String email,
+        String nickname
 ) {}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
앱 로그인 시 유니크한 닉네임, 이메일 넘겨주도록 구현했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
앱 로그인 시에는 웹 로그인과 다르게, 애플에게 인증 정보를 요청하는 첫 요청을 앱에서 수행하기 때문에, 다른 구현이 필요합니다.
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
사용자의 인증 정보에 담긴 email과 nickname을 받아 기존 `UniqueUserInfoGenerator`를 통해 유니크한 값을 생성합니다.
## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

빠르게 구현하고, 리팩터링은 추후에 진행하겠습니다.
