### PR TITLE
[BOM-833] feat: day 1 데일리 가이드 수행만으로 완료 처리

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
@@ -2,6 +2,8 @@ package me.bombom.api.v1.challenge.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
@@ -24,6 +26,8 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/challenges")
 public class ChallengeDailyGuideController implements ChallengeDailyGuideControllerApi {
 
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
     private final ChallengeDailyGuideService challengeDailyGuideService;
 
     @Override
@@ -44,6 +48,7 @@ public class ChallengeDailyGuideController implements ChallengeDailyGuideControl
             @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,
             @Valid @RequestBody DailyGuideCommentRequest request
     ) {
-        challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request);
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request, today);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
@@ -1,5 +1,7 @@
 package me.bombom.api.v1.challenge.event;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.article.event.MarkAsReadEvent;
@@ -14,13 +16,16 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class ChallengeParticipantTodoListener {
 
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
     private final ChallengeDailyTodoService challengeDailyTodoService;
 
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void on(MarkAsReadEvent event) {
         try {
-            challengeDailyTodoService.updateChallengeDailyTodo(event.memberId());
+            LocalDate today = LocalDate.now(SEOUL_ZONE);
+            challengeDailyTodoService.updateChallengeDailyTodo(event.memberId(), today);
         } catch (Exception e) {
             log.error("챌린지 데일리 투두 저장 중 오류가 발생했습니다. memberId={}", event.memberId(), e);
         }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -35,6 +35,8 @@ public class ChallengeDailyGuideService {
     private final ChallengeDailyGuideRepository challengeDailyGuideRepository;
     private final ChallengeDailyGuideCommentRepository challengeDailyGuideCommentRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
+    private final ChallengeDailyTodoService challengeDailyTodoService;
+    private final ChallengeTodoService challengeTodoService;
 
     public TodayDailyGuideResponse getTodayDailyGuide(Long challengeId, Long memberId) {
         Challenge challenge = challengeRepository.findById(challengeId)
@@ -78,7 +80,7 @@ public class ChallengeDailyGuideService {
 
     @Transactional
     public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
-                                        DailyGuideCommentRequest request) {
+                                        DailyGuideCommentRequest request, LocalDate today) {
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
@@ -131,6 +133,14 @@ public class ChallengeDailyGuideService {
                 .content(request.content())
                 .build();
         challengeDailyGuideCommentRepository.save(comment);
+
+        // day1일 때만 체크리스트 자동 완료 처리
+        if (dayIndex == 1) {
+            // READ todo 자동 생성 (뉴스레터 1개 읽기)
+            challengeDailyTodoService.updateChallengeDailyTodo(memberId, today);
+            // COMMENT todo 생성 (한 줄 코멘트 작성)
+            challengeTodoService.insertCommentDone(participant, today);
+        }
     }
 
     private int calculateDayIndex(LocalDate startDate, LocalDate today) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
@@ -15,8 +15,7 @@ public class ChallengeDailyTodoService {
     private final ChallengeDailyTodoRepository challengeDailyTodoRepository;
 
     @Transactional
-    public void updateChallengeDailyTodo(Long memberId) {
-        LocalDate today = LocalDate.now();
+    public void updateChallengeDailyTodo(Long memberId, LocalDate today) {
         challengeDailyTodoRepository.insertTodayReadTodoIfMissing(memberId, today, ChallengeTodoType.READ.name());
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
@@ -40,6 +40,14 @@ public class ChallengeTodoService {
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "ChallengeTodo")
                         .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndTodoType"));
 
+        // 중복 체크
+        if (challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(), today, challengeTodo.getId())) {
+            log.debug("Comment todo already exists for participantId={}, date={}, todoId={}",
+                    participant.getId(), today, challengeTodo.getId());
+            return;
+        }
+
         ChallengeDailyTodo dailyTodo = ChallengeDailyTodo.builder()
                 .participantId(participant.getId())
                 .todoDate(today)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.challenge.service;
 
 import static java.time.temporal.ChronoUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
@@ -12,14 +13,19 @@ import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.ChallengeTodo;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.domain.DailyGuideType;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
@@ -51,15 +57,25 @@ class ChallengeDailyGuideServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private ChallengeTodoRepository challengeTodoRepository;
+
+    @Autowired
+    private ChallengeDailyTodoRepository challengeDailyTodoRepository;
+
     private Member member;
     private Challenge challenge;
     private ChallengeParticipant participant;
     private ChallengeDailyGuide guide;
     private LocalDate today;
+    private ChallengeTodo readTodo;
+    private ChallengeTodo commentTodo;
 
     @BeforeEach
     void setUp() {
         challengeDailyGuideCommentRepository.deleteAllInBatch();
+        challengeDailyTodoRepository.deleteAllInBatch();
+        challengeTodoRepository.deleteAllInBatch();
         challengeDailyGuideRepository.deleteAllInBatch();
         challengeParticipantRepository.deleteAllInBatch();
         challengeRepository.deleteAllInBatch();
@@ -82,6 +98,14 @@ class ChallengeDailyGuideServiceTest {
                         member.getId(),
                         0
                 )
+        );
+
+        // READ, COMMENT todo 생성
+        readTodo = challengeTodoRepository.save(
+                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
+        );
+        commentTodo = challengeTodoRepository.save(
+                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.COMMENT)
         );
 
         int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
@@ -164,7 +188,8 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 dayIndex,
                 member.getId(),
-                request
+                request,
+                today
         );
 
         // then
@@ -195,7 +220,8 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 dayIndex,
                 member.getId(),
-                request
+                request,
+                today
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -266,7 +292,8 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 disabledGuide.getDayIndex(),
                 member.getId(),
-                request
+                request,
+                today
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -280,7 +307,8 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 999, // 존재하지 않는 dayIndex
                 member.getId(),
-                request
+                request,
+                today
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -333,7 +361,8 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 0,
                 member.getId(),
-                request
+                request,
+                today
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -358,7 +387,8 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 0,
                 member.getId(),
-                request
+                request,
+                today
         );
 
         // then - 댓글이 생성되었는지 확인
@@ -369,6 +399,180 @@ class ChallengeDailyGuideServiceTest {
             softly.assertThat(comments.get(0).getParticipantId()).isEqualTo(participant.getId());
             softly.assertThat(comments.get(0).getContent()).isEqualTo("주말 댓글");
         });
+    }
+
+    @Test
+    void day1에_코멘트_작성시_READ와_COMMENT_체크리스트_자동_완료() {
+        // given - day1 가이드 생성
+        ChallengeDailyGuide day1Guide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        1,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day01.webp",
+                        "첫날 가이드",
+                        true
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("첫날 코멘트");
+
+        // when
+        challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                1,
+                member.getId(),
+                request,
+                today
+        );
+
+        // then - 코멘트 생성 확인
+        List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
+        assertThat(comments).hasSize(1);
+
+        // then - READ todo 생성 확인
+        boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(), today, readTodo.getId());
+        assertThat(readTodoExists).isTrue();
+
+        // then - COMMENT todo 생성 확인
+        boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(), today, commentTodo.getId());
+        assertThat(commentTodoExists).isTrue();
+    }
+
+    @Test
+    void day1이_아닐때_코멘트_작성시_체크리스트_생성_안함() {
+        // given - day2 가이드 생성
+        ChallengeDailyGuide day2Guide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        2,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day02.webp",
+                        "둘째날 가이드",
+                        true
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("둘째날 코멘트");
+
+        // when
+        challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                2,
+                member.getId(),
+                request,
+                today
+        );
+
+        // then - 코멘트는 생성됨
+        List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
+        assertThat(comments).hasSize(1);
+
+        // then - READ todo 생성 안 됨 (아직 아티클을 읽지 않았으므로)
+        boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(), today, readTodo.getId());
+        assertThat(readTodoExists).isFalse();
+
+        // then - COMMENT todo 생성 안 됨 (day1이 아니므로)
+        boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(), today, commentTodo.getId());
+        assertThat(commentTodoExists).isFalse();
+    }
+
+    @Test
+    void day1에_이미_READ_todo가_있어도_중복_생성_안함() {
+        // given - day1 가이드 생성
+        ChallengeDailyGuide day1Guide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        1,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day01.webp",
+                        "첫날 가이드",
+                        true
+                )
+        );
+
+        // 이미 READ todo 생성
+        challengeDailyTodoRepository.save(
+                TestFixture.createChallengeDailyTodo(
+                        participant.getId(),
+                        today,
+                        readTodo.getId()
+                )
+        );
+
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("첫날 코멘트");
+
+        // when
+        challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                1,
+                member.getId(),
+                request,
+                today
+        );
+
+        // then - READ todo는 1개만 존재 (중복 생성 안 됨)
+        List<ChallengeDailyTodo> readTodos = challengeDailyTodoRepository.findAll().stream()
+                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
+                .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
+                .filter(todo -> todo.getTodoDate().equals(today))
+                .toList();
+        assertThat(readTodos).hasSize(1);
+
+        // then - COMMENT todo 생성 확인
+        boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(), today, commentTodo.getId());
+        assertThat(commentTodoExists).isTrue();
+    }
+
+    @Test
+    void day1에_이미_COMMENT_todo가_있어도_중복_생성_안함() {
+        // given - day1 가이드 생성
+        ChallengeDailyGuide day1Guide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        1,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day01.webp",
+                        "첫날 가이드",
+                        true
+                )
+        );
+
+        // 이미 COMMENT todo 생성
+        challengeDailyTodoRepository.save(
+                TestFixture.createChallengeDailyTodo(
+                        participant.getId(),
+                        today,
+                        commentTodo.getId()
+                )
+        );
+
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("첫날 코멘트");
+
+        // when
+        challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                1,
+                member.getId(),
+                request,
+                today
+        );
+
+        // then - COMMENT todo는 1개만 존재 (중복 생성 안 됨)
+        List<ChallengeDailyTodo> commentTodos = challengeDailyTodoRepository.findAll().stream()
+                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
+                .filter(todo -> todo.getChallengeTodoId().equals(commentTodo.getId()))
+                .filter(todo -> todo.getTodoDate().equals(today))
+                .toList();
+        assertThat(commentTodos).hasSize(1);
+
+        // then - READ todo 생성 확인
+        boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(), today, readTodo.getId());
+        assertThat(readTodoExists).isTrue();
     }
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.challenge.service;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.article.event.MarkAsReadEvent;
@@ -27,6 +28,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 @IntegrationTest
 class ChallengeDailyTodoServiceTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     @Autowired
     private ApplicationEventPublisher eventPublisher;
