### PR TITLE
[FE][BOM-434] refactor: fetcher에서 date 타입 변환 로직 분리

### DIFF
--- a/frontend/src/apis/articles.ts
+++ b/frontend/src/apis/articles.ts
@@ -1,13 +1,9 @@
 import { fetcher } from './fetcher';
 import type { components, operations } from '@/types/openapi';
 
-export type GetArticlesParams = Omit<
-  components['schemas']['ArticlesOptionsRequest'],
-  'date'
-> &
-  components['schemas']['Pageable'] & {
-    date?: Date;
-  };
+export type GetArticlesParams =
+  components['schemas']['ArticlesOptionsRequest'] &
+    components['schemas']['Pageable'];
 
 export type GetArticlesResponse = components['schemas']['PageArticleResponse'];
 

--- a/frontend/src/apis/fetcher.ts
+++ b/frontend/src/apis/fetcher.ts
@@ -1,14 +1,13 @@
 import ApiError from './ApiError';
 import { DEFAULT_ERROR_MESSAGES } from './constants/defaultErrorMessage';
 import { ENV } from './env';
-import { formatDate } from '@/utils/date';
 import { logger } from '@/utils/logger';
 
 type JsonBody = Record<string, unknown>;
 
 type FetcherOptions<TRequest extends JsonBody> = {
   path: string;
-  query?: Record<string, string | number | Date | undefined | string[]>;
+  query?: Record<string, string | number | undefined | string[]>;
   body?: TRequest;
   headers?: HeadersInit;
 };
@@ -42,7 +41,7 @@ type FetchMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE' | 'PUT';
 type RequestOptions<TRequest> = {
   path: string;
   method: FetchMethod;
-  query?: Record<string, string | number | Date | undefined | string[]>;
+  query?: Record<string, string | number | undefined | string[]>;
   body?: TRequest;
   headers?: HeadersInit;
 };
@@ -58,12 +57,7 @@ const request = async <TRequest, TResponse>({
     const url = new URL(ENV.baseUrl + path);
     const stringifiedQuery: Record<string, string> = Object.fromEntries(
       Object.entries(query)
-        .map(([key, value]) => {
-          if (value instanceof Date) {
-            return [key, formatDate(value, '-')];
-          }
-          return [key, value?.toString()];
-        })
+        .map(([key, value]) => [key, value?.toString()])
         .filter(([, value]) => value),
     );
     url.search = new URLSearchParams(stringifiedQuery).toString();

--- a/frontend/src/pages/detail/components/TodayUnreadArticlesSection/TodayUnreadArticlesSection.tsx
+++ b/frontend/src/pages/detail/components/TodayUnreadArticlesSection/TodayUnreadArticlesSection.tsx
@@ -5,6 +5,7 @@ import EmptyUnreadCard from '../EmptyUnreadCard/EmptyUnreadCard';
 import NewsletterItemCard from '../NewsletterItemCard/NewsletterItemCard';
 import { queries } from '@/apis/queries';
 import { useDevice } from '@/hooks/useDevice';
+import { formatDate } from '@/utils/date';
 import type { Device } from '@/hooks/useDevice';
 
 interface TodayUnreadArticlesSectionProps {
@@ -15,7 +16,9 @@ const TodayUnreadArticlesSection = ({
   articleId,
 }: TodayUnreadArticlesSectionProps) => {
   const today = useMemo(() => new Date(), []);
-  const { data: todayArticles } = useQuery(queries.articles({ date: today }));
+  const { data: todayArticles } = useQuery(
+    queries.articles({ date: formatDate(today, '-') }),
+  );
   const device = useDevice();
 
   const unreadArticles = todayArticles?.content?.filter(

--- a/frontend/src/pages/detail/hooks/useArticleAsReadMutation.ts
+++ b/frontend/src/pages/detail/hooks/useArticleAsReadMutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { patchArticleRead } from '@/apis/articles';
 import { queries } from '@/apis/queries';
+import { formatDate } from '@/utils/date';
 
 interface UseArticleAsReadMutationParams {
   articleId: number;
@@ -20,7 +21,7 @@ const useArticleAsReadMutation = ({
         queryKey: queries.articleById({ id: articleId }).queryKey,
       });
       queryClient.invalidateQueries({
-        queryKey: queries.articles({ date: today }).queryKey,
+        queryKey: queries.articles({ date: formatDate(today, '-') }).queryKey,
       });
     },
   });


### PR DESCRIPTION
## 📌 What
fetcher에서 수행되던 데이터 변환 로직을 호출부로 이동

## ❓ Why
Date 여부를 체크하고 타입을 변환하는 것은 fetcher의 책임과 관련성이 낮다고 판단하여 리팩토링 진행

## 🔧 How
- 데이터가 생성된 지점에서 변환을 수행하도록 코드를 분리함

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
