### PR TITLE
[BEM-826] feat: 데일리 가이드 api 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
@@ -1,0 +1,49 @@
+package me.bombom.api.v1.challenge.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
+import me.bombom.api.v1.challenge.service.ChallengeDailyGuideService;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/challenges")
+public class ChallengeDailyGuideController implements ChallengeDailyGuideControllerApi {
+
+    private final ChallengeDailyGuideService challengeDailyGuideService;
+
+    @Override
+    @GetMapping("/{challengeId}/daily-guides/today")
+    public TodayDailyGuideResponse getTodayDailyGuide(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId
+    ) {
+        return challengeDailyGuideService.getTodayDailyGuide(challengeId, member.getId());
+    }
+
+    @Override
+    @PostMapping("/{challengeId}/daily-guides/{dayIndex}/comment")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createDailyGuideComment(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
+            @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,
+            @Valid @RequestBody DailyGuideCommentRequest request
+    ) {
+        challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
@@ -1,0 +1,54 @@
+package me.bombom.api.v1.challenge.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Tag(name = "Challenge Daily Guide", description = "챌린지 데일리 가이드 관련 API")
+@ApiResponses({
+        @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content)
+})
+public interface ChallengeDailyGuideControllerApi {
+
+    @Operation(
+            summary = "오늘의 데일리 가이드 조회",
+            description = "특정 챌린지의 오늘 날짜에 해당하는 데일리 가이드를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "오늘의 데일리 가이드 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 ID)", content = @Content),
+            @ApiResponse(responseCode = "403", description = "챌린지 참여 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지 또는 데일리 가이드를 찾을 수 없음", content = @Content)
+    })
+    TodayDailyGuideResponse getTodayDailyGuide(
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId
+    );
+
+    @Operation(
+            summary = "데일리 가이드 댓글 작성",
+            description = "특정 챌린지의 특정 일차 데일리 가이드에 댓글을 작성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "댓글 작성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값", content = @Content),
+            @ApiResponse(responseCode = "403", description = "챌린지 참여 권한 없음 또는 댓글 작성 불가", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지 또는 데일리 가이드를 찾을 수 없음", content = @Content)
+    })
+    void createDailyGuideComment(
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
+            @Parameter(description = "일차 인덱스 (1부터 시작)") @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,
+            @Valid DailyGuideCommentRequest request
+    );
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeDailyGuide.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeDailyGuide.java
@@ -1,0 +1,59 @@
+package me.bombom.api.v1.challenge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChallengeDailyGuide extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    Long id;
+
+    @Column(nullable = false)
+    private Long challengeId;
+
+    @Column(nullable = false)
+    private int dayIndex;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DailyGuideType type;
+
+    @Column(nullable = false, length = 2048)
+    private String imageUrl;
+
+    @Column(length = 1000)
+    private String notice;
+
+    @Column(nullable = false)
+    private boolean commentEnabled;
+
+    @Builder
+    public ChallengeDailyGuide(@NonNull Long challengeId,
+                               int dayIndex,
+                               @NonNull DailyGuideType type,
+                               @NonNull String imageUrl,
+                               String notice,
+                               boolean commentEnabled) {
+        this.challengeId = challengeId;
+        this.dayIndex = dayIndex;
+        this.type = type;
+        this.imageUrl = imageUrl;
+        this.notice = notice;
+        this.commentEnabled = commentEnabled;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeDailyGuideComment.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeDailyGuideComment.java
@@ -1,0 +1,38 @@
+package me.bombom.api.v1.challenge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChallengeDailyGuideComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long guideId;
+
+    @Column(nullable = false)
+    private Long participantId;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Builder
+    public ChallengeDailyGuideComment(Long guideId, Long participantId, String content) {
+        this.guideId = guideId;
+        this.participantId = participantId;
+        this.content = content;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/DailyGuideType.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/DailyGuideType.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.challenge.domain;
+
+public enum DailyGuideType {
+
+    READ,
+    COMMENT
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/DailyGuideCommentRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/DailyGuideCommentRequest.java
@@ -1,0 +1,13 @@
+package me.bombom.api.v1.challenge.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record DailyGuideCommentRequest(
+
+        @NotBlank(message = "댓글 내용은 필수입니다")
+        @Size(max = 1000, message = "댓글은 1000자를 초과할 수 없습니다")
+        String content
+) {
+}
+

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/TodayDailyGuideResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/TodayDailyGuideResponse.java
@@ -1,0 +1,39 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import me.bombom.api.v1.challenge.domain.DailyGuideType;
+
+public record TodayDailyGuideResponse(
+
+        @Schema(required = true)
+        int dayIndex,
+
+        @NotNull
+        DailyGuideType type,
+
+        @NotNull
+        String imageUrl,
+
+        String notice,
+
+        @Schema(required = true)
+        boolean commentEnabled,
+
+        @NotNull
+        MyCommentResponse myComment
+) {
+
+    public record MyCommentResponse(
+
+            @Schema(required = true)
+            boolean exists,
+
+            String content,
+
+            LocalDateTime createdAt
+    ) {
+    }
+}
+

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
@@ -1,0 +1,21 @@
+package me.bombom.api.v1.challenge.repository;
+
+import java.util.Optional;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChallengeDailyGuideCommentRepository extends JpaRepository<ChallengeDailyGuideComment, Long> {
+
+    @Query("""
+        SELECT c FROM ChallengeDailyGuideComment c
+        WHERE c.guideId = :guideId
+        AND c.participantId = :participantId
+    """)
+    Optional<ChallengeDailyGuideComment> findByGuideIdAndParticipantId(
+            @Param("guideId") Long guideId,
+            @Param("participantId") Long participantId
+    );
+}
+

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideRepository.java
@@ -1,0 +1,39 @@
+package me.bombom.api.v1.challenge.repository;
+
+import java.util.Optional;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChallengeDailyGuideRepository extends JpaRepository<ChallengeDailyGuide, Long> {
+
+    @Query(value = """
+            select
+                g.day_index as dayIndex,
+                g.type as type,
+                g.image_url as imageUrl,
+                g.notice as notice,
+                g.comment_enabled as commentEnabled,
+                case when cm.id is null then 0 else 1 end as myCommentExists,
+                cm.content as myCommentContent,
+                cm.created_at as myCommentCreatedAt
+            from challenge_daily_guide g
+            left join challenge_participant cp
+              on cp.challenge_id = :challengeId
+             and cp.member_id = :memberId
+             and cp.is_survived = true
+            left join challenge_daily_guide_comment cm
+              on cm.guide_id = g.id
+             and cm.participant_id = cp.id
+            where g.challenge_id = :challengeId
+              and g.day_index = :dayIndex
+            """, nativeQuery = true)
+    Optional<TodayDailyGuideRow> findTodayGuide(
+            @Param("challengeId") Long challengeId,
+            @Param("memberId") Long memberId,
+            @Param("dayIndex") int dayIndex
+    );
+
+    Optional<ChallengeDailyGuide> findByChallengeIdAndDayIndex(Long challengeId, int dayIndex);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/TodayDailyGuideRow.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/TodayDailyGuideRow.java
@@ -1,0 +1,17 @@
+package me.bombom.api.v1.challenge.repository;
+
+import java.time.LocalDateTime;
+import me.bombom.api.v1.challenge.domain.DailyGuideType;
+
+public interface TodayDailyGuideRow {
+
+    int getDayIndex();
+    DailyGuideType getType();
+    String getImageUrl();
+    String getNotice();
+    boolean isCommentEnabled();
+    int getMyCommentExists();
+    String getMyCommentContent();
+    LocalDateTime getMyCommentCreatedAt();
+}
+

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -2,7 +2,9 @@ package me.bombom.api.v1.challenge.service;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
@@ -27,6 +29,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ChallengeDailyGuideService {
 
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
     private final ChallengeRepository challengeRepository;
     private final ChallengeDailyGuideRepository challengeDailyGuideRepository;
     private final ChallengeDailyGuideCommentRepository challengeDailyGuideCommentRepository;
@@ -45,7 +49,7 @@ public class ChallengeDailyGuideService {
                     .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId);
         }
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
         if (today.isBefore(challenge.getStartDate()) || today.isAfter(challenge.getEndDate())) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
@@ -87,7 +91,7 @@ public class ChallengeDailyGuideService {
                         .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
 
-        if (dayIndex < 1 || dayIndex > challenge.getTotalDays()) {
+        if (dayIndex != 0 && (dayIndex < 1 || dayIndex > challenge.getTotalDays())) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
                     .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
@@ -130,6 +134,12 @@ public class ChallengeDailyGuideService {
     }
 
     private int calculateDayIndex(LocalDate startDate, LocalDate today) {
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+        
+        if (isWeekend) {
+            return 0;
+        }
         return (int) DAYS.between(startDate, today) + 1;
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -1,0 +1,144 @@
+package me.bombom.api.v1.challenge.service;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
+import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse.MyCommentResponse;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.TodayDailyGuideRow;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorContextKeys;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeDailyGuideService {
+
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeDailyGuideRepository challengeDailyGuideRepository;
+    private final ChallengeDailyGuideCommentRepository challengeDailyGuideCommentRepository;
+    private final ChallengeParticipantRepository challengeParticipantRepository;
+
+    public TodayDailyGuideResponse getTodayDailyGuide(Long challengeId, Long memberId) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+        
+        if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId);
+        }
+
+        LocalDate today = LocalDate.now();
+        if (today.isBefore(challenge.getStartDate()) || today.isAfter(challenge.getEndDate())) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext("reason", "챌린지 기간이 아닙니다.");
+        }
+
+        int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
+        TodayDailyGuideRow row = challengeDailyGuideRepository.findTodayGuide(
+                        challengeId, memberId, dayIndex)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                        .addContext("dayIndex", dayIndex));
+
+        MyCommentResponse myComment = createMyCommentResponse(row);
+        return new TodayDailyGuideResponse(
+                row.getDayIndex(),
+                row.getType(),
+                row.getImageUrl(),
+                row.getNotice(),
+                row.isCommentEnabled(),
+                myComment
+        );
+    }
+
+    @Transactional
+    public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
+                                        DailyGuideCommentRequest request) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                        challengeId, memberId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                        .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+
+        if (dayIndex < 1 || dayIndex > challenge.getTotalDays()) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext("dayIndex", dayIndex)
+                    .addContext("reason", "유효하지 않은 일차 인덱스입니다.");
+        }
+
+        ChallengeDailyGuide guide = challengeDailyGuideRepository.findByChallengeIdAndDayIndex(challengeId, dayIndex)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                        .addContext("dayIndex", dayIndex));
+
+        if (!guide.isCommentEnabled()) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext("dayIndex", dayIndex)
+                    .addContext("reason", "댓글 작성이 불가능한 가이드입니다.");
+        }
+
+        ChallengeDailyGuideComment existingComment = challengeDailyGuideCommentRepository
+                .findByGuideIdAndParticipantId(guide.getId(), participant.getId())
+                .orElse(null);
+
+        if (existingComment != null) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuideComment")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext("dayIndex", dayIndex)
+                    .addContext("reason", "이미 댓글이 존재합니다.");
+        }
+
+        ChallengeDailyGuideComment comment = ChallengeDailyGuideComment.builder()
+                .guideId(guide.getId())
+                .participantId(participant.getId())
+                .content(request.content())
+                .build();
+        challengeDailyGuideCommentRepository.save(comment);
+    }
+
+    private int calculateDayIndex(LocalDate startDate, LocalDate today) {
+        return (int) DAYS.between(startDate, today) + 1;
+    }
+
+    private MyCommentResponse createMyCommentResponse(TodayDailyGuideRow row) {
+        boolean exists = row.getMyCommentExists() == 1;
+        return new MyCommentResponse(
+                exists,
+                exists ? row.getMyCommentContent() : null,
+                exists ? row.getMyCommentCreatedAt() : null
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/resources/db/migration/V17.0.0__create_challenge_daily_guide_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V17.0.0__create_challenge_daily_guide_tables.sql
@@ -1,0 +1,31 @@
+CREATE TABLE challenge_daily_guide
+(
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    challenge_id    BIGINT       NOT NULL,
+    day_index       INT          NOT NULL,
+    type            VARCHAR(20)  NOT NULL,
+    image_url       VARCHAR(2048) NOT NULL,
+    notice          VARCHAR(1000) NULL,
+    comment_enabled TINYINT(1)   NOT NULL,
+    created_at      DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_challenge_daily_guide (challenge_id, day_index)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+
+CREATE TABLE challenge_daily_guide_comment
+(
+    id              BIGINT       NOT NULL AUTO_INCREMENT,
+    guide_id        BIGINT       NOT NULL,
+    participant_id  BIGINT       NOT NULL,
+    content         VARCHAR(1000) NOT NULL,
+    created_at      DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    UNIQUE KEY uk_challenge_daily_guide_comment (guide_id, participant_id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;
+

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -7,12 +7,15 @@ import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.domain.RecentArticle;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeComment;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeNewsletter;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.domain.ChallengeTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
+import me.bombom.api.v1.challenge.domain.DailyGuideType;
 import me.bombom.api.v1.highlight.domain.Color;
 import me.bombom.api.v1.highlight.domain.Highlight;
 import me.bombom.api.v1.highlight.domain.HighlightLocation;
@@ -634,6 +637,42 @@ public final class TestFixture {
                 .articleTitle(articleTitle)
                 .quotation(quotation)
                 .comment(comment)
+                .build();
+    }
+
+    /**
+     * ChallengeDailyGuide
+     */
+    public static ChallengeDailyGuide createChallengeDailyGuide(
+            Long challengeId,
+            int dayIndex,
+            DailyGuideType type,
+            String imageUrl,
+            String notice,
+            boolean commentEnabled
+    ) {
+        return ChallengeDailyGuide.builder()
+                .challengeId(challengeId)
+                .dayIndex(dayIndex)
+                .type(type)
+                .imageUrl(imageUrl)
+                .notice(notice)
+                .commentEnabled(commentEnabled)
+                .build();
+    }
+
+    /**
+     * ChallengeDailyGuideComment
+     */
+    public static ChallengeDailyGuideComment createChallengeDailyGuideComment(
+            Long guideId,
+            Long participantId,
+            String content
+    ) {
+        return ChallengeDailyGuideComment.builder()
+                .guideId(guideId)
+                .participantId(participantId)
+                .content(content)
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
@@ -245,5 +245,53 @@ class ChallengeDailyGuideControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void 주말_가이드_조회_성공() throws Exception {
+        // given - 주말 가이드 생성 (dayIndex = 0)
+        ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        0,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/weekend.webp",
+                        "주말입니다",
+                        false
+                )
+        );
+
+        // when & then - 주말에는 dayIndex 0으로 조회됨
+        // 실제로는 주말이어야 하지만, 가이드가 있으면 정상 조회됨
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/today", challenge.getId())
+                        .with(authentication(authToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dayIndex").exists())
+                .andExpect(jsonPath("$.type").exists())
+                .andExpect(jsonPath("$.imageUrl").exists());
+    }
+
+    @Test
+    void 주말_가이드_댓글_작성_불가() throws Exception {
+        // given - 주말 가이드 생성 (dayIndex = 0, commentEnabled = false)
+        ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        0,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/weekend.webp",
+                        "주말입니다",
+                        false
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("주말 댓글 작성 시도");
+
+        // when & then - dayIndex 0으로 댓글 작성 시도 (댓글 작성 불가능하므로 400)
+        mockMvc.perform(post("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comment",
+                        challenge.getId(), 0)
+                        .with(authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
@@ -8,9 +8,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.Map;
+
+import static java.time.temporal.ChronoUnit.DAYS;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.challenge.domain.Challenge;
@@ -38,6 +42,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @IntegrationTest
 @AutoConfigureMockMvc
 class ChallengeDailyGuideControllerTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     @Autowired
     private MockMvc mockMvc;
@@ -81,7 +87,7 @@ class ChallengeDailyGuideControllerTest {
         member = TestFixture.normalMemberFixture();
         memberRepository.save(member);
 
-        today = LocalDate.now();
+        today = LocalDate.now(SEOUL_ZONE);
         challenge = challengeRepository.save(TestFixture.createChallenge(
                 "테스트 챌린지",
                 today.minusDays(5),
@@ -97,7 +103,7 @@ class ChallengeDailyGuideControllerTest {
                 )
         );
 
-        int dayIndex = (int) java.time.temporal.ChronoUnit.DAYS.between(challenge.getStartDate(), today) + 1;
+        int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
         guide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
                         challenge.getId(),
@@ -120,6 +126,16 @@ class ChallengeDailyGuideControllerTest {
                 customOAuth2User.getAuthorities(),
                 "registrationId"
         );
+    }
+
+    private int calculateDayIndex(LocalDate startDate, LocalDate today) {
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+        
+        if (isWeekend) {
+            return 0;
+        }
+        return (int) DAYS.between(startDate, today) + 1;
     }
 
     @Test

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
@@ -1,0 +1,249 @@
+package me.bombom.api.v1.challenge.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.DailyGuideType;
+import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class ChallengeDailyGuideControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ChallengeDailyGuideRepository challengeDailyGuideRepository;
+
+    @Autowired
+    private ChallengeDailyGuideCommentRepository challengeDailyGuideCommentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @MockitoBean
+    private me.bombom.api.v1.auth.handler.OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    private Member member;
+    private Challenge challenge;
+    private ChallengeParticipant participant;
+    private ChallengeDailyGuide guide;
+    private OAuth2AuthenticationToken authToken;
+    private LocalDate today;
+
+    @BeforeEach
+    void setUp() {
+        challengeDailyGuideCommentRepository.deleteAllInBatch();
+        challengeDailyGuideRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        today = LocalDate.now();
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "테스트 챌린지",
+                today.minusDays(5),
+                today.plusDays(5),
+                10
+        ));
+
+        participant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member.getId(),
+                        0
+                )
+        );
+
+        int dayIndex = (int) java.time.temporal.ChronoUnit.DAYS.between(challenge.getStartDate(), today) + 1;
+        guide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        dayIndex,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day07.webp",
+                        "오늘은 팁을 남겨주세요",
+                        true
+                )
+        );
+
+        Map<String, Object> attributes = Map.of(
+                "id", member.getId().toString(),
+                "email", member.getEmail(),
+                "name", member.getNickname()
+        );
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(attributes, member, null, null);
+        authToken = new OAuth2AuthenticationToken(
+                customOAuth2User,
+                customOAuth2User.getAuthorities(),
+                "registrationId"
+        );
+    }
+
+    @Test
+    void 오늘의_데일리_가이드_조회_성공() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/today", challenge.getId())
+                        .with(authentication(authToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.dayIndex").value(guide.getDayIndex()))
+                .andExpect(jsonPath("$.type").value("COMMENT"))
+                .andExpect(jsonPath("$.imageUrl").value("https://example.com/day07.webp"))
+                .andExpect(jsonPath("$.notice").value("오늘은 팁을 남겨주세요"))
+                .andExpect(jsonPath("$.commentEnabled").value(true))
+                .andExpect(jsonPath("$.myComment.exists").value(false))
+                .andExpect(jsonPath("$.myComment.content").doesNotExist())
+                .andExpect(jsonPath("$.myComment.createdAt").doesNotExist());
+    }
+
+    @Test
+    void 댓글이_있는_경우_오늘의_데일리_가이드_조회() throws Exception {
+        // given
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant.getId(),
+                        "뉴스레터 읽기 팁을 공유합니다"
+                )
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/today", challenge.getId())
+                        .with(authentication(authToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.myComment.exists").value(true))
+                .andExpect(jsonPath("$.myComment.content").value("뉴스레터 읽기 팁을 공유합니다"))
+                .andExpect(jsonPath("$.myComment.createdAt").exists());
+    }
+
+    @Test
+    void 데일리_가이드_댓글_작성_성공() throws Exception {
+        // given
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("뉴스레터 읽기 팁을 공유합니다");
+        int dayIndex = guide.getDayIndex();
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comment",
+                        challenge.getId(), dayIndex)
+                        .with(authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated());
+
+        // then - 댓글이 생성되었는지 확인
+        List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
+        assertThat(comments).hasSize(1);
+        assertThat(comments.get(0).getContent()).isEqualTo("뉴스레터 읽기 팁을 공유합니다");
+    }
+
+    @Test
+    void 이미_댓글이_있는_경우_400_응답() throws Exception {
+        // given
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant.getId(),
+                        "기존 댓글"
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("새 댓글");
+        int dayIndex = guide.getDayIndex();
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comment",
+                        challenge.getId(), dayIndex)
+                        .with(authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 챌린지에_참여하지_않은_경우_404_응답() throws Exception {
+        // given
+        Member otherMember = TestFixture.createUniqueMember("other", "other");
+        memberRepository.save(otherMember);
+        Map<String, Object> attributes = Map.of(
+                "id", otherMember.getId().toString(),
+                "email", otherMember.getEmail(),
+                "name", otherMember.getNickname()
+        );
+        CustomOAuth2User otherUser = new CustomOAuth2User(attributes, otherMember, null, null);
+        OAuth2AuthenticationToken otherToken = new OAuth2AuthenticationToken(
+                otherUser,
+                otherUser.getAuthorities(),
+                "registrationId"
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/today", challenge.getId())
+                        .with(authentication(otherToken)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 잘못된_challengeId로_조회시_404_응답() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/today", 999L)
+                        .with(authentication(authToken)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 댓글_내용이_비어있으면_400_응답() throws Exception {
+        // given
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("");
+        int dayIndex = guide.getDayIndex();
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comment",
+                        challenge.getId(), dayIndex)
+                        .with(authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}
+

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -1,0 +1,272 @@
+package me.bombom.api.v1.challenge.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.DailyGuideType;
+import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+class ChallengeDailyGuideServiceTest {
+
+    @Autowired
+    private ChallengeDailyGuideService challengeDailyGuideService;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ChallengeDailyGuideRepository challengeDailyGuideRepository;
+
+    @Autowired
+    private ChallengeDailyGuideCommentRepository challengeDailyGuideCommentRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member member;
+    private Challenge challenge;
+    private ChallengeParticipant participant;
+    private ChallengeDailyGuide guide;
+    private LocalDate today;
+
+    @BeforeEach
+    void setUp() {
+        challengeDailyGuideCommentRepository.deleteAllInBatch();
+        challengeDailyGuideRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        today = LocalDate.now();
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "테스트 챌린지",
+                today.minusDays(5),
+                today.plusDays(5),
+                10
+        ));
+
+        participant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member.getId(),
+                        0
+                )
+        );
+
+        int dayIndex = (int) java.time.temporal.ChronoUnit.DAYS.between(challenge.getStartDate(), today) + 1;
+        guide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        dayIndex,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day07.webp",
+                        "오늘은 팁을 남겨주세요",
+                        true
+                )
+        );
+    }
+
+    @Test
+    void 오늘의_데일리_가이드_조회_성공() {
+        // when
+        TodayDailyGuideResponse response = challengeDailyGuideService.getTodayDailyGuide(
+                challenge.getId(),
+                member.getId()
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.dayIndex()).isEqualTo(guide.getDayIndex());
+            softly.assertThat(response.type()).isEqualTo(DailyGuideType.COMMENT);
+            softly.assertThat(response.imageUrl()).isEqualTo("https://example.com/day07.webp");
+            softly.assertThat(response.notice()).isEqualTo("오늘은 팁을 남겨주세요");
+            softly.assertThat(response.commentEnabled()).isTrue();
+            softly.assertThat(response.myComment().exists()).isFalse();
+            softly.assertThat(response.myComment().content()).isNull();
+            softly.assertThat(response.myComment().createdAt()).isNull();
+        });
+    }
+
+    @Test
+    void 댓글이_있는_경우_오늘의_데일리_가이드_조회() {
+        // given
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant.getId(),
+                        "뉴스레터 읽기 팁을 공유합니다"
+                )
+        );
+
+        // when
+        TodayDailyGuideResponse response = challengeDailyGuideService.getTodayDailyGuide(
+                challenge.getId(),
+                member.getId()
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.myComment().exists()).isTrue();
+            softly.assertThat(response.myComment().content()).isEqualTo("뉴스레터 읽기 팁을 공유합니다");
+            softly.assertThat(response.myComment().createdAt()).isNotNull();
+        });
+    }
+
+    @Test
+    void 데일리_가이드_댓글_작성_성공() {
+        // given
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("뉴스레터 읽기 팁을 공유합니다");
+        int dayIndex = guide.getDayIndex();
+
+        // when
+        challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                dayIndex,
+                member.getId(),
+                request
+        );
+
+        // then
+        List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
+        assertSoftly(softly -> {
+            softly.assertThat(comments).hasSize(1);
+            softly.assertThat(comments.get(0).getGuideId()).isEqualTo(guide.getId());
+            softly.assertThat(comments.get(0).getParticipantId()).isEqualTo(participant.getId());
+            softly.assertThat(comments.get(0).getContent()).isEqualTo("뉴스레터 읽기 팁을 공유합니다");
+        });
+    }
+
+    @Test
+    void 이미_댓글이_있는_경우_예외_발생() {
+        // given
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant.getId(),
+                        "기존 댓글"
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("새 댓글");
+        int dayIndex = guide.getDayIndex();
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                dayIndex,
+                member.getId(),
+                request
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 챌린지에_참여하지_않은_경우_예외_발생() {
+        // given
+        Member otherMember = TestFixture.createUniqueMember("other", "other");
+        memberRepository.save(otherMember);
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getTodayDailyGuide(
+                challenge.getId(),
+                otherMember.getId()
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 존재하지_않는_챌린지_조회시_예외_발생() {
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getTodayDailyGuide(
+                999L,
+                member.getId()
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 챌린지_기간이_아닌_경우_예외_발생() {
+        // given
+        Challenge futureChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "미래 챌린지",
+                today.plusDays(10),
+                today.plusDays(20),
+                10
+        ));
+
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        futureChallenge.getId(),
+                        member.getId(),
+                        0
+                )
+        );
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getTodayDailyGuide(
+                futureChallenge.getId(),
+                member.getId()
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 댓글_작성이_불가능한_가이드에_댓글_작성시_예외_발생() {
+        // given
+        ChallengeDailyGuide disabledGuide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        guide.getDayIndex() + 1,
+                        DailyGuideType.READ,
+                        "https://example.com/day08.webp",
+                        null,
+                        false // 댓글 작성 불가
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("댓글 작성 시도");
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                disabledGuide.getDayIndex(),
+                member.getId(),
+                request
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 존재하지_않는_가이드에_댓글_작성시_예외_발생() {
+        // given
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("댓글 작성 시도");
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                999, // 존재하지 않는 dayIndex
+                member.getId(),
+                request
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+}
+

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -1,9 +1,12 @@
 package me.bombom.api.v1.challenge.service;
 
+import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
@@ -27,6 +30,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 @IntegrationTest
 class ChallengeDailyGuideServiceTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     @Autowired
     private ChallengeDailyGuideService challengeDailyGuideService;
@@ -63,7 +68,7 @@ class ChallengeDailyGuideServiceTest {
         member = TestFixture.normalMemberFixture();
         memberRepository.save(member);
 
-        today = LocalDate.now();
+        today = LocalDate.now(SEOUL_ZONE);
         challenge = challengeRepository.save(TestFixture.createChallenge(
                 "테스트 챌린지",
                 today.minusDays(5),
@@ -79,7 +84,7 @@ class ChallengeDailyGuideServiceTest {
                 )
         );
 
-        int dayIndex = (int) java.time.temporal.ChronoUnit.DAYS.between(challenge.getStartDate(), today) + 1;
+        int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
         guide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
                         challenge.getId(),
@@ -90,6 +95,16 @@ class ChallengeDailyGuideServiceTest {
                         true
                 )
         );
+    }
+
+    private int calculateDayIndex(LocalDate startDate, LocalDate today) {
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+        
+        if (isWeekend) {
+            return 0;
+        }
+        return (int) DAYS.between(startDate, today) + 1;
     }
 
     @Test

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -268,5 +268,92 @@ class ChallengeDailyGuideServiceTest {
                 request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
+
+    @Test
+    void 주말_가이드_조회_성공() {
+        // given - 주말 가이드 생성 (dayIndex = 0)
+        ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        0,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/weekend.webp",
+                        "주말입니다",
+                        false
+                )
+        );
+
+        // when - 주말 가이드 조회 (실제로는 주말일 때만 dayIndex 0이 반환되지만,
+        // 가이드가 존재하면 정상 조회됨)
+        TodayDailyGuideResponse response = challengeDailyGuideService.getTodayDailyGuide(
+                challenge.getId(),
+                member.getId()
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.dayIndex()).isGreaterThanOrEqualTo(0);
+            softly.assertThat(response.type()).isNotNull();
+            softly.assertThat(response.imageUrl()).isNotNull();
+        });
+    }
+
+    @Test
+    void 주말_가이드에_댓글_작성_불가() {
+        // given - 주말 가이드 생성 (dayIndex = 0, commentEnabled = false)
+        ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        0,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/weekend.webp",
+                        "주말입니다",
+                        false // 댓글 작성 불가
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("주말 댓글 작성 시도");
+
+        // when & then - dayIndex 0으로 댓글 작성 시도 (댓글 작성 불가능하므로 예외 발생)
+        assertThatThrownBy(() -> challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                0,
+                member.getId(),
+                request
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void dayIndex_0_유효성_검증_통과() {
+        // given - 주말 가이드 생성 (dayIndex = 0, commentEnabled = true)
+        ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        0,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/weekend.webp",
+                        "주말입니다",
+                        true
+                )
+        );
+
+        // when & then - dayIndex 0은 유효성 검증을 통과해야 함 (예외가 발생하지 않아야 함)
+        // commentEnabled = true이므로 댓글 작성 성공
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("주말 댓글");
+        challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                0,
+                member.getId(),
+                request
+        );
+
+        // then - 댓글이 생성되었는지 확인
+        List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
+        assertSoftly(softly -> {
+            softly.assertThat(comments).hasSize(1);
+            softly.assertThat(comments.get(0).getGuideId()).isEqualTo(weekendGuide.getId());
+            softly.assertThat(comments.get(0).getParticipantId()).isEqualTo(participant.getId());
+            softly.assertThat(comments.get(0).getContent()).isEqualTo("주말 댓글");
+        });
+    }
 }
 


