### PR TITLE
[BOM-839] fix: 챌린지 아티클 읽음 처리 시 오늘 온 아티클 조건 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
@@ -25,7 +25,7 @@ public class ChallengeParticipantTodoListener {
     public void on(MarkAsReadEvent event) {
         try {
             LocalDate today = LocalDate.now(SEOUL_ZONE);
-            challengeDailyTodoService.updateChallengeDailyTodo(event.memberId(), today);
+            challengeDailyTodoService.updateChallengeDailyTodo(event.memberId(), event.articleId(), today);
         } catch (Exception e) {
             log.error("챌린지 데일리 투두 저장 중 오류가 발생했습니다. memberId={}", event.memberId(), e);
         }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
@@ -24,8 +24,19 @@ public interface ChallengeDailyTodoRepository extends JpaRepository<ChallengeDai
                   AND :today BETWEEN c.start_date AND c.end_date
                   AND cp.is_survived = true
                   AND dt.id IS NULL
+                  AND (
+                        :articleId IS NULL
+                        OR EXISTS (
+                            SELECT 1
+                            FROM article a
+                            WHERE a.id = :articleId
+                              AND a.member_id = cp.member_id
+                              AND DATE(a.arrived_date_time) = :today
+                        )
+                  )
             """, nativeQuery = true)
     int insertTodayReadTodoIfMissing(@Param("memberId") Long memberId,
+                                     @Param("articleId") Long articleId,
                                      @Param("today") LocalDate today,
                                      @Param("todoType") String todoType);
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -138,7 +138,7 @@ public class ChallengeDailyGuideService {
         // day1일 때만 체크리스트 자동 완료 처리
         if (dayIndex == 1) {
             // READ todo 자동 생성 (뉴스레터 1개 읽기)
-            challengeDailyTodoService.updateChallengeDailyTodo(memberId, today);
+            challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
             // COMMENT todo 생성 (한 줄 코멘트 작성)
             challengeTodoService.insertCommentDone(participant, today);
             

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
@@ -15,7 +15,8 @@ public class ChallengeDailyTodoService {
     private final ChallengeDailyTodoRepository challengeDailyTodoRepository;
 
     @Transactional
-    public void updateChallengeDailyTodo(Long memberId, LocalDate today) {
-        challengeDailyTodoRepository.insertTodayReadTodoIfMissing(memberId, today, ChallengeTodoType.READ.name());
+    public void updateChallengeDailyTodo(Long memberId, Long articleId, LocalDate today) {
+        challengeDailyTodoRepository.insertTodayReadTodoIfMissing(
+                memberId, articleId, today, ChallengeTodoType.READ.name());
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
@@ -3,10 +3,13 @@ package me.bombom.api.v1.challenge.service;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.event.MarkAsReadEvent;
+import me.bombom.api.v1.article.repository.ArticleRepository;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
@@ -49,13 +52,18 @@ class ChallengeDailyTodoServiceTest {
     @Autowired
     private ChallengeDailyTodoRepository challengeDailyTodoRepository;
 
+    @Autowired
+    private ArticleRepository articleRepository;
+
     private Member member;
     private Challenge challenge;
     private ChallengeTodo readTodo;
+    private Article todayArticle;
 
     @BeforeEach
     void setUp() {
         challengeDailyTodoRepository.deleteAllInBatch();
+        articleRepository.deleteAllInBatch();
         challengeTodoRepository.deleteAllInBatch();
         challengeParticipantRepository.deleteAllInBatch();
         challengeRepository.deleteAllInBatch();
@@ -82,6 +90,15 @@ class ChallengeDailyTodoServiceTest {
         readTodo = challengeTodoRepository.save(
                 TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
         );
+
+        todayArticle = articleRepository.save(
+                TestFixture.createArticle(
+                        "오늘 뉴스레터",
+                        member.getId(),
+                        1L,
+                        LocalDateTime.now(SEOUL_ZONE)
+                )
+        );
     }
 
     @Test
@@ -93,7 +110,7 @@ class ChallengeDailyTodoServiceTest {
                 challenge.getId(), member.getId()).orElseThrow();
 
         // when
-        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), 1L));
+        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), todayArticle.getId()));
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
@@ -130,7 +147,7 @@ class ChallengeDailyTodoServiceTest {
         );
 
         // when
-        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), 1L));
+        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), todayArticle.getId()));
         TestTransaction.flagForCommit();
         TestTransaction.end();
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지의 읽음 TODO 완료 조건을 오늘의 아티클로 추가합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존에 기재된 정책을 구현하기 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- `ChallengeDailyTodoRepository`의 메서드에 조건이 추가됐습니다.
- articleId가 null이거나 (데일리가이드 첫 날이라 아티클이 없을 경우) 해당 article이 오늘 온 경우 읽기 완료 TODO 삽입을 시도합니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 쿼리에 추가된 조건만 적절한지 봐주시면 좋을 것 같습니다!
