### PR TITLE
[BOM-844] feat: 인용구 길이 제한 증가 및 코멘트 작성 시 길이 검증

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/Article.java
@@ -5,7 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -30,7 +29,7 @@ public class Article extends BaseEntity {
     @Column(nullable = false, columnDefinition = "mediumtext")
     private String contents;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String contentsText;
 
     @Column(length = 512)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentOptionsRequest;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
 import me.bombom.api.v1.challenge.service.ChallengeCommentService;
 import me.bombom.api.v1.common.resolver.LoginMember;
@@ -15,6 +16,7 @@ import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
 import org.springframework.http.HttpStatus;
@@ -48,7 +50,7 @@ public class ChallengeCommentController implements ChallengeCommentControllerApi
                     @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC),
                     @SortDefault(sort = "id", direction = Sort.Direction.ASC)
             }) Pageable pageable
-    ){
+    ) {
         return challengeCommentService.getChallengeComments(challengeId, member.getId(), request, pageable);
     }
 
@@ -68,7 +70,17 @@ public class ChallengeCommentController implements ChallengeCommentControllerApi
             @LoginMember Member member,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Valid @RequestBody ChallengeCommentRequest request
-    ){
+    ) {
         challengeCommentService.createChallengeComment(member.getId(), challengeId, request);
+    }
+
+    @Override
+    @GetMapping("/comments/articles/{articleId}/highlights")
+    public Page<ChallengeCommentHighlightResponse> getChallengeArticleHighlights(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long articleId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Direction.DESC) Pageable pageable
+    ) {
+        return challengeCommentService.getChallengeArticleHighlights(member.getId(), articleId, pageable);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
@@ -13,11 +13,11 @@ import java.util.List;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentOptionsRequest;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -71,5 +71,20 @@ public interface ChallengeCommentControllerApi {
             @Parameter(hidden = true) Member member,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Valid @RequestBody ChallengeCommentRequest request
+    );
+
+    @Operation(
+            summary = "챌린지 아티클 하이라이트/메모 조회",
+            description = "지정한 챌린지 아티클에 대해 내가 작성한 하이라이트/메모 목록을 페이징 조회합니다. "
+                    + "(예: ?page=0&size=20&sort=createdAt,desc)"
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "하이라이트/메모 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값", content = @Content)
+    })
+    Page<ChallengeCommentHighlightResponse> getChallengeArticleHighlights(
+            @Parameter(hidden = true) Member member,
+            @Parameter(description = "챌린지 아티클 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long articleId,
+            @Parameter(description = "페이징 및 정렬 (예: ?page=0&size=20&sort=createdAt,desc)") Pageable pageable
     );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeComment.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeComment.java
@@ -31,6 +31,7 @@ public class ChallengeComment extends BaseEntity {
     @Column(nullable = false)
     private String articleTitle;
 
+    @Column(length = 400)
     private String quotation;
 
     @Column(nullable = false)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeComment.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeComment.java
@@ -31,7 +31,7 @@ public class ChallengeComment extends BaseEntity {
     @Column(nullable = false)
     private String articleTitle;
 
-    @Column(length = 400)
+    @Column(columnDefinition = "TEXT")
     private String quotation;
 
     @Column(nullable = false)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/ChallengeCommentRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/ChallengeCommentRequest.java
@@ -8,7 +8,6 @@ public record ChallengeCommentRequest(
         @NotNull
         Long articleId,
 
-        @Size(max = 400, message = "인용구는 400자 이하로 입력해야 합니다.")
         String quotation,
 
         @NotNull

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/ChallengeCommentRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/ChallengeCommentRequest.java
@@ -8,6 +8,7 @@ public record ChallengeCommentRequest(
         @NotNull
         Long articleId,
 
+        @Size(max = 400, message = "인용구는 400자 이하로 입력해야 합니다.")
         String quotation,
 
         @NotNull

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeCommentHighlightResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeCommentHighlightResponse.java
@@ -1,0 +1,20 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import jakarta.validation.constraints.NotNull;
+
+public record ChallengeCommentHighlightResponse(
+
+        @NotNull
+        Long highlightId,
+
+        @NotNull
+        String text,
+
+        String memo
+) {
+
+    @QueryProjection
+    public ChallengeCommentHighlightResponse {
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -42,8 +42,7 @@ public class ChallengeCommentService {
             ChallengeCommentOptionsRequest request,
             Pageable pageable
     ) {
-        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId,
-                        memberId)
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
                         .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                         .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
@@ -56,8 +55,7 @@ public class ChallengeCommentService {
         );
     }
 
-    public List<ChallengeCommentCandidateArticleResponse> getChallengeCommentCandidateArticles(Long memberId,
-                                                                                               LocalDate date) {
+    public List<ChallengeCommentCandidateArticleResponse> getChallengeCommentCandidateArticles(Long memberId, LocalDate date) {
         return articleRepository.findChallengeCommentCandidateArticles(
                 memberId,
                 date.atStartOfDay(),
@@ -71,10 +69,7 @@ public class ChallengeCommentService {
             Long challengeId,
             ChallengeCommentRequest request
     ) {
-        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
-                        challengeId,
-                        memberId
-                )
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -19,6 +19,7 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.highlight.repository.HighlightRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,6 +36,9 @@ public class ChallengeCommentService {
     private final ArticleRepository articleRepository;
     private final HighlightRepository highlightRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Value("${challenge.highlight.truncate-ratio}")
+    private double highlightTruncateRatio;
 
     public Page<ChallengeCommentResponse> getChallengeComments(
             Long challengeId,
@@ -99,6 +103,11 @@ public class ChallengeCommentService {
             Long articleId,
             Pageable pageable
     ) {
-        return highlightRepository.findChallengeArticleHighlights(memberId, articleId, pageable);
+        return highlightRepository.findChallengeArticleHighlights(
+                memberId,
+                articleId,
+                highlightTruncateRatio,
+                pageable
+        );
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -6,11 +6,11 @@ import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.repository.ArticleRepository;
 import me.bombom.api.v1.challenge.domain.ChallengeComment;
-import me.bombom.api.v1.challenge.domain.ChallengeComment.ChallengeCommentBuilder;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentOptionsRequest;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
 import me.bombom.api.v1.challenge.event.CreateChallengeCommentEvent;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
@@ -18,6 +18,7 @@ import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.highlight.repository.HighlightRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,6 +33,7 @@ public class ChallengeCommentService {
     private final ChallengeCommentRepository challengeCommentRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
     private final ArticleRepository articleRepository;
+    private final HighlightRepository highlightRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
 
     public Page<ChallengeCommentResponse> getChallengeComments(
@@ -39,11 +41,12 @@ public class ChallengeCommentService {
             Long memberId,
             ChallengeCommentOptionsRequest request,
             Pageable pageable
-    ){
-        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
+    ) {
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId,
+                        memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
-                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
-                    .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
+                        .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                        .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
         return challengeCommentRepository.findAllByTeamInDuration(
                 participant.getChallengeTeamId(),
                 memberId,
@@ -53,7 +56,8 @@ public class ChallengeCommentService {
         );
     }
 
-    public List<ChallengeCommentCandidateArticleResponse> getChallengeCommentCandidateArticles(Long memberId, LocalDate date) {
+    public List<ChallengeCommentCandidateArticleResponse> getChallengeCommentCandidateArticles(Long memberId,
+                                                                                               LocalDate date) {
         return articleRepository.findChallengeCommentCandidateArticles(
                 memberId,
                 date.atStartOfDay(),
@@ -93,5 +97,13 @@ public class ChallengeCommentService {
 
         challengeCommentRepository.save(comment);
         applicationEventPublisher.publishEvent(new CreateChallengeCommentEvent(participant.getId()));
+    }
+
+    public Page<ChallengeCommentHighlightResponse> getChallengeArticleHighlights(
+            Long memberId,
+            Long articleId,
+            Pageable pageable
+    ) {
+        return highlightRepository.findChallengeArticleHighlights(memberId, articleId, pageable);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/CustomHighlightRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/CustomHighlightRepository.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.highlight.repository;
 
 import java.util.List;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.highlight.dto.response.HighlightCountPerNewsletterResponse;
 import me.bombom.api.v1.highlight.dto.response.HighlightResponse;
 import org.springframework.data.domain.Page;
@@ -9,6 +10,12 @@ import org.springframework.data.domain.Pageable;
 public interface CustomHighlightRepository {
 
     Page<HighlightResponse> findHighlights(Long memberId, Long articleId, Long newsletterId, Pageable pageable);
+
+    Page<ChallengeCommentHighlightResponse> findChallengeArticleHighlights(
+            Long memberId,
+            Long articleId,
+            Pageable pageable
+    );
 
     List<HighlightCountPerNewsletterResponse> countPerNewsletters(Long memberId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/CustomHighlightRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/CustomHighlightRepository.java
@@ -14,6 +14,7 @@ public interface CustomHighlightRepository {
     Page<ChallengeCommentHighlightResponse> findChallengeArticleHighlights(
             Long memberId,
             Long articleId,
+            double textTruncateRatio,
             Pageable pageable
     );
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/HighlightRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/HighlightRepository.java
@@ -14,17 +14,15 @@ public interface HighlightRepository extends JpaRepository<Highlight, Long>, Cus
 
     int countByMemberId(Long memberId);
 
-    int countByArticleId(Long articleId);
-
     List<Highlight> findAllByArticleId(Long articleId);
 
     void deleteAllByMemberId(Long memberId);
 
     @Modifying(clearAutomatically = true)
     @Query("""
-        UPDATE Highlight h 
-        SET h.articleId = 0 
-        WHERE h.articleId IN :articleIds
-    """)
+                UPDATE Highlight h 
+                SET h.articleId = 0 
+                WHERE h.articleId IN :articleIds
+            """)
     void updateArticleDeleted(List<Long> articleIds);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/HighlightRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/HighlightRepositoryImpl.java
@@ -2,15 +2,19 @@ package me.bombom.api.v1.highlight.repository;
 
 import static me.bombom.api.v1.article.domain.QArticle.article;
 import static me.bombom.api.v1.highlight.domain.QHighlight.highlight;
-import static me.bombom.api.v1.member.domain.QMember.member;
 import static me.bombom.api.v1.newsletter.domain.QNewsletter.newsletter;
 
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
+import me.bombom.api.v1.challenge.dto.response.QChallengeCommentHighlightResponse;
 import me.bombom.api.v1.highlight.dto.response.HighlightCountPerNewsletterResponse;
 import me.bombom.api.v1.highlight.dto.response.HighlightResponse;
 import me.bombom.api.v1.highlight.dto.response.QHighlightCountPerNewsletterResponse;
@@ -34,6 +38,32 @@ public class HighlightRepositoryImpl implements CustomHighlightRepository {
     ) {
         JPAQuery<Long> totalQuery = getTotalQuery(memberId, articleId, newsletterId);
         List<HighlightResponse> content = getContent(memberId, articleId, newsletterId, pageable);
+        return PageableExecutionUtils.getPage(content, pageable, totalQuery::fetchOne);
+    }
+
+    @Override
+    public Page<ChallengeCommentHighlightResponse> findChallengeArticleHighlights(
+            Long memberId,
+            Long articleId,
+            Pageable pageable
+    ) {
+        JPAQuery<Long> totalQuery = getTotalQuery(memberId, articleId, null);
+
+        List<ChallengeCommentHighlightResponse> content = jpaQueryFactory
+                .select(new QChallengeCommentHighlightResponse(
+                        highlight.id,
+                        truncatedHighlightText(),
+                        highlight.memo
+                ))
+                .from(highlight)
+                .join(article).on(article.id.eq(highlight.articleId))
+                .where(createMemberIdWhereClause(memberId))
+                .where(createArticleIdWhereClause(articleId))
+                .orderBy(highlight.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
         return PageableExecutionUtils.getPage(content, pageable, totalQuery::fetchOne);
     }
 
@@ -106,5 +136,19 @@ public class HighlightRepositoryImpl implements CustomHighlightRepository {
         return Optional.ofNullable(newsletterId)
                 .map(highlight.newsletterId::eq)
                 .orElse(null);
+    }
+
+    private Expression<String> truncatedHighlightText() {
+        NumberExpression<Integer> threshold =
+                article.contentsText.length()
+                        .doubleValue()
+                        .multiply(0.08)
+                        .ceil()
+                        .intValue();
+
+        return new CaseBuilder()
+                .when(highlight.text.length().gt(threshold))
+                .then(highlight.text.substring(0, threshold).concat("..."))
+                .otherwise(highlight.text);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/HighlightRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/highlight/repository/HighlightRepositoryImpl.java
@@ -45,6 +45,7 @@ public class HighlightRepositoryImpl implements CustomHighlightRepository {
     public Page<ChallengeCommentHighlightResponse> findChallengeArticleHighlights(
             Long memberId,
             Long articleId,
+            double textTruncateRatio,
             Pageable pageable
     ) {
         JPAQuery<Long> totalQuery = getTotalQuery(memberId, articleId, null);
@@ -52,7 +53,7 @@ public class HighlightRepositoryImpl implements CustomHighlightRepository {
         List<ChallengeCommentHighlightResponse> content = jpaQueryFactory
                 .select(new QChallengeCommentHighlightResponse(
                         highlight.id,
-                        truncatedHighlightText(),
+                        truncatedHighlightText(textTruncateRatio),
                         highlight.memo
                 ))
                 .from(highlight)
@@ -138,11 +139,11 @@ public class HighlightRepositoryImpl implements CustomHighlightRepository {
                 .orElse(null);
     }
 
-    private Expression<String> truncatedHighlightText() {
+    private Expression<String> truncatedHighlightText(double textTruncateRatio) {
         NumberExpression<Integer> threshold =
                 article.contentsText.length()
                         .doubleValue()
-                        .multiply(0.08)
+                        .multiply(textTruncateRatio)
                         .ceil()
                         .intValue();
 

--- a/backend/bom-bom-server/src/main/resources/db/migration/V17.0.1__increase_challenge_comment_quotation_length.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V17.0.1__increase_challenge_comment_quotation_length.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge_comment
+    MODIFY COLUMN quotation VARCHAR(400) NULL;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
@@ -17,6 +17,10 @@ import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentRequest;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.highlight.domain.Color;
+import me.bombom.api.v1.highlight.domain.Highlight;
+import me.bombom.api.v1.highlight.domain.HighlightLocation;
+import me.bombom.api.v1.highlight.repository.HighlightRepository;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.newsletter.domain.Category;
@@ -66,6 +70,9 @@ class ChallengeCommentControllerTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private HighlightRepository highlightRepository;
+
     private Member member;
     private List<Newsletter> newsletters;
     private Article article;
@@ -80,6 +87,7 @@ class ChallengeCommentControllerTest {
         newsletterDetailRepository.deleteAllInBatch();
         categoryRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
+        highlightRepository.deleteAllInBatch();
 
         member = TestFixture.normalMemberFixture();
         memberRepository.save(member);
@@ -215,5 +223,63 @@ class ChallengeCommentControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 인용구가_400자를_넘으면_400을_응답한다() throws Exception {
+        // given
+        String tooLongQuotation = "a".repeat(401);
+        ChallengeCommentRequest request = new ChallengeCommentRequest(
+                article.getId(),
+                tooLongQuotation,
+                "챌린지 한 줄 코멘트로 20자 이상의 댓글을 작성했습니다."
+        );
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments", 1L)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 하이라이트가_8퍼센트를_넘으면_잘라서_응답한다() throws Exception {
+        // given
+        String contentsText = "b".repeat(100);
+        Article longArticle = articleRepository.save(
+                Article.builder()
+                        .title("하이라이트 아티클")
+                        .contents("<p>본문</p>")
+                        .contentsText(contentsText)
+                        .thumbnailUrl("https://example.com/thumb.png")
+                        .expectedReadTime(4)
+                        .contentsSummary("요약")
+                        .isRead(true)
+                        .memberId(member.getId())
+                        .newsletterId(newsletters.getFirst().getId())
+                        .arrivedDateTime(LocalDateTime.now())
+                        .build()
+        );
+
+        highlightRepository.save(
+                Highlight.builder()
+                        .highlightLocation(new HighlightLocation(0, "div[0]/p[0]", 10, "div[0]/p[0]"))
+                        .memberId(member.getId())
+                        .newsletterId(longArticle.getNewsletterId())
+                        .articleId(longArticle.getId())
+                        .title(longArticle.getTitle())
+                        .color(Color.from("#00ff00"))
+                        .text("ABCDEFGHIJKL")
+                        .memo("memo")
+                        .build()
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/comments/articles/{articleId}/highlights", longArticle.getId())
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content[0].text").value("ABCDEFGH..."));
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
@@ -226,24 +226,6 @@ class ChallengeCommentControllerTest {
     }
 
     @Test
-    void 인용구가_400자를_넘으면_400을_응답한다() throws Exception {
-        // given
-        String tooLongQuotation = "a".repeat(401);
-        ChallengeCommentRequest request = new ChallengeCommentRequest(
-                article.getId(),
-                tooLongQuotation,
-                "챌린지 한 줄 코멘트로 20자 이상의 댓글을 작성했습니다."
-        );
-
-        // when & then
-        mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments", 1L)
-                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
     void 하이라이트가_8퍼센트를_넘으면_잘라서_응답한다() throws Exception {
         // given
         String contentsText = "b".repeat(100);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
@@ -15,10 +15,15 @@ import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentOptionsRequest;
 import me.bombom.api.v1.challenge.dto.request.ChallengeCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.highlight.domain.Color;
+import me.bombom.api.v1.highlight.domain.Highlight;
+import me.bombom.api.v1.highlight.domain.HighlightLocation;
+import me.bombom.api.v1.highlight.repository.HighlightRepository;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.newsletter.domain.Category;
@@ -61,6 +66,9 @@ class ChallengeCommentServiceTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private HighlightRepository highlightRepository;
+
     private Member member;
     private Article article;
     private List<Article> articles;
@@ -76,6 +84,7 @@ class ChallengeCommentServiceTest {
         newsletterDetailRepository.deleteAllInBatch();
         categoryRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
+        highlightRepository.deleteAllInBatch();
 
         member = TestFixture.normalMemberFixture();
         memberRepository.save(member);
@@ -277,5 +286,51 @@ class ChallengeCommentServiceTest {
                 999L,
                 request
         )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 하이라이트_텍스트가_기사_8퍼센트를_넘으면_잘라서_반환한다() {
+        // given
+        String contentsText = "a".repeat(100);
+        Article longArticle = articleRepository.save(
+                Article.builder()
+                        .title("길이가 긴 아티클")
+                        .contents("<p>본문</p>")
+                        .contentsText(contentsText)
+                        .thumbnailUrl("https://example.com/thumb.png")
+                        .expectedReadTime(3)
+                        .contentsSummary("요약")
+                        .isRead(true)
+                        .memberId(member.getId())
+                        .newsletterId(newsletters.getFirst().getId())
+                        .arrivedDateTime(LocalDateTime.now())
+                        .build()
+        );
+
+        highlightRepository.save(
+                Highlight.builder()
+                        .highlightLocation(new HighlightLocation(0, "div[0]/p[0]", 10, "div[0]/p[0]"))
+                        .memberId(member.getId())
+                        .newsletterId(longArticle.getNewsletterId())
+                        .articleId(longArticle.getId())
+                        .title(longArticle.getTitle())
+                        .color(Color.from("#ff0000"))
+                        .text("0123456789")
+                        .memo("memo")
+                        .build()
+        );
+
+        // when
+        Page<ChallengeCommentHighlightResponse> result = challengeCommentService.getChallengeArticleHighlights(
+                member.getId(),
+                longArticle.getId(),
+                PageRequest.of(0, 10)
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotalElements()).isEqualTo(1);
+            softly.assertThat(result.getContent().getFirst().text()).isEqualTo("01234567...");
+        });
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 코멘트를 작성할 때 인용구 길이 제한을 증가하고, 코멘트 작성 시 인용구 길이 제한을 검증합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
저작권상 2차 가공의 문제에 걸릴 있을 수 있으므로 아티클 하이라이트에 대한 인용구 사용 로직을 재정립해야했습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
## 로직을 변경하게 된 context
- UI가 변동된 부분은 없습니다. 챌린지 코멘트 작성 버튼 클릭 후 흐름은 아래와 같았습니다.
<p align="center">
<img width="400" height="605" alt="image" src="https://github.com/user-attachments/assets/627bf6e6-c66c-4fd1-8240-affe736c230f" />
</p>

1. 코멘트를 올릴 아티클 목록 중 하나 선택
2. 해당 아티클에 하이라이트/메모가 있다면 인용구로 사용할 수 있도록 하이라이트/메모 목록 조회 가능
3. 하이라이트 선택 시, 인용구에 하이라이트 내용이 들어감
- 지금 사진 예시에서는 인용구란 `혹시 집에서 홈트레이닝을 할 때, 옆에서 누군가...` 부분이 되겠습니다.

### 1️⃣ 아티클의 본문을 인용해 코멘트를 작성하는 행위의 저작권 문제
- 하이라이트를 인용구로 사용하게 되면, 아티클의 본문을 긁어와 사용하게 됩니다.
- 만약 사용자가 아티클 전문을 긁어 하이라이팅하면, 코멘트 작성시에도 아티클 전문을 인용구로 삼아 코멘트를 작성하게 됩니다.
- 이는 곧 뉴스레터 아티클에 대한 일종의 2차 가공 행위가 될 수 있어, 인용구의 길이 제한을 두고자 합니다.
- **전문 길이 중 약 5%~10% 정도로 적게 가져가서 안전하게 하기 위해 8%로 기준을 잡았습니다.**
  - ex: 미라클레터, 뉴닉 아티클 기준, 대략 6,000자 정도여서 8%면 480자가 됩니다.
- 따라서 인용구로 사용할 수 있는 글자수는 해당 아티클 본문의 8%가 1차적 기준입니다.

### 2️⃣ UI에서 보이는 인용구 길이 제한
- 저작권상으로 문제가 되지 않기위해 8% 기준은 잡았지만, 아티클의 글 자체가 너무 길어지면 이 8%도 매우 길어질 수 있습니다.
- UI상으로 좋지 못한 디자인이 될 것이라고 예상해, 프론트에서는 이 최대 8% 길이의 하이라이트를 받아도 이 조차도 UI에서 너무 길어보이면 더 잘라서 (...)를 append 하기로 했습니다.
<img width="2228" height="546" alt="image" src="https://github.com/user-attachments/assets/99f42df3-46d1-4775-9963-74a436628a2b" />

- 프론트에서는 4줄이 넘어가면 잘라서 보여줄 예정이고, 위가 4줄 예시 사진입니다.

---
## 백엔드 구현 사항
### 1. 챌린지 아티클에 대한 하이라이트/메모 목록 조회 API
- 기존에는 원래 있던 하이라이트/메모 목록 조회 API를 재사용했습니다.
- 하지만 위처럼 인용구의 최대 8%만 허용하기 위해서는 서버 내에서 아티클 전체 길이를 가지고 계산하는 로직이 필요했습니다.
- 이번에 하이라이트/메모 목록 조회 API를 챌린지 하이라이트에 계속해서 재사용하면서 아쉬웠던 점이 불필요하게 넘어오는 정보량이 너무 많았다는 점인데, (ex: `color`, `newsletterName`, `articleTitle` ...) 그래서 이번 기회에 API를 분리하기로 했습니다.
- 챌린지 아티클에 대한 하이라이트/메모 목록 조회는 `id`와 `text`, `memo`만 넘어갑니다.
- **하이라이트 본문(`text`)은 아티클 전문에서 8%가 넘어가면 자르고 (...)를 append합니다.**

### 2. 인용구 길이 제한 증가
- 프론트에서 저 4줄이 대략 400자라고 합니다.
- 일단 `ChallengeComment`의 `quotation` 길이를 기존 255 -> 400자로 증가했습니다.
- 코멘트 작성 요청시에도, request에서 `quotation`에 max 400자 제한을 걸어 검증하기로 했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 아티클 본문의 8% 길이를 제한하고 하이라이트 잘라내는 로직을 원래 service에서 해야할까 고민했는데, 저작권의 문제라서 비즈니스 로직상으로 변경될 내용이 아닌 고정될 로직인 것 같아 repository에서 바로 처리하도록 넣었습니다.
  - 적절할지, 더 좋은 의견 있다면 피드백 부탁드립니다!
- 하이라이트/메모 목록 조회 API의 쿼리를 집중적으로 피드백해주시면 좋을 것 같습니다. 특히 8% 제한해서 조회하는 부분이 올바른가 확인 부탁드립니다!