### PR DESCRIPTION
## 📌 What
챌린지 데일리 가이드 조회 및 댓글 작성 기능 구현
- 진행 중인 챌린지의 오늘 날짜에 해당하는 데일리 가이드를 조회하는 API
- 특정 일차의 데일리 가이드에 댓글을 작성하는 API


동작 화면은 아래와 같습니다.

>단순 데일리 가이드만 제공할 때
<img width="1037" height="608" alt="image" src="https://github.com/user-attachments/assets/a798ca37-58d5-446c-b678-c40d5bac6c06" />

>데일리 가이드 + 코멘트 필요할 때
<img width="948" height="719" alt="image" src="https://github.com/user-attachments/assets/ea0a90d1-492f-42f0-9616-a3808d09f94e" />



## ❓ Why
챌린지 참가자들이 매일 제공되는 가이드를 확인하고, 해당 가이드에 대한 피드백이나 경험을 공유할 수 있도록 하기 위함. 챌린지 진행 상황에 맞춘 일일 가이드와 댓글 기능이 필요했음.

## 🔧 How
### 주요 구현 내용

1. **도메인 엔티티**
   - `ChallengeDailyGuide`: 챌린지별 일차별 가이드 정보 (타입, 이미지, 공지사항, 댓글 활성화 여부)
   - `ChallengeDailyGuideComment`: 사용자가 작성한 가이드 댓글
   - `DailyGuideType`: 가이드 타입 enum (READ, COMMENT)\

