### PR TITLE
[BOM-811] feat: 아티클을 읽었을 때 챌린지 todo 업데이트

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
@@ -1,0 +1,25 @@
+package me.bombom.api.v1.challenge.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.article.event.MarkAsReadEvent;
+import me.bombom.api.v1.challenge.service.ChallengeDailyTodoService;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeParticipantTodoListener {
+
+    private final ChallengeDailyTodoService challengeDailyTodoService;
+
+    @TransactionalEventListener
+    public void on(MarkAsReadEvent event) {
+        try {
+            challengeDailyTodoService.updateChallengeDailyTodo(event.memberId());
+        } catch (Exception e) {
+            log.error("챌린지 데일리 투두 저장 중 오류가 발생했습니다. memberId={}", event.memberId(), e);
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
@@ -5,6 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.article.event.MarkAsReadEvent;
 import me.bombom.api.v1.challenge.service.ChallengeDailyTodoService;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
 @Slf4j
@@ -15,6 +17,7 @@ public class ChallengeParticipantTodoListener {
     private final ChallengeDailyTodoService challengeDailyTodoService;
 
     @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void on(MarkAsReadEvent event) {
         try {
             challengeDailyTodoService.updateChallengeDailyTodo(event.memberId());

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
@@ -1,7 +1,30 @@
 package me.bombom.api.v1.challenge.repository;
 
+import java.time.LocalDate;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyTodo;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChallengeDailyTodoRepository extends JpaRepository<ChallengeDailyTodo, Long> {
+
+    @Modifying
+    @Query(value = """
+                insert ignore into challenge_daily_todo(participant_id, challenge_todo_id, todo_date)
+                select cp.id, ct.id, :today
+                from challenge_participant cp
+                join challenge c on c.id = cp.challenge_id
+                join challenge_todo ct on ct.challenge_id = cp.challenge_id and ct.todo_type = 'READ'
+                left join challenge_daily_todo dt
+                    on dt.participant_id = cp.id
+                   and dt.challenge_todo_id = ct.id
+                   and dt.todo_date = :today
+                where cp.member_id = :memberId
+                  and :today between c.start_date and c.end_date
+                  and cp.is_survived = true
+                  and dt.id is null
+            """, nativeQuery = true)
+    int insertTodayReadTodoIfMissing(@Param("memberId") Long memberId,
+                                     @Param("today") LocalDate today);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
@@ -27,5 +27,7 @@ public interface ChallengeDailyTodoRepository extends JpaRepository<ChallengeDai
             """, nativeQuery = true)
     int insertTodayReadTodoIfMissing(@Param("memberId") Long memberId,
                                      @Param("today") LocalDate today);
-    boolean existsByParticipantIdAndTodoDateAndChallengeTodoId(Long participantId, LocalDate todoDate, Long challengeTodoId);
+
+    boolean existsByParticipantIdAndTodoDateAndChallengeTodoId(Long participantId, LocalDate todoDate,
+                                                               Long challengeTodoId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
@@ -11,19 +11,19 @@ public interface ChallengeDailyTodoRepository extends JpaRepository<ChallengeDai
 
     @Modifying
     @Query(value = """
-                insert ignore into challenge_daily_todo(participant_id, challenge_todo_id, todo_date)
-                select cp.id, ct.id, :today
-                from challenge_participant cp
-                join challenge c on c.id = cp.challenge_id
-                join challenge_todo ct on ct.challenge_id = cp.challenge_id and ct.todo_type = 'READ'
-                left join challenge_daily_todo dt
-                    on dt.participant_id = cp.id
-                   and dt.challenge_todo_id = ct.id
-                   and dt.todo_date = :today
-                where cp.member_id = :memberId
-                  and :today between c.start_date and c.end_date
-                  and cp.is_survived = true
-                  and dt.id is null
+                INSERT IGNORE INTO challenge_daily_todo(participant_id, challenge_todo_id, todo_date)
+                SELECT cp.id, ct.id, :today
+                FROM challenge_participant cp
+                JOIN challenge c ON c.id = cp.challenge_id
+                JOIN challenge_todo ct ON ct.challenge_id = cp.challenge_id AND ct.todo_type = 'READ'
+                LEFT JOIN challenge_daily_todo dt
+                    ON dt.participant_id = cp.id
+                   AND dt.challenge_todo_id = ct.id
+                   AND dt.todo_date = :today
+                WHERE cp.member_id = :memberId
+                  AND :today BETWEEN c.start_date AND c.end_date
+                  AND cp.is_survived = true
+                  AND dt.id IS NULL
             """, nativeQuery = true)
     int insertTodayReadTodoIfMissing(@Param("memberId") Long memberId,
                                      @Param("today") LocalDate today);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
@@ -15,7 +15,7 @@ public interface ChallengeDailyTodoRepository extends JpaRepository<ChallengeDai
                 SELECT cp.id, ct.id, :today
                 FROM challenge_participant cp
                 JOIN challenge c ON c.id = cp.challenge_id
-                JOIN challenge_todo ct ON ct.challenge_id = cp.challenge_id AND ct.todo_type = 'READ'
+                JOIN challenge_todo ct ON ct.challenge_id = cp.challenge_id AND ct.todo_type = :todoType
                 LEFT JOIN challenge_daily_todo dt
                     ON dt.participant_id = cp.id
                    AND dt.challenge_todo_id = ct.id
@@ -26,7 +26,8 @@ public interface ChallengeDailyTodoRepository extends JpaRepository<ChallengeDai
                   AND dt.id IS NULL
             """, nativeQuery = true)
     int insertTodayReadTodoIfMissing(@Param("memberId") Long memberId,
-                                     @Param("today") LocalDate today);
+                                     @Param("today") LocalDate today,
+                                     @Param("todoType") String todoType);
 
     boolean existsByParticipantIdAndTodoDateAndChallengeTodoId(Long participantId, LocalDate todoDate,
                                                                Long challengeTodoId);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
@@ -1,0 +1,22 @@
+package me.bombom.api.v1.challenge.service;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeDailyTodoService {
+
+    private final ChallengeDailyTodoRepository challengeDailyTodoRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void updateChallengeDailyTodo(Long memberId) {
+        LocalDate today = LocalDate.now();
+        challengeDailyTodoRepository.insertTodayReadTodoIfMissing(memberId, today);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -14,7 +13,7 @@ public class ChallengeDailyTodoService {
 
     private final ChallengeDailyTodoRepository challengeDailyTodoRepository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void updateChallengeDailyTodo(Long memberId) {
         LocalDate today = LocalDate.now();
         challengeDailyTodoRepository.insertTodayReadTodoIfMissing(memberId, today);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.challenge.service;
 
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +17,6 @@ public class ChallengeDailyTodoService {
     @Transactional
     public void updateChallengeDailyTodo(Long memberId) {
         LocalDate today = LocalDate.now();
-        challengeDailyTodoRepository.insertTodayReadTodoIfMissing(memberId, today);
+        challengeDailyTodoRepository.insertTodayReadTodoIfMissing(memberId, today, ChallengeTodoType.READ.name());
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
@@ -18,7 +18,6 @@ import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.support.IntegrationTest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,17 +51,14 @@ class ChallengeDailyTodoServiceTest {
     private Challenge challenge;
     private ChallengeTodo readTodo;
 
-    @AfterEach
-    void tearDown() {
+    @BeforeEach
+    void setUp() {
         challengeDailyTodoRepository.deleteAllInBatch();
         challengeTodoRepository.deleteAllInBatch();
         challengeParticipantRepository.deleteAllInBatch();
         challengeRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
-    }
 
-    @BeforeEach
-    void setUp() {
         member = memberRepository.save(TestFixture.createUniqueMember("tester", "12345"));
 
         LocalDate today = LocalDate.now();
@@ -98,8 +94,13 @@ class ChallengeDailyTodoServiceTest {
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
-        // then
-        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll();
+        // then - 특정 멤버와 챌린지에 대한 todo만 확인
+        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
+                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
+                .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
+                .filter(todo -> todo.getTodoDate().equals(today))
+                .toList();
+
         assertSoftly(softly -> {
             softly.assertThat(dailyTodos).hasSize(1);
             softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
@@ -129,8 +130,13 @@ class ChallengeDailyTodoServiceTest {
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
-        // then
-        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll();
+        // then - 특정 멤버와 챌린지에 대한 todo만 확인
+        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
+                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
+                .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
+                .filter(todo -> todo.getTodoDate().equals(today))
+                .toList();
+
         assertSoftly(softly -> {
             softly.assertThat(dailyTodos).hasSize(1);
             softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
@@ -1,0 +1,141 @@
+package me.bombom.api.v1.challenge.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.article.event.MarkAsReadEvent;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyTodo;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.ChallengeTodo;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.transaction.TestTransaction;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@IntegrationTest
+class ChallengeDailyTodoServiceTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ChallengeTodoRepository challengeTodoRepository;
+
+    @Autowired
+    private ChallengeDailyTodoRepository challengeDailyTodoRepository;
+
+    private Member member;
+    private Challenge challenge;
+    private ChallengeTodo readTodo;
+
+    @AfterEach
+    void tearDown() {
+        challengeDailyTodoRepository.deleteAllInBatch();
+        challengeTodoRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @BeforeEach
+    void setUp() {
+        member = memberRepository.save(TestFixture.createUniqueMember("tester", "12345"));
+
+        LocalDate today = LocalDate.now();
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "테스트 챌린지",
+                today.minusDays(5),
+                today.plusDays(5),
+                10
+        ));
+
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member.getId(),
+                        0
+                )
+        );
+
+        readTodo = challengeTodoRepository.save(
+                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
+        );
+    }
+
+    @Test
+    void 아티클_읽기시_챌린지_투두_업데이트() {
+        // given
+        LocalDate today = LocalDate.now();
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                challenge.getId(), member.getId()).orElseThrow();
+
+        // when
+        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), 1L));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then
+        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll();
+        assertSoftly(softly -> {
+            softly.assertThat(dailyTodos).hasSize(1);
+            softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
+            softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
+            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(today);
+        });
+    }
+
+    @Test
+    void 이미_존재하는_챌린지_투두_중복_생성_안함() {
+        // given
+        LocalDate today = LocalDate.now();
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                challenge.getId(), member.getId()).orElseThrow();
+
+        // 기존 todo 생성
+        challengeDailyTodoRepository.save(
+                TestFixture.createChallengeDailyTodo(
+                        participant.getId(),
+                        today,
+                        readTodo.getId()
+                )
+        );
+
+        // when
+        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), 1L));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then
+        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll();
+        assertSoftly(softly -> {
+            softly.assertThat(dailyTodos).hasSize(1);
+            softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
+            softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
+            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(today);
+        });
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
@@ -25,7 +25,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @IntegrationTest
 class ChallengeDailyTodoServiceTest {
 
@@ -83,6 +82,7 @@ class ChallengeDailyTodoServiceTest {
     }
 
     @Test
+    @Transactional
     void 아티클_읽기시_챌린지_투두_업데이트() {
         // given
         LocalDate today = LocalDate.now();
@@ -110,6 +110,7 @@ class ChallengeDailyTodoServiceTest {
     }
 
     @Test
+    @Transactional
     void 이미_존재하는_챌린지_투두_중복_생성_안함() {
         // given
         LocalDate today = LocalDate.now();

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -32,7 +32,6 @@ import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.support.IntegrationTest;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -67,8 +66,8 @@ class ChallengeProgressServiceTest {
     private Member member;
     private Challenge challenge;
 
-    @AfterEach
-    void tearDown() {
+    @BeforeEach
+    void setUp() {
         challengeDailyResultRepository.deleteAllInBatch();
         challengeDailyTodoRepository.deleteAllInBatch();
         challengeTodoRepository.deleteAllInBatch();
@@ -76,10 +75,7 @@ class ChallengeProgressServiceTest {
         challengeTeamRepository.deleteAllInBatch();
         challengeRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
-    }
 
-    @BeforeEach
-    void setUp() {
         member = memberRepository.save(
                 TestFixture.createUniqueMember("tester", java.util.UUID.randomUUID().toString()));
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -33,14 +33,6 @@ import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.support.IntegrationTest;
 import org.junit.jupiter.api.AfterEach;
-import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
-import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
-import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
-import me.bombom.api.v1.challenge.repository.ChallengeRepository;
-import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
-import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.member.repository.MemberRepository;
-import me.bombom.support.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,7 +80,8 @@ class ChallengeProgressServiceTest {
 
     @BeforeEach
     void setUp() {
-        member = memberRepository.save(TestFixture.createUniqueMember("tester", "12345"));
+        member = memberRepository.save(
+                TestFixture.createUniqueMember("tester", java.util.UUID.randomUUID().toString()));
 
         challenge = challengeRepository.save(TestFixture.createChallenge(
                 "Test Challenge",
@@ -119,7 +112,8 @@ class ChallengeProgressServiceTest {
     @Test
     void 유저의_챌린지_진행상황을_조회한다() {
         // when
-        MemberChallengeProgressResponse response = challengeProgressService.getMemberProgress(challenge.getId(), member);
+        MemberChallengeProgressResponse response = challengeProgressService.getMemberProgress(challenge.getId(),
+                member);
 
         // then
         assertSoftly(softly -> {
@@ -164,11 +158,16 @@ class ChallengeProgressServiceTest {
                         true)
         );
 
-        ChallengeDailyResult result1 = createChallengeDailyResult(participant1.getId(), LocalDate.now(), ChallengeDailyStatus.SHIELD);
-        ChallengeDailyResult result2 = createChallengeDailyResult(participant1.getId(), LocalDate.now().plusDays(1), ChallengeDailyStatus.COMPLETE);
-        ChallengeDailyResult result3 = createChallengeDailyResult(participant2.getId(), LocalDate.now(), ChallengeDailyStatus.COMPLETE);
-        ChallengeDailyResult result4 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(1), ChallengeDailyStatus.SHIELD);
-        ChallengeDailyResult result5 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(2), ChallengeDailyStatus.COMPLETE);
+        ChallengeDailyResult result1 = createChallengeDailyResult(participant1.getId(), LocalDate.now(),
+                ChallengeDailyStatus.SHIELD);
+        ChallengeDailyResult result2 = createChallengeDailyResult(participant1.getId(), LocalDate.now().plusDays(1),
+                ChallengeDailyStatus.COMPLETE);
+        ChallengeDailyResult result3 = createChallengeDailyResult(participant2.getId(), LocalDate.now(),
+                ChallengeDailyStatus.COMPLETE);
+        ChallengeDailyResult result4 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(1),
+                ChallengeDailyStatus.SHIELD);
+        ChallengeDailyResult result5 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(2),
+                ChallengeDailyStatus.COMPLETE);
         challengeDailyResultRepository.saveAll(List.of(result1, result2, result3, result4, result5));
 
         // when
@@ -192,7 +191,8 @@ class ChallengeProgressServiceTest {
             softly.assertThat(responseB.dailyProgresses())
                     .hasSize(3)
                     .extracting("status")
-                    .containsExactlyInAnyOrder(ChallengeDailyStatus.COMPLETE, ChallengeDailyStatus.SHIELD, ChallengeDailyStatus.COMPLETE);
+                    .containsExactlyInAnyOrder(ChallengeDailyStatus.COMPLETE, ChallengeDailyStatus.SHIELD,
+                            ChallengeDailyStatus.COMPLETE);
 
             softly.assertThat(responseB.dailyProgresses())
                     .extracting("date")


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
아티클을 읽었을 때 챌린지 참가자만 읽기 체크가 되어야함

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 완료 조건을 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
아티클 “읽기” 이벤트는 모든 유저에게서 발생하지만, 챌린지 기능 관점에서는
(1) 진행 중 챌린지 참여자이면서 (2) 챌린지의 READ todo에 대해 (3) 오늘 첫 1회만 challenge_daily_todo를 생성해야 합니다.

기존처럼 “조회 → 존재 확인 → insert”를 분리하면
동시 요청(더블클릭/재시도/중복 이벤트)에서 레이스 컨디션이 생기기 쉽고
쿼리가 2번 이상 늘어나기 쉬워서
DB에서 멱등(idempotent) 하게 처리되도록 했습니다.

### case
- 챌린지 미참여: 대상 유저가가 없음 → insert 0건, 반환 0
- 참여 중이지만 오늘 READ 이미 처리됨: todo가 존재 → 조건에서 제외 → insert 0건, 반환 0
- 참여 중 & 오늘 첫 READ: 없는 만큼 생성 → insert N건(참여 중 챌린지 수만큼 가능), 반환 N
- 동시 실행(중복 이벤트/재시도): 둘 다 insert 시도해도 유니크 + insert ignore로 하나만 들어감 → 보통 반환 (1, 0)



### 쿼리가 조금 무겁지 않을까?

이 쿼리 하나로 처리하는 게 “무거워 보일 수”는 있는데, 실제 비용은 생각보다 크지 않습니다.
이 쿼리는 `where cp.member_id = :memberId`가 가장 먼저 범위를 확 줄여서, 챌린지 미참여자는 challenge_participant에서 0건으로 바로 종료됩니다. (테이블 전체를 도는 구조가 아닙니다.)
참여자만 대상으로 조인이 진행됩니다.

### 추후 개선 했으면 하는 것

로직을 짜면서 뭔가 챌린지의 카테고리가 있으면 좋을 것 같다는 생각을 했습니다.  
뉴스레터 한 달 읽기는 기수가 달라도 하나의 카테고리로 묶이면 쿼리짤 때 훨씬 더 단순해질 것 같습니다. 
지금은 추가하기에는 비용이 크고 시간이 없어서 일단 계획만 잡아두었습니다.


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
쿼리에서 실수한 부분이 없는지 확인해주세요. 