### PR TITLE
[BE][BOM-527] fix: 가이드메일 점수 가입 당일에만 오르게 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/guidemail/controller/GuideMailController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/guidemail/controller/GuideMailController.java
@@ -17,9 +17,10 @@ public class GuideMailController implements GuideMailControllerApi{
 
     private final GuideMailService guideMailService;
 
+    @Override
     @PatchMapping("/read")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void updateRead(@LoginMember Member member) {
-        guideMailService.updateReadScore(member.getId());
+        guideMailService.updateReadScore(member);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/guidemail/service/GuideMailService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/guidemail/service/GuideMailService.java
@@ -1,6 +1,8 @@
 package me.bombom.api.v1.guidemail.service;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.pet.ScorePolicyConstants;
 import me.bombom.api.v1.pet.service.PetService;
 import me.bombom.api.v1.reading.service.ReadingService;
@@ -16,8 +18,17 @@ public class GuideMailService {
     private final ReadingService readingService;
 
     @Transactional
-    public void updateReadScore(Long memberId) {
-        petService.increaseCurrentScoreForGuideMail(memberId, ScorePolicyConstants.ARTICLE_READING_SCORE);
-        readingService.updateReadingCountForGuideMail(memberId);
+    public void updateReadScore(Member member) {
+        Long memberId = member.getId();
+        LocalDate registerDate = member.getCreatedAt().toLocalDate();
+        boolean isRegisterDay = isRegisterDay(registerDate);
+        if (isRegisterDay) {
+            petService.increaseCurrentScoreForGuideMail(memberId, ScorePolicyConstants.ARTICLE_READING_SCORE);
+        }
+        readingService.updateReadingCountForGuideMail(memberId, isRegisterDay);
+    }
+
+    private boolean isRegisterDay(LocalDate registerDate) {
+        return registerDate.isEqual(LocalDate.now());
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -172,10 +172,12 @@ public class ReadingService {
     }
 
     @Transactional
-    public void updateReadingCountForGuideMail(Long memberId) {
-        updateContinueReadingCount(memberId);
-        updateTodayReadingCount(memberId);
-        updateWeeklyReadingCount(memberId);
+    public void updateReadingCountForGuideMail(Long memberId, boolean isRegisterDay) {
+        if (isRegisterDay) {
+            updateContinueReadingCount(memberId);
+            updateTodayReadingCount(memberId);
+            updateWeeklyReadingCount(memberId);
+        }
         updateMonthlyReadingCount(memberId);
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/guidemail/service/GuideMailServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/guidemail/service/GuideMailServiceTest.java
@@ -94,7 +94,7 @@ class GuideMailServiceTest {
         int currentContinueDayCount = continueReading.getDayCount();
 
         // when
-        guideMailService.updateReadScore(member.getId());
+        guideMailService.updateReadScore(member);
 
         // then
         Pet updatedPet = petRepository.findByMemberId(member.getId()).get();


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
가이드메일 점수 가입 당일에만 오르게 수정했습니다. 
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
재오의 요청으로
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
원래 아티클 오르는 기준과 동일하게 수정했습니다.
## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