@@ -60,7 +63,7 @@ class ChallengeDailyTodoServiceTest {
 
         member = memberRepository.save(TestFixture.createUniqueMember("tester", "12345"));
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
         challenge = challengeRepository.save(TestFixture.createChallenge(
                 "테스트 챌린지",
                 today.minusDays(5),
@@ -85,7 +88,7 @@ class ChallengeDailyTodoServiceTest {
     @Transactional
     void 아티클_읽기시_챌린지_투두_업데이트() {
         // given
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                 challenge.getId(), member.getId()).orElseThrow();
 
@@ -113,7 +116,7 @@ class ChallengeDailyTodoServiceTest {
     @Transactional
     void 이미_존재하는_챌린지_투두_중복_생성_안함() {
         // given
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                 challenge.getId(), member.getId()).orElseThrow();
 


### PR DESCRIPTION
## 📌 What
day1 데일리 가이드 코멘트 작성 시 체크리스트 자동 완료 기능

- day1에 데일리 가이드 코멘트를 작성하면 READ todo(뉴스레터 1개 읽기)와 COMMENT todo(한 줄 코멘트 작성)가 자동으로 완료 처리됨
- today 파라미터를 외부에서 주입받도록 리팩토링하여 테스트 용이성 및 일관성 향상

## ❓ Why
day1에 사용자가 데일리 가이드를 수행(코멘트 작성)만으로도 첫날 체크리스트가 모두 완료되도록 하여 사용자 경험을 개선하기 위함. 또한 today 파라미터를 외부 주입으로 변경하여 테스트에서 특정 날짜를 주입할 수 있도록 하고, 날짜 계산 로직을 통일하기 위함.

## 🔧 How
### 주요 구현 내용

**day1 체크리스트 자동 완료 로직**
- `ChallengeDailyGuideService.createDailyGuideComment()`에서 `dayIndex == 1`일 때 자동 완료 처리
- READ todo: `ChallengeDailyTodoService.updateChallengeDailyTodo(memberId, today)` 호출
- COMMENT todo: `ChallengeTodoService.insertCommentDone(participant, today)` 호출
- 중복 생성 방지: `ChallengeTodoService.insertCommentDone()`에 중복 체크 로직 추가

**today 파라미터 외부 주입 리팩토링**
- `ChallengeDailyGuideService.createDailyGuideComment()`에 `LocalDate today` 파라미터 추가
- `ChallengeDailyGuideController`에서 한국 시간대 기준 today 계산하여 전달
- `ChallengeDailyTodoService`의 중복 메서드 제거 (파라미터 없는 메서드 삭제)
- `ChallengeParticipantTodoListener`에서도 한국 시간대 기준 today 계산하여 전달

### 기술적 결정 사항
- **day1만 적용**: `dayIndex == 1`일 때만 체크리스트 자동 완료 처리
- **한국 시간대 기준**: 모든 날짜 계산을 `ZoneId.of("Asia/Seoul")` 기준으로 통일
- **중복 방지**: UNIQUE 제약 조건과 Service 레벨 검증으로 이중 체크
- **테스트 용이성**: today 파라미터 외부 주입으로 테스트에서 특정 날짜 주입 가능

## 👀 Review Point (Optional)
- day1 체크리스트 자동 완료 로직이 의도한 대로 동작하는지 확인 부탁드립니다
- today 파라미터 외부 주입 변경으로 인한 기존 로직 영향도 확인
- 한국 시간대 기준 날짜 계산이 모든 곳에서 일관되게 적용되었는지 확인