### PR TITLE
[BOM-780] refactor: 지난 뉴스레터 관리 Role 기반 관리로 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/PreviousArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/PreviousArticleService.java
@@ -41,7 +41,8 @@ public class PreviousArticleService {
             NewsletterPreviousPolicyRepository newsletterPreviousPolicyRepository,
             PreviousArticleRepository previousArticleRepository,
             MemberRepository memberRepository,
-            List<PreviousArticleStrategy> strategies) {
+            List<PreviousArticleStrategy> strategies
+    ) {
         this.articleRepository = articleRepository;
         this.newsletterPreviousPolicyRepository = newsletterPreviousPolicyRepository;
         this.previousArticleRepository = previousArticleRepository;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/PreviousArticleService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/service/PreviousArticleService.java
@@ -12,13 +12,14 @@ import me.bombom.api.v1.article.repository.ArticleRepository;
 import me.bombom.api.v1.article.repository.PreviousArticleRepository;
 import me.bombom.api.v1.article.service.strategy.PreviousArticleStrategy;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.newsletter.domain.NewsletterPreviousPolicy;
 import me.bombom.api.v1.newsletter.domain.NewsletterPreviousStrategy;
 import me.bombom.api.v1.newsletter.repository.NewsletterPreviousPolicyRepository;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,11 +29,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class PreviousArticleService {
 
     private static final int PREVIOUS_ARTICLE_KEEP_COUNT = 10;
+    private static final String ARCHIVE_ROLE_AUTHORITY = "ARCHIVE";
+
     private final PreviousArticleRepository previousArticleRepository;
-
-    @Value("${admin.previous-article.member-id}")
-    private Long previousArticleAdminId;
-
+    private final MemberRepository memberRepository;
     private final ArticleRepository articleRepository;
     private final NewsletterPreviousPolicyRepository newsletterPreviousPolicyRepository;
     private final Map<NewsletterPreviousStrategy, PreviousArticleStrategy> strategyMap;
@@ -40,13 +40,16 @@ public class PreviousArticleService {
     public PreviousArticleService(
             ArticleRepository articleRepository,
             NewsletterPreviousPolicyRepository newsletterPreviousPolicyRepository,
-            List<PreviousArticleStrategy> strategies,
-            PreviousArticleRepository previousArticleRepository) {
+            PreviousArticleRepository previousArticleRepository,
+            MemberRepository memberRepository,
+            List<PreviousArticleStrategy> strategies
+    ) {
         this.articleRepository = articleRepository;
         this.newsletterPreviousPolicyRepository = newsletterPreviousPolicyRepository;
+        this.previousArticleRepository = previousArticleRepository;
+        this.memberRepository = memberRepository;
         this.strategyMap = strategies.stream()
                 .collect(Collectors.toUnmodifiableMap(PreviousArticleStrategy::getStrategy, Function.identity()));
-        this.previousArticleRepository = previousArticleRepository;
     }
 
     public List<PreviousArticleResponse> getPreviousArticles(PreviousArticleRequest request) {
@@ -76,9 +79,17 @@ public class PreviousArticleService {
 
     @Transactional
     public void moveAdminArticles() {
+        List<Member> members = memberRepository.findByRoleAuthority(ARCHIVE_ROLE_AUTHORITY);
+        if (members.isEmpty()) {
+            throw new CServerErrorException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "member")
+                    .addContext(ErrorContextKeys.OPERATION, "moveAdminArticles");
+        }
+
+        Long previousArticleAdminId = members.getFirst().getId();
         int copied = articleRepository.safeCopyToArchive(previousArticleAdminId);
         int deleted = articleRepository.safeDeleteArchived(previousArticleAdminId, PREVIOUS_ARTICLE_KEEP_COUNT);
-        log.info("아티클 이동 완료: {}건 복사, {}건 삭제", copied, deleted);
+        log.info("아티클 이동 완료: {}건 복사, {}건 삭제 (adminId: {})", copied, deleted, previousArticleAdminId);
     }
 
     private List<PreviousArticleResponse> executeStrategy(NewsletterPreviousPolicy policy) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,4 +21,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByNickname(String nickname);
 
     long countByRoleId(long roleId);
+
+    @Query("""
+        SELECT m
+        FROM Member m
+        JOIN Role r ON m.roleId = r.id
+        WHERE r.authority = :authority
+        ORDER BY m.id ASC
+    """)
+    List<Member> findByRoleAuthority(@Param("authority") String authority);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
@@ -1,6 +1,5 @@
 package me.bombom.api.v1.member.repository;
 
-import java.util.List;
 import java.util.Optional;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -23,11 +22,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     long countByRoleId(long roleId);
 
     @Query("""
-        SELECT m
+        SELECT m.id
         FROM Member m
         JOIN Role r ON m.roleId = r.id
-        WHERE r.authority = :authority
-        ORDER BY m.id ASC
+        WHERE r.authority = 'ARCHIVE'
     """)
-    List<Member> findByRoleAuthority(@Param("authority") String authority);
+    Optional<Long> findArchiveAdminId();
+
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/RoleRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/RoleRepository.java
@@ -1,0 +1,10 @@
+package me.bombom.api.v1.member.repository;
+
+import java.util.Optional;
+import me.bombom.api.v1.member.domain.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+
+    Optional<Role> findByAuthority(String authority);
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
지난 뉴스레터 관리 멤버를 yml에서 member_id를 가져오는 것이 아닌, Role을 이용하여 DB에서 멤버를 조회하도록 수정했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

기존에는 previous-article.member-id를 환경 설정 파일(yml)에서 관리했으나, 이는 환경별(dev/prod)로 ID를 다르게 관리해야 하는 번거로움이 있었고, 운영상 관리자 계정이 변경될 경우 재배포가 필요했습니다. 이를 개선하기 위해 **DB의 Role 기반(권한)**으로 관리자를 동적으로 찾도록 변경하여 유연성을 확보했습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

**1. 하드코딩 제거**
PreviousArticleService에서 @Value로 주입받던 previousArticleAdminId 필드를 제거했습니다.

**2. 단일 쿼리 최적화**
- MemberRepository에 findByRoleAuthority 메서드를 추가하여 JOIN 쿼리를 통해 Role 권한 이름으로 멤버를 한 번에 조회하도록 구현했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

ARCHIVE 권한을 가진 유저가 없을 경우 CServerErrorException을 발생시키도록 처리했는데, 이 예외 처리가 적절한지 봐주시면 좋겠습니다.