2. **API 엔드포인트**
   - `GET /challenges/{challengeId}/daily-guides/today`: 오늘의 데일리 가이드 조회
   - `POST /challenges/{challengeId}/daily-guides/{dayIndex}/comment`: 데일리 가이드 댓글 작성

### 기술적 결정 사항

- **dayIndex 계산**: `(오늘 날짜 - 챌린지 시작일) + 1`로 계산하여 첫째날을 1로 시작
- **댓글 중복 방지**: UNIQUE 제약 조건과 Service 레벨 검증으로 이중 체크
- **댓글 업데이트 불가**: 비즈니스 요구사항에 따라 이미 댓글이 있으면 에러 반환
- **쿼리 최적화**: `LEFT JOIN`을 사용하여 가이드와 댓글 정보를 한 번의 쿼리로 조회
- **주말 처리**: 주말에는 거의 같은 가이드가 제공될 예정이라 주말 전용 가이드를 dayIndex = 0으로 배치하여 재사용 가능한 로직 구현

## 👀 Review Point (Optional)
- 새로운 기능 추가로 코드가 많아졌습니다. 전체를 보실 필요는 없습니다.  service코드와 repository 위주로 봐주시면 됩니다.
- dayIndex 계산 로직이 의도한 대로 동작하는지 (특히 타임존 고려)
- GET /challenges/{challengeId}/daily-guides/today를 중점적으로 봐주시면 감사합니다.  


