### PR TITLE
[BOM-804] feat: 챌린지 신청 및 취소 API 구현 

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
@@ -1,0 +1,47 @@
+package me.bombom.api.v1.challenge.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.dto.request.ChallengeCommentOptionsRequest;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.service.ChallengeCommentService;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/challenges")
+public class ChallengeCommentController implements ChallengeCommentControllerApi {
+
+    private final ChallengeCommentService challengeCommentService;
+
+    @Override
+    @GetMapping("/{challengeId}/comments")
+    public Page<ChallengeCommentResponse> getChallengeComments(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
+            @Valid @ModelAttribute ChallengeCommentOptionsRequest request,
+            @PageableDefault(size = 20)
+            @SortDefault.SortDefaults({
+                    @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC),
+                    @SortDefault(sort = "id", direction = Sort.Direction.ASC)
+            }) Pageable pageable
+    ){
+        return challengeCommentService.getChallengeComments(challengeId, member.getId(), request, pageable);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
@@ -1,0 +1,44 @@
+package me.bombom.api.v1.challenge.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import me.bombom.api.v1.challenge.dto.request.ChallengeCommentOptionsRequest;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Challenge Comment", description = "챌린지 코멘트 관련 API")
+@ApiResponses({
+        @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content)
+})
+public interface ChallengeCommentControllerApi {
+
+    @Operation(
+            summary = "챌린지 팀 댓글 조회",
+            description = "특정 챌린지에 참여 중인 사용자의 팀 댓글을 기간(start~end)으로 필터링해 페이징 조회합니다. "
+                    + "(예: ?page=0&size=20&sort=createdAt,desc)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팀 댓글 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값", content = @Content),
+            @ApiResponse(responseCode = "403", description = "팀 또는 챌린지 접근 권한 없음", content = @Content)
+    })
+    Page<ChallengeCommentResponse> getChallengeComments(
+            @Parameter(hidden = true) Member member,
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
+            @Parameter(description = "필터링 관련 요청") @Valid @ModelAttribute ChallengeCommentOptionsRequest request,
+            @Parameter(description = "페이징 및 정렬 (예: ?page=0&size=20&sort=createdAt,desc)") Pageable pageable
+    );
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
@@ -10,11 +10,13 @@ import me.bombom.api.v1.challenge.service.ChallengeService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -48,6 +50,7 @@ public class ChallengeController implements ChallengeControllerApi {
 
     @Override
     @PostMapping("/{id}/application")
+    @ResponseStatus(HttpStatus.CREATED)
     public void applyChallenge(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
             @LoginMember Member member
@@ -57,6 +60,7 @@ public class ChallengeController implements ChallengeControllerApi {
 
     @Override
     @DeleteMapping("/{id}/application")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     public void cancelChallenge(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
             @LoginMember Member member

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
@@ -10,8 +10,10 @@ import me.bombom.api.v1.challenge.service.ChallengeService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -42,5 +44,23 @@ public class ChallengeController implements ChallengeControllerApi {
             @LoginMember(anonymous = true) Member member
     ) {
         return challengeService.checkEligibility(id, member);
+    }
+
+    @Override
+    @PostMapping("/{id}/application")
+    public void applyChallenge(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @LoginMember Member member
+    ) {
+        challengeService.applyChallenge(id, member);
+    }
+
+    @Override
+    @DeleteMapping("/{id}/application")
+    public void cancelChallenge(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @LoginMember Member member
+    ) {
+        challengeService.cancelChallenge(id, member);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
@@ -51,4 +51,34 @@ public interface ChallengeControllerApi {
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
             @Parameter(hidden = true) @LoginMember(anonymous = true) Member member
     );
+
+    @Operation(
+            summary = "챌린지 신청",
+            description = "특정 챌린지에 신청합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "챌린지 신청 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (이미 시작된 챌린지, 중복 신청, 구독하지 않은 뉴스레터 등)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음", content = @Content)
+    })
+    void applyChallenge(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @Parameter(hidden = true) @LoginMember Member member
+    );
+
+    @Operation(
+            summary = "챌린지 취소",
+            description = "신청한 챌린지를 취소합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "챌린지 취소 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (이미 시작된 챌린지)", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지 또는 신청 내역을 찾을 수 없음", content = @Content)
+    })
+    void cancelChallenge(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @Parameter(hidden = true) @LoginMember Member member
+    );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
@@ -57,7 +57,7 @@ public interface ChallengeControllerApi {
             description = "특정 챌린지에 신청합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "챌린지 신청 성공"),
+            @ApiResponse(responseCode = "201", description = "챌린지 신청 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (이미 시작된 챌린지, 중복 신청, 구독하지 않은 뉴스레터 등)", content = @Content),
             @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
             @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음", content = @Content)
@@ -72,7 +72,7 @@ public interface ChallengeControllerApi {
             description = "신청한 챌린지를 취소합니다."
     )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "챌린지 취소 성공"),
+            @ApiResponse(responseCode = "204", description = "챌린지 취소 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 (이미 시작된 챌린지)", content = @Content),
             @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
             @ApiResponse(responseCode = "404", description = "챌린지 또는 신청 내역을 찾을 수 없음", content = @Content)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeComment.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeComment.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.challenge.domain;
 
+import jakarta.annotation.Nonnull;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -22,10 +23,15 @@ public class ChallengeComment extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private Long articleId;
+    private Long newsletterId;
 
     @Column(nullable = false)
     private Long participantId;
+
+    @Column(nullable = false)
+    private String articleTitle;
+
+    private String quotation;
 
     @Column(nullable = false)
     private String comment;
@@ -33,13 +39,17 @@ public class ChallengeComment extends BaseEntity {
     @Builder
     public ChallengeComment(
             Long id,
-            @NonNull Long articleId,
+            @NonNull Long newsletterId,
             @NonNull Long participantId,
+            @Nonnull String articleTitle,
+            String quotation,
             @NonNull String comment
     ) {
         this.id = id;
-        this.articleId = articleId;
+        this.newsletterId = newsletterId;
         this.participantId = participantId;
+        this.articleTitle = articleTitle;
+        this.quotation = quotation;
         this.comment = comment;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/ChallengeCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/ChallengeCommentResponse.java
@@ -1,0 +1,15 @@
+package me.bombom.api.v1.challenge.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ChallengeCommentResponse(
+
+        String nickname,
+        String newsletterName,
+        String articleTitle,
+        String quotation,
+        String comment,
+        LocalDateTime createdAt
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/ChallengeCommentOptionsRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/ChallengeCommentOptionsRequest.java
@@ -1,0 +1,18 @@
+package me.bombom.api.v1.challenge.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+
+public record ChallengeCommentOptionsRequest(
+
+        @NotNull
+        @DateTimeFormat(iso = ISO.DATE)
+        LocalDate start,
+
+        @NotNull
+        @DateTimeFormat(iso = ISO.DATE)
+        LocalDate end
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeCommentResponse.java
@@ -1,0 +1,28 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record ChallengeCommentResponse(
+
+        String nickname,
+
+        @NotNull
+        String newsletterName,
+
+        @Schema(required = true)
+        boolean isSubscribed,
+
+        @NotNull
+        String articleTitle,
+
+        String quotation,
+
+        @NotNull
+        String comment,
+
+        @NotNull
+        LocalDateTime createdAt
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
@@ -1,0 +1,42 @@
+package me.bombom.api.v1.challenge.repository;
+
+import java.time.LocalDate;
+import me.bombom.api.v1.challenge.domain.ChallengeComment;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChallengeCommentRepository extends JpaRepository<ChallengeComment, Long> {
+
+    @Query("""
+        SELECT new me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse(
+            m.nickname,
+            n.name,
+            CASE
+                WHEN s.id IS NULL THEN false
+                ELSE true
+            END,
+            cc.articleTitle,
+            cc.quotation,
+            cc.comment,
+            cc.createdAt
+        )
+        FROM ChallengeComment cc
+        JOIN ChallengeParticipant cp ON cc.participantId = cp.id
+        LEFT JOIN Member m ON cp.memberId = m.id
+        JOIN Newsletter n ON cc.newsletterId = n.id
+        LEFT JOIN Subscribe s ON s.newsletterId = cc.newsletterId AND s.memberId = :currentMemberId
+        WHERE cp.challengeTeamId = :teamId
+        AND FUNCTION('DATE', cc.createdAt) BETWEEN :startDate AND :endDate
+    """)
+    Page<ChallengeCommentResponse> findAllByTeamInDuration(
+            @Param("teamId") Long teamId,
+            @Param("currentMemberId") Long currentMemberId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            Pageable pageable
+    );
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -14,8 +14,6 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
     
     Optional<ChallengeParticipant> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
 
-    Optional<ChallengeParticipant> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
-
     @Query("""
         SELECT new me.bombom.api.v1.challenge.dto.ChallengeParticipantCount(p.challengeId, COUNT(p.id))
         FROM ChallengeParticipant p

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.challenge.repository;
 
 import java.util.List;
+import java.util.Optional;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.ChallengeParticipantCount;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,8 @@ import org.springframework.data.repository.query.Param;
 public interface ChallengeParticipantRepository extends JpaRepository<ChallengeParticipant, Long> {
     
     boolean existsByChallengeIdAndMemberId(Long challengeId, Long memberId);
+    
+    Optional<ChallengeParticipant> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
 
     @Query("""
         SELECT new me.bombom.api.v1.challenge.dto.ChallengeParticipantCount(p.challengeId, COUNT(p.id))
@@ -19,5 +22,5 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
     """)
     List<ChallengeParticipantCount> countByChallengeIdInGroupByChallengeId(@Param("challengeIds") List<Long> challengeIds);
     
-    List<ChallengeParticipant> findAllByMemberId(Long memberId);
+    List<ChallengeParticipant> findByMemberIdAndChallengeIdIn(Long memberId, List<Long> challengeIds);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -1,7 +1,7 @@
 package me.bombom.api.v1.challenge.repository;
 
-import java.util.Optional;
 import java.util.List;
+import java.util.Optional;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.ChallengeParticipantCount;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,9 +10,9 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChallengeParticipantRepository extends JpaRepository<ChallengeParticipant, Long> {
 
-    long countByChallengeId(Long challengeId);
-
     boolean existsByChallengeIdAndMemberId(Long challengeId, Long memberId);
+
+    Optional<ChallengeParticipant> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
 
     @Query("""
         SELECT new me.bombom.api.v1.challenge.dto.ChallengeParticipantCount(p.challengeId, COUNT(p.id))
@@ -21,8 +21,6 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
         GROUP BY p.challengeId
     """)
     List<ChallengeParticipantCount> countByChallengeIdInGroupByChallengeId(@Param("challengeIds") List<Long> challengeIds);
-
-    List<ChallengeParticipant> findAllByMemberId(Long memberId);
-
-    Optional<ChallengeParticipant> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
+    
+    List<ChallengeParticipant> findByMemberIdAndChallengeIdIn(Long memberId, List<Long> challengeIds);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.challenge.repository;
 
+import java.util.Optional;
 import java.util.List;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.ChallengeParticipantCount;
@@ -8,7 +9,9 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ChallengeParticipantRepository extends JpaRepository<ChallengeParticipant, Long> {
-    
+
+    long countByChallengeId(Long challengeId);
+
     boolean existsByChallengeIdAndMemberId(Long challengeId, Long memberId);
 
     @Query("""
@@ -18,6 +21,8 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
         GROUP BY p.challengeId
     """)
     List<ChallengeParticipantCount> countByChallengeIdInGroupByChallengeId(@Param("challengeIds") List<Long> challengeIds);
-    
+
     List<ChallengeParticipant> findAllByMemberId(Long memberId);
+
+    Optional<ChallengeParticipant> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -1,0 +1,44 @@
+package me.bombom.api.v1.challenge.service;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.dto.request.ChallengeCommentOptionsRequest;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorContextKeys;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeCommentService {
+
+    private final ChallengeCommentRepository challengeCommentRepository;
+    private final ChallengeParticipantRepository challengeParticipantRepository;
+
+    public Page<ChallengeCommentResponse> getChallengeComments(
+            Long challengeId,
+            Long memberId,
+            ChallengeCommentOptionsRequest request,
+            Pageable pageable
+    ){
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
+        return challengeCommentRepository.findAllByTeamInDuration(
+                participant.getChallengeTeamId(),
+                memberId,
+                request.start(),
+                request.end(),
+                pageable
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -102,6 +102,12 @@ public class ChallengeService {
                         .addContext(ErrorContextKeys.OPERATION, "applyChallenge"));
 
         EligibilityReason reason = validateEligibility(challenge, challengeId, member.getId());
+
+        if (reason == EligibilityReason.ALREADY_APPLIED) {
+            log.debug("챌린지 신청 중복 요청 - challengeId={}, memberId={}", challengeId, member.getId());
+            return;
+        }
+        
         if (reason != EligibilityReason.ELIGIBLE) {
             throw createApplyException(challengeId, member, reason);
         }
@@ -207,12 +213,6 @@ public class ChallengeService {
             return new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                     .addContext(ErrorContextKeys.OPERATION, "applyChallenge");
-        }
-        if (reason == EligibilityReason.ALREADY_APPLIED) {
-            return new CIllegalArgumentException(ErrorDetail.DUPLICATED_DATA)
-                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
-                    .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
-                    .addContext("challengeId", challengeId);
         }
         if (reason == EligibilityReason.NOT_SUBSCRIBED) {
             return new CIllegalArgumentException(ErrorDetail.PRECONDITION_FAILED)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -27,15 +27,17 @@ import me.bombom.api.v1.challenge.repository.ChallengeRepository;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.common.exception.UnauthorizedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ChallengeService {
 
     // TODO: 이후에 수료 처리 등 구현 시 관리 방법 고려
@@ -57,7 +59,7 @@ public class ChallengeService {
 
         Map<Long, Long> participantCounts = getParticipantCounts(challengeIds);
         Map<Long, List<ChallengeNewsletterResponse>> newslettersByChallengeId = getNewslettersByChallengeId(challengeIds);
-        Map<Long, ChallengeParticipant> myParticipation = findMyParticipation(member);
+        Map<Long, ChallengeParticipant> myParticipation = findMyParticipation(member, challengeIds);
 
         return challenges.stream()
                 .map(challenge -> toChallengeResponse(
@@ -88,21 +90,99 @@ public class ChallengeService {
             return new ChallengeEligibilityResponse(false, EligibilityReason.NOT_LOGGED_IN);
         }
 
+        EligibilityReason reason = validateEligibility(challenge, challengeId, member.getId());
+        return new ChallengeEligibilityResponse(reason == EligibilityReason.ELIGIBLE, reason);
+    }
+
+    @Transactional
+    public void applyChallenge(Long challengeId, Member member) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                        .addContext(ErrorContextKeys.OPERATION, "applyChallenge"));
+
+        EligibilityReason reason = validateEligibility(challenge, challengeId, member.getId());
+        if (reason != EligibilityReason.ELIGIBLE) {
+            throw createApplyException(challengeId, member, reason);
+        }
+
+        ChallengeParticipant participant = ChallengeParticipant.builder()
+                .challengeId(challengeId)
+                .memberId(member.getId())
+                .build();
+
+        challengeParticipantRepository.save(participant);
+    }
+
+    private RuntimeException createApplyException(Long challengeId, Member member, EligibilityReason reason) {
+        if (reason == EligibilityReason.NOT_LOGGED_IN) {
+            return new UnauthorizedException(ErrorDetail.UNAUTHORIZED)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                    .addContext(ErrorContextKeys.OPERATION, "applyChallenge");
+        }
+        if (reason == EligibilityReason.ALREADY_STARTED) {
+            return new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                    .addContext(ErrorContextKeys.OPERATION, "applyChallenge");
+        }
+        if (reason == EligibilityReason.ALREADY_APPLIED) {
+            return new CIllegalArgumentException(ErrorDetail.DUPLICATED_DATA)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                    .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
+                    .addContext("challengeId", challengeId);
+        }
+        if (reason == EligibilityReason.NOT_SUBSCRIBED) {
+            return new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                    .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
+                    .addContext("challengeId", challengeId);
+        }
+        return new CServerErrorException(ErrorDetail.INTERNAL_SERVER_ERROR)
+                .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                .addContext(ErrorContextKeys.OPERATION, "applyChallenge")
+                .addContext("reason", "ELIGIBLE 상태에서는 예외를 생성할 수 없습니다.");
+    }
+
+    @Transactional
+    public void cancelChallenge(Long challengeId, Member member) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                        .addContext(ErrorContextKeys.OPERATION, "cancelChallenge"));
+
         if (challenge.hasStarted(LocalDate.now())) {
-            return new ChallengeEligibilityResponse(false, EligibilityReason.ALREADY_STARTED);
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                    .addContext(ErrorContextKeys.OPERATION, "cancelChallenge")
+                    .addContext("reason", "이미 시작된 챌린지는 취소할 수 없습니다.");
         }
 
-        boolean alreadyApplied = challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, member.getId());
+        ChallengeParticipant participant = challengeParticipantRepository
+                .findByChallengeIdAndMemberId(challengeId, member.getId())
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                        .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
+                        .addContext("challengeId", challengeId));
+
+        challengeParticipantRepository.delete(participant);
+    }
+
+    private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
+        if (challenge.hasStarted(LocalDate.now())) {
+            return EligibilityReason.ALREADY_STARTED;
+        }
+
+        boolean alreadyApplied = challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId);
         if (alreadyApplied) {
-            return new ChallengeEligibilityResponse(false, EligibilityReason.ALREADY_APPLIED);
+            return EligibilityReason.ALREADY_APPLIED;
         }
 
-        boolean hasSubscribedNewsletter = challengeNewsletterRepository.existsSubscribedNewsletter(challengeId, member.getId());
+        boolean hasSubscribedNewsletter = challengeNewsletterRepository.existsSubscribedNewsletter(challengeId, memberId);
         if (!hasSubscribedNewsletter) {
-            return new ChallengeEligibilityResponse(false, EligibilityReason.NOT_SUBSCRIBED);
+            return EligibilityReason.NOT_SUBSCRIBED;
         }
 
-        return new ChallengeEligibilityResponse(true, EligibilityReason.ELIGIBLE);
+        return EligibilityReason.ELIGIBLE;
     }
 
     private ChallengeResponse toChallengeResponse(
@@ -129,11 +209,11 @@ public class ChallengeService {
                 .collect(toMap(ChallengeParticipantCount::challengeId, ChallengeParticipantCount::count));
     }
 
-    private Map<Long, ChallengeParticipant> findMyParticipation(Member member) {
+    private Map<Long, ChallengeParticipant> findMyParticipation(Member member, List<Long> challengeIds) {
         if (member == null) {
             return Collections.emptyMap();
         }
-        return challengeParticipantRepository.findAllByMemberId(member.getId())
+        return challengeParticipantRepository.findByMemberIdAndChallengeIdIn(member.getId(), challengeIds)
                 .stream()
                 .collect(toMap(ChallengeParticipant::getChallengeId, p -> p));
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -215,7 +215,7 @@ public class ChallengeService {
                     .addContext("challengeId", challengeId);
         }
         if (reason == EligibilityReason.NOT_SUBSCRIBED) {
-            return new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+            return new CIllegalArgumentException(ErrorDetail.PRECONDITION_FAILED)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                     .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
                     .addContext("challengeId", challengeId);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/ErrorDetail.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/ErrorDetail.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorDetail {
 
     /*
-    * M : 모두 사용
-    */
+     * M : 모두 사용
+     */
     INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "M001", "잘못된 입력값입니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "M002", "허용되지 않는 접근입니다."),
     ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "M003", "존재하지 않는 데이터입니다."),
@@ -22,10 +22,11 @@ public enum ErrorDetail {
     DUPLICATED_DATA(HttpStatus.BAD_REQUEST, "M009", "이미 존재하는 데이터입니다."),
     BLANK_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "M010", "공백은 허용하지 않습니다"),
     INVALID_REQUEST_BODY_VALIDATION(HttpStatus.BAD_REQUEST, "M011", "요청 바디 유효성이 맞지 않습니다."),
+    PRECONDITION_FAILED(HttpStatus.BAD_REQUEST, "M012", "사전 조건을 만족하지 않습니다."),
 
     /*
-    * J : 인증
-    */
+     * J : 인증
+     */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "J001", "로그인이 필요합니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "J002", "유효하지 않은 인증 정보입니다. 다시 로그인 해주세요."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "J003", "유효하지 않은 인증 정보입니다. 다시 로그인 해주세요."),
@@ -38,7 +39,7 @@ public enum ErrorDetail {
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "J009", "잘못된 이메일 형식입니다."),
 
     /*
-    * G : 인가
+     * G : 인가
      */
     FORBIDDEN_RESOURCE(HttpStatus.FORBIDDEN, "A001", "접근 권한이 없는 리소스입니다."),
     ;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
@@ -7,7 +7,9 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
+import jakarta.validation.ConstraintViolationException;
 
 @Slf4j
 @RestControllerAdvice

--- a/backend/bom-bom-server/src/main/resources/db/migration/V16.0.1__add_quotation_column_to_challenge_comment.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V16.0.1__add_quotation_column_to_challenge_comment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge_comment
+    ADD COLUMN quotation VARCHAR(255) NULL AFTER participant_id;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V16.0.2__update_challenge_comment_columns.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V16.0.2__update_challenge_comment_columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE challenge_comment
+    DROP COLUMN article_id,
+    ADD COLUMN newsletter_id BIGINT NOT NULL AFTER id,
+    ADD COLUMN article_title VARCHAR(255) NOT NULL;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -5,6 +5,7 @@ import java.util.List;
 import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.domain.RecentArticle;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeComment;
 import me.bombom.api.v1.challenge.domain.ChallengeNewsletter;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.highlight.domain.Color;
@@ -534,6 +535,22 @@ public final class TestFixture {
                 .build();
     }
 
+    public static ChallengeParticipant createChallengeParticipantWithTeam(
+            Long challengeId,
+            Long memberId,
+            Long challengeTeamId,
+            int completedDays,
+            int shield
+    ) {
+        return ChallengeParticipant.builder()
+                .challengeId(challengeId)
+                .memberId(memberId)
+                .challengeTeamId(challengeTeamId)
+                .completedDays(completedDays)
+                .shield(shield)
+                .build();
+    }
+
     /**
      * ChallengeNewsletter
      */
@@ -544,6 +561,25 @@ public final class TestFixture {
         return ChallengeNewsletter.builder()
                 .challengeId(challengeId)
                 .newsletterId(newsletterId)
+                .build();
+    }
+
+    /**
+     * ChallengeComment
+     */
+    public static ChallengeComment createChallengeComment(
+            Long newsletterId,
+            Long participantId,
+            String articleTitle,
+            String quotation,
+            String comment
+    ) {
+        return ChallengeComment.builder()
+                .newsletterId(newsletterId)
+                .participantId(participantId)
+                .articleTitle(articleTitle)
+                .quotation(quotation)
+                .comment(comment)
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
@@ -1,0 +1,151 @@
+package me.bombom.api.v1.challenge.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.article.domain.Article;
+import me.bombom.api.v1.article.repository.ArticleRepository;
+import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.domain.Category;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.domain.NewsletterDetail;
+import me.bombom.api.v1.newsletter.repository.CategoryRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterDetailRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class ChallengeCommentControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ChallengeCommentRepository challengeCommentRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private NewsletterRepository newsletterRepository;
+
+    @Autowired
+    private NewsletterDetailRepository newsletterDetailRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+    private OAuth2AuthenticationToken authToken;
+
+    @BeforeEach
+    void setUp() {
+        challengeCommentRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        articleRepository.deleteAllInBatch();
+        newsletterRepository.deleteAllInBatch();
+        newsletterDetailRepository.deleteAllInBatch();
+        categoryRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+        var attributes = java.util.Map.<String, Object>of(
+                "id", member.getId().toString(),
+                "email", member.getEmail(),
+                "name", member.getNickname()
+        );
+        CustomOAuth2User principal = new CustomOAuth2User(attributes, member, null, null);
+        authToken = new OAuth2AuthenticationToken(
+                principal,
+                principal.getAuthorities(),
+                "registrationId"
+        );
+
+        List<Category> categories = TestFixture.createCategories();
+        categoryRepository.saveAll(categories);
+
+        List<NewsletterDetail> details = TestFixture.createNewsletterDetails();
+        newsletterDetailRepository.saveAll(details);
+
+        List<Newsletter> newsletters = TestFixture.createNewslettersWithDetails(categories, details);
+        newsletterRepository.saveAll(newsletters);
+
+        Article article = TestFixture.createArticles(member, newsletters).get(0);
+        articleRepository.save(article);
+
+        ChallengeParticipant participant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipantWithTeam(
+                        1L,
+                        member.getId(),
+                        10L,
+                        0,
+                        0
+                )
+        );
+
+        challengeCommentRepository.save(
+                TestFixture.createChallengeComment(
+                        article.getNewsletterId(),
+                        participant.getId(),
+                        article.getTitle(),
+                        "quote",
+                        "comment"
+                )
+        );
+    }
+
+    @Test
+    void 챌린지_팀_댓글을_기간으로_필터링해_조회한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/comments", 1L)
+                        .param("start", LocalDate.now().minusDays(1).toString())
+                        .param("end", LocalDate.now().plusDays(1).toString())
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                authToken))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].comment").value("comment"))
+                .andExpect(jsonPath("$.totalElements").value(1));
+    }
+
+    @Test
+    void id가_1_미만이면_400을_응답한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/comments", 0L)
+                        .param("start", LocalDate.now().toString())
+                        .param("end", LocalDate.now().toString())
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(
+                                authToken))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerUnitTest.java
@@ -1,7 +1,9 @@
 package me.bombom.api.v1.challenge.controller;
 
 import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -15,11 +17,16 @@ import me.bombom.api.v1.member.domain.Member;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.MethodParameter;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.support.WebDataBinderFactory;
@@ -34,7 +41,16 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 class ChallengeControllerUnitTest {
 
     @Configuration
+    @EnableWebSecurity
     static class TestConfig implements WebMvcConfigurer {
+
+        @Bean
+        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
 
         @Override
         public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
@@ -100,6 +116,22 @@ class ChallengeControllerUnitTest {
     void 챌린지_신청_가능_여부를_요청시_음수_id면_400() throws Exception {
         //when & then
         mockMvc.perform(get("/api/v1/challenges/{id}/eligibility", -1L))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 챌린지_신청시_음수_id면_400() throws Exception {
+        //when & then
+        mockMvc.perform(post("/api/v1/challenges/{id}/application", -1L))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 챌린지_취소시_음수_id면_400() throws Exception {
+        //when & then
+        mockMvc.perform(delete("/api/v1/challenges/{id}/application", -1L))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
@@ -1,0 +1,185 @@
+package me.bombom.api.v1.challenge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.article.domain.Article;
+import me.bombom.api.v1.article.repository.ArticleRepository;
+import me.bombom.api.v1.challenge.domain.ChallengeComment;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.dto.request.ChallengeCommentOptionsRequest;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.domain.Category;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.domain.NewsletterDetail;
+import me.bombom.api.v1.newsletter.repository.CategoryRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterDetailRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@IntegrationTest
+class ChallengeCommentServiceTest {
+
+    @Autowired
+    private ChallengeCommentService challengeCommentService;
+
+    @Autowired
+    private ChallengeCommentRepository challengeCommentRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private NewsletterRepository newsletterRepository;
+
+    @Autowired
+    private NewsletterDetailRepository newsletterDetailRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+    private Article article;
+    private ChallengeParticipant participant;
+
+    @BeforeEach
+    void setUp() {
+        challengeCommentRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        articleRepository.deleteAllInBatch();
+        newsletterRepository.deleteAllInBatch();
+        newsletterDetailRepository.deleteAllInBatch();
+        categoryRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        List<Category> categories = TestFixture.createCategories();
+        categoryRepository.saveAll(categories);
+
+        List<NewsletterDetail> details = TestFixture.createNewsletterDetails();
+        newsletterDetailRepository.saveAll(details);
+
+        List<Newsletter> newsletters = TestFixture.createNewslettersWithDetails(categories, details);
+        newsletterRepository.saveAll(newsletters);
+
+        article = TestFixture.createArticles(member, newsletters).get(0);
+        articleRepository.save(article);
+
+        participant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipantWithTeam(
+                        1L,
+                        member.getId(),
+                        10L,
+                        0,
+                        0
+                )
+        );
+    }
+
+    @Test
+    void 같은_팀_댓글만_기간_내_조회_성공() {
+        // given
+        LocalDate start = LocalDate.now().minusDays(1);
+        LocalDate end = LocalDate.now().plusDays(1);
+
+        Member otherMember = TestFixture.createMemberFixture("other@bombom.news", "other");
+        memberRepository.save(otherMember);
+
+        ChallengeParticipant otherTeamParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipantWithTeam(
+                        2L,
+                        otherMember.getId(),
+                        20L,
+                        0,
+                        0
+                )
+        );
+
+        ChallengeComment otherTeamComment = challengeCommentRepository.save(
+                TestFixture.createChallengeComment(
+                        article.getNewsletterId(),
+                        participant.getId(),
+                        article.getTitle(),
+                        "quote",
+                        "우리 팀 댓글"
+                )
+        );
+
+        challengeCommentRepository.save(
+                TestFixture.createChallengeComment(
+                        article.getNewsletterId(),
+                        otherTeamParticipant.getId(),
+                        article.getTitle(),
+                        "quote2",
+                        "다른 팀 댓글"
+                )
+        );
+
+        // when
+        Page<ChallengeCommentResponse> result = challengeCommentService.getChallengeComments(
+                1L,
+                member.getId(),
+                new ChallengeCommentOptionsRequest(start, end),
+                PageRequest.of(0, 10)
+        );
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).comment()).isEqualTo(otherTeamComment.getComment());
+    }
+
+    @Test
+    void 요청_기간에_댓글이_없으면_빈_페이지를_반환한다() {
+        // given
+        LocalDate start = LocalDate.now().plusDays(1);
+        LocalDate end = LocalDate.now().plusDays(2);
+
+        // when
+        Page<ChallengeCommentResponse> result = challengeCommentService.getChallengeComments(
+                1L,
+                member.getId(),
+                new ChallengeCommentOptionsRequest(start, end),
+                PageRequest.of(0, 10)
+        );
+
+        // then
+        assertThat(result.getTotalElements()).isZero();
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void 챌린지_참가자가_아니면_예외_발생() {
+        // given
+        LocalDate start = LocalDate.now().minusDays(1);
+        LocalDate end = LocalDate.now().plusDays(1);
+
+        // when & then
+        assertThatThrownBy(() -> challengeCommentService.getChallengeComments(
+                99L,
+                member.getId(),
+                new ChallengeCommentOptionsRequest(start, end),
+                PageRequest.of(0, 10)
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -465,4 +465,140 @@ class ChallengeServiceTest {
                 .isInstanceOf(CIllegalArgumentException.class)
                 .hasMessage(ErrorDetail.ENTITY_NOT_FOUND.getMessage());
     }
+
+    @Test
+    void 모든_조건을_만족하는_챌린지_신청() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        ChallengeNewsletter challengeNewsletter = TestFixture.createChallengeNewsletter(challenge.getId(), newsletters.get(0).getId());
+        challengeNewsletterRepository.save(challengeNewsletter);
+
+        Subscribe subscribe = TestFixture.createSubscribe(newsletters.get(0), member);
+        subscribeRepository.save(subscribe);
+
+        // when
+        challengeService.applyChallenge(challenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(challengeParticipantRepository.existsByChallengeIdAndMemberId(challenge.getId(), member.getId())).isTrue();
+        });
+    }
+
+    @Test
+    void 존재하지_않는_챌린지_ID로_신청_시_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> challengeService.applyChallenge(0L, member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasMessage(ErrorDetail.ENTITY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 이미_시작된_챌린지_신청_시_예외가_발생한다() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.minusDays(5), today.plusDays(10));
+        challengeRepository.save(challenge);
+
+        ChallengeNewsletter challengeNewsletter = TestFixture.createChallengeNewsletter(challenge.getId(), newsletters.get(0).getId());
+        challengeNewsletterRepository.save(challengeNewsletter);
+
+        Subscribe subscribe = TestFixture.createSubscribe(newsletters.get(0), member);
+        subscribeRepository.save(subscribe);
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.applyChallenge(challenge.getId(), member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasMessage(ErrorDetail.INVALID_INPUT_VALUE.getMessage());
+    }
+
+    @Test
+    void 이미_신청한_챌린지_신청_시_예외가_발생한다() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        ChallengeParticipant participant = TestFixture.createChallengeParticipant(challenge.getId(), member.getId(), 0, true);
+        challengeParticipantRepository.save(participant);
+
+        ChallengeNewsletter challengeNewsletter = TestFixture.createChallengeNewsletter(challenge.getId(), newsletters.get(0).getId());
+        challengeNewsletterRepository.save(challengeNewsletter);
+
+        Subscribe subscribe = TestFixture.createSubscribe(newsletters.get(0), member);
+        subscribeRepository.save(subscribe);
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.applyChallenge(challenge.getId(), member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasMessage(ErrorDetail.DUPLICATED_DATA.getMessage());
+    }
+
+    @Test
+    void 구독하지_않은_뉴스레터를_가진_챌린지_신청_시_예외가_발생한다() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        ChallengeNewsletter challengeNewsletter = TestFixture.createChallengeNewsletter(challenge.getId(), newsletters.get(0).getId());
+        challengeNewsletterRepository.save(challengeNewsletter);
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.applyChallenge(challenge.getId(), member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasMessage(ErrorDetail.INVALID_INPUT_VALUE.getMessage());
+    }
+
+    @Test
+    void 신청한_챌린지_취소() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        ChallengeParticipant participant = TestFixture.createChallengeParticipant(challenge.getId(), member.getId(), 0, true);
+        challengeParticipantRepository.save(participant);
+
+        // when
+        challengeService.cancelChallenge(challenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(challengeParticipantRepository.existsByChallengeIdAndMemberId(challenge.getId(), member.getId())).isFalse();
+        });
+    }
+
+    @Test
+    void 존재하지_않는_챌린지_ID로_취소_시_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> challengeService.cancelChallenge(0L, member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasMessage(ErrorDetail.ENTITY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 이미_시작된_챌린지_취소_시_예외가_발생한다() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.minusDays(5), today.plusDays(10));
+        challengeRepository.save(challenge);
+
+        ChallengeParticipant participant = TestFixture.createChallengeParticipant(challenge.getId(), member.getId(), 5, true);
+        challengeParticipantRepository.save(participant);
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.cancelChallenge(challenge.getId(), member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasMessage(ErrorDetail.INVALID_INPUT_VALUE.getMessage());
+    }
+
+    @Test
+    void 신청하지_않은_챌린지_취소_시_예외가_발생한다() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        // when & then
+        assertThatThrownBy(() -> challengeService.cancelChallenge(challenge.getId(), member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasMessage(ErrorDetail.ENTITY_NOT_FOUND.getMessage());
+    }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -514,13 +514,14 @@ class ChallengeServiceTest {
     }
 
     @Test
-    void 이미_신청한_챌린지_신청_시_예외가_발생한다() {
+    void 이미_신청한_챌린지_신청_시_정상_반환한다() {
         // given
         Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
         challengeRepository.save(challenge);
 
         ChallengeParticipant participant = TestFixture.createChallengeParticipant(challenge.getId(), member.getId(), 0, true);
         challengeParticipantRepository.save(participant);
+        long countBefore = challengeParticipantRepository.count();
 
         ChallengeNewsletter challengeNewsletter = TestFixture.createChallengeNewsletter(challenge.getId(), newsletters.get(0).getId());
         challengeNewsletterRepository.save(challengeNewsletter);
@@ -528,10 +529,13 @@ class ChallengeServiceTest {
         Subscribe subscribe = TestFixture.createSubscribe(newsletters.get(0), member);
         subscribeRepository.save(subscribe);
 
-        // when & then
-        assertThatThrownBy(() -> challengeService.applyChallenge(challenge.getId(), member))
-                .isInstanceOf(CIllegalArgumentException.class)
-                .hasMessage(ErrorDetail.DUPLICATED_DATA.getMessage());
+        // when
+        challengeService.applyChallenge(challenge.getId(), member);
+        long countAfter = challengeParticipantRepository.count();
+
+        // then
+        assertThat(countBefore).isEqualTo(1);
+        assertThat(countAfter).isEqualTo(1); // 중복 신청되어도 개수 변경 없음
     }
 
     @Test

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -546,7 +546,7 @@ class ChallengeServiceTest {
         // when & then
         assertThatThrownBy(() -> challengeService.applyChallenge(challenge.getId(), member))
                 .isInstanceOf(CIllegalArgumentException.class)
-                .hasMessage(ErrorDetail.INVALID_INPUT_VALUE.getMessage());
+                .hasMessage(ErrorDetail.PRECONDITION_FAILED.getMessage());
     }
 
     @Test


### PR DESCRIPTION
[변경범위](https://github.com/woowacourse-teams/2025-bom-bom/pull/598/files/99b5ea77efbab3624230c93fc44fd515dee4d2fe..ec86a2cb98285f71082e87ed86bcfb42b773cefd)
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 신청 / 취소 API 추가
- POST /challenges/{id}/application
- DELETE /challenges/{id}/application

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 신청을 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
Eligibility 판단 로직 정리
- validateEligibility 메서드는 상태 판단만 담당하고 EligibilityReason을 반환
- 조회 API(checkEligibility)에서는 상태 응답으로 사용
- 신청 API(applyChallenge)에서는 상태에 따라 예외를 생성

챌린지 목록 조회 성능 개선
- 기존: member 기준 전체 참여 조회
- 변경: challengeId IN 기반 조회로 범위 제한

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
잘못된 로직 있는지 위주로 부탁드립니다
(Eligibility 판단 로직 부분을 Policy 같이 다른 객체로 분리해도 괜찮을 것 같다고 생각은 했는데, 시간 문제로 일단 서비스 내부에 다 구현 했습니다.)
