### PR TITLE
[BOM-832] fix: 챌린지 조회시 시작전 혹은 참여중만 필터링

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -62,6 +62,11 @@ public class ChallengeService {
         Map<Long, ChallengeParticipant> myParticipation = findMyParticipation(member, challengeIds);
 
         return challenges.stream()
+                .filter(challenge -> {
+                    ChallengeStatus status = challenge.getStatus(LocalDate.now());
+                    boolean isJoined = myParticipation.containsKey(challenge.getId());
+                    return status == ChallengeStatus.BEFORE_START || isJoined;
+                })
                 .map(challenge -> toChallengeResponse(
                         challenge,
                         participantCounts,

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
@@ -111,7 +111,7 @@ class ChallengeControllerTest {
     @Test
     void 비로그인_상태로_챌린지_목록_조회() throws Exception {
         // given
-        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.minusDays(10), today.plusDays(10));
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
         challengeRepository.save(challenge);
 
         ChallengeNewsletter challengeNewsletter = TestFixture.createChallengeNewsletter(
@@ -120,7 +120,7 @@ class ChallengeControllerTest {
         );
         challengeNewsletterRepository.save(challengeNewsletter);
 
-        // when & then
+        // when & then - 시작전 챌린지이므로 반환되어야 함
         mockMvc.perform(get("/api/v1/challenges"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -111,22 +111,12 @@ class ChallengeServiceTest {
         // when
         List<ChallengeResponse> result = challengeService.getChallenges(null);
 
-        // then
+        // then - 시작전 챌린지만 반환되어야 함 (challenge2만)
         assertSoftly(softly -> {
-            softly.assertThat(result).hasSize(2);
-            softly.assertThat(result)
-                    .extracting("id")
-                    .containsExactlyInAnyOrder(challenge1.getId(), challenge2.getId());
-            softly.assertThat(result)
-                    .extracting("title")
-                    .containsExactlyInAnyOrder("첫 번째 챌린지", "두 번째 챌린지");
-            softly.assertThat(result)
-                    .extracting(ChallengeResponse::detail)
-                    .allMatch(detail -> !detail.isJoined());
-            softly.assertThat(result)
-                    .extracting(ChallengeResponse::detail)
-                    .extracting(ChallengeDetailResponse::progress)
-                    .containsOnly(0);
+            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result.get(0).id()).isEqualTo(challenge2.getId());
+            softly.assertThat(result.get(0).detail().isJoined()).isFalse();
+            softly.assertThat(result.get(0).detail().progress()).isEqualTo(0);
         });
     }
 
@@ -183,7 +173,7 @@ class ChallengeServiceTest {
     @Test
     void 참가자_수_조회() {
         // given
-        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.minusDays(10), today.plusDays(10));
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
         challengeRepository.save(challenge);
 
         Member member1 = TestFixture.createUniqueMember("member1", "provider1");
@@ -197,7 +187,7 @@ class ChallengeServiceTest {
         // when
         List<ChallengeResponse> result = challengeService.getChallenges(null);
 
-        // then
+        // then - 시작전 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).participantCount()).isEqualTo(2);
@@ -207,7 +197,7 @@ class ChallengeServiceTest {
     @Test
     void 챌린지별_뉴스레터_조회() {
         // given
-        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.minusDays(10), today.plusDays(10));
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
         challengeRepository.save(challenge);
 
         ChallengeNewsletter challengeNewsletter1 = TestFixture.createChallengeNewsletter(challenge.getId(), newsletters.get(0).getId());
@@ -217,7 +207,7 @@ class ChallengeServiceTest {
         // when
         List<ChallengeResponse> result = challengeService.getChallenges(null);
 
-        // then
+        // then - 시작전 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).newsletters()).hasSize(2);
@@ -233,10 +223,18 @@ class ChallengeServiceTest {
         Challenge challenge = TestFixture.createChallenge("진행 중 챌린지", 1, today.minusDays(5), today.plusDays(5));
         challengeRepository.save(challenge);
 
-        // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        ChallengeParticipant participant = TestFixture.createChallengeParticipant(
+                challenge.getId(),
+                member.getId(),
+                3,
+                true
+        );
+        challengeParticipantRepository.save(participant);
 
-        // then
+        // when
+        List<ChallengeResponse> result = challengeService.getChallenges(member);
+
+        // then - 참여한 진행중 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).status()).isEqualTo(ChallengeStatus.ONGOING);
@@ -249,10 +247,18 @@ class ChallengeServiceTest {
         Challenge challenge = TestFixture.createChallenge("종료된 챌린지", 1, today.minusDays(20), today.minusDays(1));
         challengeRepository.save(challenge);
 
-        // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        ChallengeParticipant participant = TestFixture.createChallengeParticipant(
+                challenge.getId(),
+                member.getId(),
+                15,
+                true
+        );
+        challengeParticipantRepository.save(participant);
 
-        // then
+        // when
+        List<ChallengeResponse> result = challengeService.getChallenges(member);
+
+        // then - 참여한 종료된 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).status()).isEqualTo(ChallengeStatus.COMPLETED);
@@ -306,13 +312,13 @@ class ChallengeServiceTest {
     @Test
     void 참가하지_않은_챌린지_detail_조회() {
         // given
-        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.minusDays(10), today.plusDays(10));
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
         challengeRepository.save(challenge);
 
         // when
         List<ChallengeResponse> result = challengeService.getChallenges(member);
 
-        // then
+        // then - 시작전 챌린지이므로 반환되어야 함
         ChallengeDetailResponse detail = result.get(0).detail();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);


### PR DESCRIPTION
## 📌 What
챌린지 목록 조회 시 모든 챌린지를 반환하던 것을 필터링하여, 시작전 챌린지와 참여한 챌린지만 반환하도록 변경했습니다.

## ❓ Why
챌린지 상태(시작전/진행중/종료)와 참여 여부의 조합 6가지 중, 시작전 챌린지(참여 여부 무관)와 참여한 챌린지(상태 무관)만 사용자에게 노출하는 것이 적절할 것 같아서

## 🔧 How
`ChallengeService.getChallenges()` 메서드에 필터링 로직을 추가했습니다. 

### 필터링 조건
- **시작전(BEFORE_START) 챌린지**: 참여 여부와 관계없이 항상 반환
- **참여한 챌린지**: 상태(진행중/종료)와 관계없이 항상 반환

1. 시작전 + 참여
2. 시작전 + 미참여
3. 진행중 + 참여
4. 종료 + 참여

### 제외되는 조합
- 진행중 + 미참여
- 종료 + 미참여
- 
## 👀 Review Point
시작전 챌린지와 참여한 챌린지만 반환하는 로직이 비즈니스 요구사항에 맞는지 확인 부탁드립니다.