### PR TITLE
hotfix: day1 미션을 완료하면 progress도 반영되도록 기능 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -37,6 +37,7 @@ public class ChallengeDailyGuideService {
     private final ChallengeParticipantRepository challengeParticipantRepository;
     private final ChallengeDailyTodoService challengeDailyTodoService;
     private final ChallengeTodoService challengeTodoService;
+    private final ChallengeTeamService challengeTeamService;
 
     public TodayDailyGuideResponse getTodayDailyGuide(Long challengeId, Long memberId) {
         Challenge challenge = challengeRepository.findById(challengeId)
@@ -140,6 +141,18 @@ public class ChallengeDailyGuideService {
             challengeDailyTodoService.updateChallengeDailyTodo(memberId, today);
             // COMMENT todo 생성 (한 줄 코멘트 작성)
             challengeTodoService.insertCommentDone(participant, today);
+            
+            // 이미 완료되지 않았으면 progress 처리
+            // day1에 두 todo(READ, COMMENT)가 모두 생성되므로 바로 완료 처리
+            if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
+                challengeTodoService.completeDailyTodo(participant, today);
+                
+                // 팀 progress 업데이트
+                if (participant.getChallengeTeamId() != null) {
+                    var challengeTeam = challengeTeamService.getChallengeTeamByParticipant(participant);
+                    challengeTeamService.updateTeamProgress(challengeTeam);
+                }
+            }
         }
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -22,6 +22,7 @@ import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
@@ -63,6 +64,9 @@ class ChallengeDailyGuideServiceTest {
     @Autowired
     private ChallengeDailyTodoRepository challengeDailyTodoRepository;
 
+    @Autowired
+    private ChallengeDailyResultRepository challengeDailyResultRepository;
+
     private Member member;
     private Challenge challenge;
     private ChallengeParticipant participant;
@@ -74,6 +78,7 @@ class ChallengeDailyGuideServiceTest {
     @BeforeEach
     void setUp() {
         challengeDailyGuideCommentRepository.deleteAllInBatch();
+        challengeDailyResultRepository.deleteAllInBatch();
         challengeDailyTodoRepository.deleteAllInBatch();
         challengeTodoRepository.deleteAllInBatch();
         challengeDailyGuideRepository.deleteAllInBatch();
@@ -438,6 +443,15 @@ class ChallengeDailyGuideServiceTest {
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(), today, commentTodo.getId());
         assertThat(commentTodoExists).isTrue();
+
+        // then - progress 처리 확인: ChallengeDailyResult 생성 확인
+        boolean dailyResultExists = challengeDailyResultRepository.existsByParticipantIdAndDate(
+                participant.getId(), today);
+        assertThat(dailyResultExists).isTrue();
+
+        // then - progress 처리 확인: completedDays 증가 확인
+        ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        assertThat(updatedParticipant.getCompletedDays()).isEqualTo(1);
     }
 
     @Test


### PR DESCRIPTION
## What

day1 데일리 가이드에서 코멘트를 작성했을 때 체크리스트 자동 완료에 더해 progress(진행률)도 자동 반영되도록 기능 추가.

**추가된 처리:**
- `ChallengeDailyResult` 생성 (일일 완료 기록)
- `ChallengeParticipant.completedDays` 증가
- 팀 progress 업데이트 (팀이 있는 경우)

## Why

day1 데일리 가이드 코멘트 작성 시 체크리스트는 완료되지만 progress가 반영되지 않는 문제가 있었음. 일반 챌린지 코멘트 작성 시에는 `completeDailyTodo()`로 progress 처리가 되지만, day1 데일리 가이드 경로에서는 누락되어 있었음.

## How

`ChallengeDailyGuideService.createDailyGuideComment()`에서 day1일 때:
1. READ todo, COMMENT todo 생성
2. `isCompletedToday()` 체크로 중복 방지
3. `completeDailyTodo()` 호출하여 `ChallengeDailyResult` 생성 및 `completedDays` 증가
4. 팀이 있는 경우 팀 progress 업데이트

`CreateChallengeCommentListener`와 동일한 방식으로 처리하여 일관성 유지.

## Review Point

- 중복 처리 방지 로직 (`isCompletedToday()`)
- Progress 계산 정확성 (`completedDays` 증가, `ChallengeDailyResult` 생성)
- 팀 progress 업데이트 (팀 없는 경우 처리)
- 트랜잭션 처리 및 테스트 커버리지
