### PR TITLE
[BOM-846] feat: 현황판 페이지 네이션 api

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeEligibilityResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
 import me.bombom.api.v1.challenge.service.ChallengeService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
@@ -66,5 +67,14 @@ public class ChallengeController implements ChallengeControllerApi {
             @LoginMember Member member
     ) {
         challengeService.cancelChallenge(id, member);
+    }
+
+    @Override
+    @GetMapping("/{id}/teams")
+    public ChallengeTeamListResponse getTeamList(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @LoginMember Member member
+    ) {
+        return challengeService.getTeamList(id, member);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
@@ -6,19 +6,15 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.List;
-import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
-import me.bombom.api.v1.common.resolver.LoginMember;
-import me.bombom.api.v1.member.domain.Member;
-import org.springframework.web.bind.annotation.GetMapping;
 import jakarta.validation.constraints.Positive;
-import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import java.util.List;
 import me.bombom.api.v1.challenge.dto.response.ChallengeEligibilityResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Challenge", description = "챌린지 관련 API")
@@ -85,6 +81,21 @@ public interface ChallengeControllerApi {
             @ApiResponse(responseCode = "404", description = "챌린지 또는 신청 내역을 찾을 수 없음", content = @Content)
     })
     void cancelChallenge(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @Parameter(hidden = true) @LoginMember Member member
+    );
+
+    @Operation(
+            summary = "챌린지 팀 목록 조회",
+            description = "챌린지에 참여한 모든 팀 목록을 조회합니다. 각 팀의 ID, 순서, 내 팀 여부 정보가 포함됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "팀 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음", content = @Content)
+    })
+    ChallengeTeamListResponse getTeamList(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
             @Parameter(hidden = true) @LoginMember Member member
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressController.java
@@ -31,11 +31,12 @@ public class ChallengeProgressController implements ChallengeProgressControllerA
     }
 
     @Override
-    @GetMapping("/{id}/progress/team")
-    public TeamChallengeProgressResponse getTeamProgress(
+    @GetMapping("/{id}/progress/teams/{teamId}")
+    public TeamChallengeProgressResponse getTeamProgressByTeamId(
             @LoginMember Member member,
-            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @PathVariable @Positive(message = "teamId는 1 이상의 값이어야 합니다.") Long teamId
     ) {
-        return challengeProgressService.getTeamProgress(id, member);
+        return challengeProgressService.getTeamProgressByTeamId(id, teamId, member);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerApi.java
@@ -13,7 +13,7 @@ import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.web.bind.annotation.PathVariable;
 
-@Tag(name = "ChallengeProgress", description = "챌린지 API")
+@Tag(name = "ChallengeProgress", description = "챌린지 진행도 관련 API")
 public interface ChallengeProgressControllerApi {
 
     @Operation(summary = "챌린지 내 사용자 진행도 조회", description = "사용자의 챌린지 진행도(투두 완료 현황, 총일수, 완료일수)를 조회합니다.")
@@ -28,14 +28,17 @@ public interface ChallengeProgressControllerApi {
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id
     );
 
-    @Operation(summary = "챌린지 팀 진행도 조회", description = "챌린지 참여 팀원들의 진행도 및 팀 요약 정보를 조회합니다.")
+    @Operation(summary = "특정 팀 진행도 조회", description = "특정 팀의 진행도 및 팀원들의 진행 상황을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "팀 진행도 조회 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
-            @ApiResponse(responseCode = "404", description = "챌린지/사용자를 찾을 수 없음", content = @Content)
+            @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (챌린지에 참가하지 않음)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지/팀을 찾을 수 없음", content = @Content)
     })
-    TeamChallengeProgressResponse getTeamProgress(
+    TeamChallengeProgressResponse getTeamProgressByTeamId(
             @Parameter(hidden = true) @LoginMember Member member,
-            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @Parameter(description = "팀 ID") @PathVariable @Positive(message = "teamId는 1 이상의 값이어야 합니다.") Long teamId
     );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeTeamListResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeTeamListResponse.java
@@ -20,7 +20,7 @@ public record ChallengeTeamListResponse(
             Long teamId,
 
             @Schema(required = true)
-            int displayOrder,
+            int teamNumber,
 
             @Schema(required = true)
             boolean isMyTeam

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeTeamListResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeTeamListResponse.java
@@ -1,0 +1,29 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+
+public record ChallengeTeamListResponse(
+
+        @Schema(required = true)
+        int totalTeamCount,
+
+        Long myTeamId,
+
+        @NotNull
+        List<TeamInfoResponse> teams
+) {
+    public record TeamInfoResponse(
+
+            @NotNull
+            Long teamId,
+
+            @Schema(required = true)
+            int displayOrder,
+
+            @Schema(required = true)
+            boolean isMyTeam
+    ) {
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
@@ -1,7 +1,18 @@
 package me.bombom.api.v1.challenge.repository;
 
+import java.util.List;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChallengeTeamRepository extends JpaRepository<ChallengeTeam, Long> {
+
+    @Query("""
+        SELECT ct
+        FROM ChallengeTeam ct
+        WHERE ct.challengeId = :challengeId
+        ORDER BY ct.id ASC
+    """)
+    List<ChallengeTeam> findAllByChallengeIdOrderByIdAsc(@Param("challengeId") Long challengeId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
@@ -12,7 +12,7 @@ public interface ChallengeTeamRepository extends JpaRepository<ChallengeTeam, Lo
         SELECT ct
         FROM ChallengeTeam ct
         WHERE ct.challengeId = :challengeId
-        ORDER BY ct.id ASC
+        ORDER BY ct.id
     """)
     List<ChallengeTeam> findAllByChallengeIdOrderByIdAsc(@Param("challengeId") Long challengeId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -80,19 +80,25 @@ public class ChallengeProgressService {
         return TeamChallengeProgressResponse.of(challenge, progressList);
     }
 
-    private void validateTeamBelongsToChallenge(Long challengeId, Long teamId) {
-        ChallengeTeam team = challengeTeamRepository.findById(teamId)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeTeam")
-                        .addContext(ErrorContextKeys.OPERATION, "validateTeamBelongsToChallenge")
-                        .addContext(ErrorContextKeys.DETAIL, "팀을 찾을 수 없습니다: " + teamId));
+    private void saveShieldDailyResult(ChallengeParticipant participant, LocalDate date) {
+        ChallengeDailyResult result = ChallengeDailyResult.builder()
+                .participantId(participant.getId())
+                .date(date)
+                .status(ChallengeDailyStatus.SHIELD)
+                .build();
+        challengeDailyResultRepository.save(result);
+    }
 
-        if (!team.getChallengeId().equals(challengeId)) {
-            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeTeam")
-                    .addContext(ErrorContextKeys.OPERATION, "validateTeamBelongsToChallenge")
-                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
-                    .addContext(ErrorContextKeys.DETAIL, "해당 팀은 이 챌린지에 속하지 않습니다: " + teamId);
+    private void checkFailure(ChallengeParticipant participant, Challenge challenge, LocalDate yesterday) {
+        // 종료 일은 포함하지 않아서 +1
+        int totalDays = challenge.getTotalDays();
+        int requiredSuccessDays = (int) Math.ceil(totalDays * SUCCESS_REQUIRED_RATIO);
+        int maxAllowedAbsent = totalDays - requiredSuccessDays;
+
+        int daysSinceStart = (int) (ChronoUnit.DAYS.between(challenge.getStartDate(), yesterday) + 1);
+        int currentAbsent = daysSinceStart - participant.getCompletedDays();
+        if (currentAbsent > maxAllowedAbsent) {
+            participant.markAsFailed();
         }
     }
 
@@ -117,25 +123,19 @@ public class ChallengeProgressService {
         }
     }
 
-    private void saveShieldDailyResult(ChallengeParticipant participant, LocalDate date) {
-        ChallengeDailyResult result = ChallengeDailyResult.builder()
-                .participantId(participant.getId())
-                .date(date)
-                .status(ChallengeDailyStatus.SHIELD)
-                .build();
-        challengeDailyResultRepository.save(result);
-    }
+    private void validateTeamBelongsToChallenge(Long challengeId, Long teamId) {
+        ChallengeTeam team = challengeTeamRepository.findById(teamId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeTeam")
+                        .addContext(ErrorContextKeys.OPERATION, "validateTeamBelongsToChallenge")
+                        .addContext(ErrorContextKeys.DETAIL, "팀을 찾을 수 없습니다: " + teamId));
 
-    private void checkFailure(ChallengeParticipant participant, Challenge challenge, LocalDate yesterday) {
-        // 종료 일은 포함하지 않아서 +1
-        int totalDays = challenge.getTotalDays();
-        int requiredSuccessDays = (int) Math.ceil(totalDays * SUCCESS_REQUIRED_RATIO);
-        int maxAllowedAbsent = totalDays - requiredSuccessDays;
-
-        int daysSinceStart = (int) (ChronoUnit.DAYS.between(challenge.getStartDate(), yesterday) + 1);
-        int currentAbsent = daysSinceStart - participant.getCompletedDays();
-        if (currentAbsent > maxAllowedAbsent) {
-            participant.markAsFailed();
+        if (!team.getChallengeId().equals(challengeId)) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeTeam")
+                    .addContext(ErrorContextKeys.OPERATION, "validateTeamBelongsToChallenge")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext(ErrorContextKeys.DETAIL, "해당 팀은 이 챌린지에 속하지 않습니다: " + teamId);
         }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -9,6 +9,7 @@ import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.dto.ChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
@@ -16,10 +17,12 @@ import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeTeamRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -36,6 +39,7 @@ public class ChallengeProgressService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
     private final ChallengeDailyResultRepository challengeDailyResultRepository;
+    private final ChallengeTeamRepository challengeTeamRepository;
 
     @Transactional
     public void proceedDailySurvivalCheck(Challenge challenge, LocalDate yesterday) {
@@ -62,28 +66,41 @@ public class ChallengeProgressService {
         return MemberChallengeProgressResponse.of(member, progressList);
     }
 
-    public TeamChallengeProgressResponse getTeamProgress(Long challengeId, Member member) {
+    public TeamChallengeProgressResponse getTeamProgressByTeamId(Long challengeId, Long teamId, Member member) {
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
-                        .addContext(ErrorContextKeys.OPERATION, "getTeamProgress"));
+                        .addContext(ErrorContextKeys.OPERATION, "getTeamProgressByTeamId"));
 
-        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, member.getId())
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
-                        .addContext(ErrorContextKeys.OPERATION, "getTeamProgress"));
+        validateParticipation(challengeId, member);
+        validateTeamBelongsToChallenge(challengeId, teamId);
 
-        List<TeamChallengeProgressFlat> progressList = challengeParticipantRepository.findTeamProgress(participant.getChallengeTeamId());
+        List<TeamChallengeProgressFlat> progressList = challengeParticipantRepository.findTeamProgress(teamId);
 
         return TeamChallengeProgressResponse.of(challenge, progressList);
+    }
+
+    private void validateTeamBelongsToChallenge(Long challengeId, Long teamId) {
+        ChallengeTeam team = challengeTeamRepository.findById(teamId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeTeam")
+                        .addContext(ErrorContextKeys.OPERATION, "validateTeamBelongsToChallenge")
+                        .addContext(ErrorContextKeys.DETAIL, "팀을 찾을 수 없습니다: " + teamId));
+
+        if (!team.getChallengeId().equals(challengeId)) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeTeam")
+                    .addContext(ErrorContextKeys.OPERATION, "validateTeamBelongsToChallenge")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext(ErrorContextKeys.DETAIL, "해당 팀은 이 챌린지에 속하지 않습니다: " + teamId);
+        }
     }
 
     private void validateParticipation(Long id, Member member) {
         boolean isParticipant = challengeParticipantRepository.existsByChallengeIdAndMemberId(id, member.getId());
         if (!isParticipant) {
-            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+            throw new UnauthorizedException(ErrorDetail.FORBIDDEN_RESOURCE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
-                    .addContext(ErrorContextKeys.OPERATION, "getMemberProgress")
                     .addContext(ErrorContextKeys.CHALLENGE_ID, id)
                     .addContext(ErrorContextKeys.MEMBER_ID, member.getId());
         }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -9,11 +9,13 @@ import java.time.LocalDate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.domain.EligibilityReason;
 import me.bombom.api.v1.challenge.dto.ChallengeNewsletterRow;
 import me.bombom.api.v1.challenge.dto.ChallengeParticipantCount;
@@ -22,9 +24,11 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeEligibilityResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeNewsletterResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeNewsletterRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeTeamRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
@@ -46,6 +50,7 @@ public class ChallengeService {
     private final ChallengeRepository challengeRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
     private final ChallengeNewsletterRepository challengeNewsletterRepository;
+    private final ChallengeTeamRepository challengeTeamRepository;
 
     public List<ChallengeResponse> getChallenges(Member member) {
         List<Challenge> challenges = challengeRepository.findAll();
@@ -151,6 +156,32 @@ public class ChallengeService {
 
     public List<Challenge> getOngoingChallenges(LocalDate date) {
         return challengeRepository.findOngoingChallenges(date);
+    }
+
+    public ChallengeTeamListResponse getTeamList(Long challengeId, Member member) {
+        if (!challengeRepository.existsById(challengeId)) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                    .addContext(ErrorContextKeys.OPERATION, "getTeamList");
+        }
+
+        Long myTeamId = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, member.getId())
+                .map(ChallengeParticipant::getChallengeTeamId)
+                .orElse(null);
+
+        List<ChallengeTeam> teams = challengeTeamRepository.findAllByChallengeIdOrderByIdAsc(challengeId);
+
+        List<ChallengeTeamListResponse.TeamInfoResponse> teamInfos = IntStream.range(0, teams.size())
+                .mapToObj(index -> {
+                    ChallengeTeam team = teams.get(index);
+                    return new ChallengeTeamListResponse.TeamInfoResponse(
+                            team.getId(),
+                            index + 1,
+                            team.getId().equals(myTeamId));
+                })
+                .toList();
+
+        return new ChallengeTeamListResponse(teams.size(), myTeamId, teamInfos);
     }
 
     private ChallengeResponse toChallengeResponse(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -6,10 +6,11 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.IntStream;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.challenge.domain.Challenge;
@@ -171,15 +172,14 @@ public class ChallengeService {
 
         List<ChallengeTeam> teams = challengeTeamRepository.findAllByChallengeIdOrderByIdAsc(challengeId);
 
-        List<ChallengeTeamListResponse.TeamInfoResponse> teamInfos = IntStream.range(0, teams.size())
-                .mapToObj(index -> {
-                    ChallengeTeam team = teams.get(index);
-                    return new ChallengeTeamListResponse.TeamInfoResponse(
-                            team.getId(),
-                            index + 1,
-                            team.getId().equals(myTeamId));
-                })
-                .toList();
+        List<ChallengeTeamListResponse.TeamInfoResponse> teamInfos = new ArrayList<>(teams.size());
+        int displayOrder = 1;
+        for (ChallengeTeam team : teams) {
+            teamInfos.add(new ChallengeTeamListResponse.TeamInfoResponse(
+                    team.getId(),
+                    displayOrder++,
+                    Objects.equals(team.getId(), myTeamId)));
+        }
 
         return new ChallengeTeamListResponse(teams.size(), myTeamId, teamInfos);
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -173,11 +173,11 @@ public class ChallengeService {
         List<ChallengeTeam> teams = challengeTeamRepository.findAllByChallengeIdOrderByIdAsc(challengeId);
 
         List<ChallengeTeamListResponse.TeamInfoResponse> teamInfos = new ArrayList<>(teams.size());
-        int displayOrder = 1;
+        int teamNumber = 1;
         for (ChallengeTeam team : teams) {
             teamInfos.add(new ChallengeTeamListResponse.TeamInfoResponse(
                     team.getId(),
-                    displayOrder++,
+                    teamNumber++,
                     Objects.equals(team.getId(), myTeamId)));
         }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerUnitTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.time.LocalDate;
 import java.util.List;
 import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
 import me.bombom.api.v1.challenge.service.ChallengeService;
 import me.bombom.api.v1.common.exception.GlobalExceptionHandler;
 import me.bombom.api.v1.member.domain.Member;
@@ -132,6 +133,45 @@ class ChallengeControllerUnitTest {
     void 챌린지_취소시_음수_id면_400() throws Exception {
         //when & then
         mockMvc.perform(delete("/api/v1/challenges/{id}/application", -1L))
+                .andDo(print())
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 팀_목록_조회_시_내_팀_포함() throws Exception {
+        // given
+        List<ChallengeTeamListResponse.TeamInfoResponse> teams = List.of(
+                new ChallengeTeamListResponse.TeamInfoResponse(1L, 1, false),
+                new ChallengeTeamListResponse.TeamInfoResponse(2L, 2, true),
+                new ChallengeTeamListResponse.TeamInfoResponse(3L, 3, false)
+        );
+        ChallengeTeamListResponse response = new ChallengeTeamListResponse(3, 2L, teams);
+
+        given(challengeService.getTeamList(1L, null))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/teams", 1L))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.totalTeamCount").value(3))
+                .andExpect(jsonPath("$.myTeamId").value(2))
+                .andExpect(jsonPath("$.teams").isArray())
+                .andExpect(jsonPath("$.teams[0].teamId").value(1))
+                .andExpect(jsonPath("$.teams[0].displayOrder").value(1))
+                .andExpect(jsonPath("$.teams[0].isMyTeam").value(false))
+                .andExpect(jsonPath("$.teams[1].teamId").value(2))
+                .andExpect(jsonPath("$.teams[1].displayOrder").value(2))
+                .andExpect(jsonPath("$.teams[1].isMyTeam").value(true))
+                .andExpect(jsonPath("$.teams[2].teamId").value(3))
+                .andExpect(jsonPath("$.teams[2].displayOrder").value(3))
+                .andExpect(jsonPath("$.teams[2].isMyTeam").value(false));
+    }
+
+    @Test
+    void 팀_목록_조회시_음수_id면_400() throws Exception {
+        //when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/teams", -1L))
                 .andDo(print())
                 .andExpect(status().isBadRequest());
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerUnitTest.java
@@ -158,13 +158,13 @@ class ChallengeControllerUnitTest {
                 .andExpect(jsonPath("$.myTeamId").value(2))
                 .andExpect(jsonPath("$.teams").isArray())
                 .andExpect(jsonPath("$.teams[0].teamId").value(1))
-                .andExpect(jsonPath("$.teams[0].displayOrder").value(1))
+                .andExpect(jsonPath("$.teams[0].teamNumber").value(1))
                 .andExpect(jsonPath("$.teams[0].isMyTeam").value(false))
                 .andExpect(jsonPath("$.teams[1].teamId").value(2))
-                .andExpect(jsonPath("$.teams[1].displayOrder").value(2))
+                .andExpect(jsonPath("$.teams[1].teamNumber").value(2))
                 .andExpect(jsonPath("$.teams[1].isMyTeam").value(true))
                 .andExpect(jsonPath("$.teams[2].teamId").value(3))
-                .andExpect(jsonPath("$.teams[2].displayOrder").value(3))
+                .andExpect(jsonPath("$.teams[2].teamNumber").value(3))
                 .andExpect(jsonPath("$.teams[2].isMyTeam").value(false));
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerTest.java
@@ -90,44 +90,6 @@ class ChallengeProgressControllerTest {
                                 "google");
         }
 
-        @Test
-        void 팀_챌린지_진행상황을_조회한다() throws Exception {
-                // given
-                Member memberB = memberRepository.save(TestFixture.createUniqueMember("userB", "B"));
-                ChallengeTeam team = challengeTeamRepository.save(createChallengeTeam(challenge.getId(), 77));
-
-                // Member A: Completed 2 days
-                challengeParticipantRepository.save(
-                                createTeamParticipant(challenge.getId(), memberA.getId(), team.getId(), 2, false));
-
-                // Member B: Completed 3 days
-                ChallengeParticipant participantB = challengeParticipantRepository.save(
-                                createTeamParticipant(challenge.getId(), memberB.getId(), team.getId(), 3, true));
-
-                // Daily Results for Member B
-                ChallengeDailyResult resultB1 = createChallengeDailyResult(participantB.getId(), LocalDate.now(),
-                                ChallengeDailyStatus.COMPLETE);
-                ChallengeDailyResult resultB2 = createChallengeDailyResult(participantB.getId(),
-                                LocalDate.now().plusDays(1),
-                                ChallengeDailyStatus.SHIELD);
-                challengeDailyResultRepository.saveAll(List.of(resultB1, resultB2));
-
-                // when & then
-                mockMvc.perform(get("/api/v1/challenges/{id}/progress/team", challenge.getId())
-                                .with(authentication(authToken)))
-                                .andExpect(status().isOk())
-                                .andDo(print())
-                                .andExpect(jsonPath("$.teamSummary.achievementAverage").value(team.getProgress()))
-                                .andExpect(jsonPath("$.members").isArray())
-                                .andExpect(jsonPath("$.members[0].nickname").value(memberB.getNickname())) // Sorted by completedDays
-                                .andExpect(jsonPath("$.members[0].dailyProgresses").isArray())
-                                .andExpect(jsonPath("$.members[0].dailyProgresses[0].status").value("COMPLETE"))
-                                .andExpect(jsonPath("$.members[0].dailyProgresses[1].status").value("SHIELD"))
-
-                                .andExpect(jsonPath("$.members[1].nickname").value(memberA.getNickname()))
-                                .andDo(print());
-        }
-
         private ChallengeParticipant createTeamParticipant(Long challengeId, Long memberId, Long teamId,
                         int completedDays, boolean isSurvived) {
                 return ChallengeParticipant.builder()
@@ -154,5 +116,42 @@ class ChallengeProgressControllerTest {
                                 .date(date)
                                 .status(status)
                                 .build();
+        }
+
+        @Test
+        void 특정_팀_진행상황을_조회한다() throws Exception {
+                // given
+                Member memberB = memberRepository.save(TestFixture.createUniqueMember("userB", "B"));
+                ChallengeTeam team = challengeTeamRepository.save(createChallengeTeam(challenge.getId(), 77));
+
+                // Member A: Completed 2 days
+                challengeParticipantRepository.save(
+                                createTeamParticipant(challenge.getId(), memberA.getId(), team.getId(), 2, false));
+
+                // Member B: Completed 3 days
+                ChallengeParticipant participantB = challengeParticipantRepository.save(
+                                createTeamParticipant(challenge.getId(), memberB.getId(), team.getId(), 3, true));
+
+                // Daily Results for Member B
+                ChallengeDailyResult resultB1 = createChallengeDailyResult(participantB.getId(), LocalDate.now(),
+                                ChallengeDailyStatus.COMPLETE);
+                ChallengeDailyResult resultB2 = createChallengeDailyResult(participantB.getId(),
+                                LocalDate.now().plusDays(1),
+                                ChallengeDailyStatus.SHIELD);
+                challengeDailyResultRepository.saveAll(List.of(resultB1, resultB2));
+
+                // when & then
+                mockMvc.perform(get("/api/v1/challenges/{id}/progress/teams/{teamId}", challenge.getId(), team.getId())
+                                .with(authentication(authToken)))
+                                .andExpect(status().isOk())
+                                .andDo(print())
+                                .andExpect(jsonPath("$.teamSummary.achievementAverage").value(team.getProgress()))
+                                .andExpect(jsonPath("$.members").isArray())
+                                .andExpect(jsonPath("$.members[0].nickname").value(memberB.getNickname())) // Sorted by completedDays
+                                .andExpect(jsonPath("$.members[0].dailyProgresses").isArray())
+                                .andExpect(jsonPath("$.members[0].dailyProgresses[0].status").value("COMPLETE"))
+                                .andExpect(jsonPath("$.members[0].dailyProgresses[1].status").value("SHIELD"))
+                                .andExpect(jsonPath("$.members[1].nickname").value(memberA.getNickname()))
+                                .andDo(print());
         }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -14,7 +14,12 @@ import java.util.Map;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
+import java.time.LocalDate;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
+import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
+import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
 import me.bombom.api.v1.common.config.WebConfig;
@@ -106,6 +111,69 @@ class ChallengeProgressControllerUnitTest {
 
         // when & then
         mockMvc.perform(get("/api/v1/challenges/{id}/progress/me", invalidId)
+                        .with(authentication(authentication)))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    void 특정_팀_진행도_조회_성공() throws Exception {
+        // given
+        Long challengeId = 1L;
+        Long teamId = 10L;
+        
+        Challenge challenge = Challenge.builder()
+                .id(challengeId)
+                .name("Test Challenge")
+                .generation(1)
+                .startDate(LocalDate.now().minusDays(5))
+                .endDate(LocalDate.now().plusDays(5))
+                .totalDays(10)
+                .build();
+        
+        TeamChallengeProgressFlat progressFlat = new TeamChallengeProgressFlat(
+                1L, "tester", true, 5, 10, 77, LocalDate.now(), ChallengeDailyStatus.COMPLETE);
+        
+        TeamChallengeProgressResponse response = TeamChallengeProgressResponse.of(
+                challenge,
+                List.of(progressFlat)
+        );
+
+        given(challengeProgressService.getTeamProgressByTeamId(eq(challengeId), eq(teamId), any(Member.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/progress/teams/{teamId}", challengeId, teamId)
+                        .with(authentication(authentication)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.challenge").exists())
+                .andExpect(jsonPath("$.teamSummary").exists())
+                .andExpect(jsonPath("$.teamSummary.achievementAverage").value(77))
+                .andExpect(jsonPath("$.members").isArray())
+                .andDo(print());
+    }
+
+    @Test
+    void 특정_팀_진행도_조회_실패_챌린지_ID가_양수가_아님() throws Exception {
+        // given
+        Long invalidId = -1L;
+        Long teamId = 10L;
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/progress/teams/{teamId}", invalidId, teamId)
+                        .with(authentication(authentication)))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    void 특정_팀_진행도_조회_실패_팀_ID가_양수가_아님() throws Exception {
+        // given
+        Long challengeId = 1L;
+        Long invalidTeamId = -1L;
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/progress/teams/{teamId}", challengeId, invalidTeamId)
                         .with(authentication(authentication)))
                 .andExpect(status().isBadRequest())
                 .andDo(print());

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -18,7 +18,6 @@ import me.bombom.api.v1.challenge.domain.ChallengeTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
-import me.bombom.api.v1.challenge.dto.response.MemberDailyResultResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
@@ -29,6 +28,8 @@ import me.bombom.api.v1.challenge.repository.ChallengeTeamRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
+import me.bombom.api.v1.common.exception.UnauthorizedException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.support.IntegrationTest;
@@ -126,110 +127,6 @@ class ChallengeProgressServiceTest {
                             tuple(ChallengeTodoType.COMMENT, ChallengeTodoStatus.INCOMPLETE)
                     );
         });
-    }
-
-    @Test
-    void 팀_챌린지_진행상황을_조회한다 () {
-        // given
-        ChallengeTeam team = challengeTeamRepository.save(createChallengeTeam(challenge.getId(), 77));
-
-        Member memberA = memberRepository.save(TestFixture.createUniqueMember("userA", "A"));
-        Member memberB = memberRepository.save(TestFixture.createUniqueMember("userB", "B"));
-
-        ChallengeParticipant participant1 = challengeParticipantRepository.save(
-                createTeamParticipant(
-                        challenge.getId(),
-                        memberA.getId(),
-                        team.getId(),
-                        2,
-                        false
-                )
-        );
-        ChallengeParticipant participant2 = challengeParticipantRepository.save(
-                createTeamParticipant(
-                        challenge.getId(),
-                        memberB.getId(),
-                        team.getId(),
-                        3,
-                        true)
-        );
-
-        ChallengeDailyResult result1 = createChallengeDailyResult(participant1.getId(), LocalDate.now(),
-                ChallengeDailyStatus.SHIELD);
-        ChallengeDailyResult result2 = createChallengeDailyResult(participant1.getId(), LocalDate.now().plusDays(1),
-                ChallengeDailyStatus.COMPLETE);
-        ChallengeDailyResult result3 = createChallengeDailyResult(participant2.getId(), LocalDate.now(),
-                ChallengeDailyStatus.COMPLETE);
-        ChallengeDailyResult result4 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(1),
-                ChallengeDailyStatus.SHIELD);
-        ChallengeDailyResult result5 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(2),
-                ChallengeDailyStatus.COMPLETE);
-        challengeDailyResultRepository.saveAll(List.of(result1, result2, result3, result4, result5));
-
-        // when
-        TeamChallengeProgressResponse response = challengeProgressService.getTeamProgress(
-                challenge.getId(), memberA);
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(response.teamSummary().achievementAverage()).isEqualTo(77);
-            softly.assertThat(response.members()).hasSize(2);
-
-            //정렬 순서 검증
-            softly.assertThat(response.members())
-                    .extracting("nickname")
-                    .containsExactly(memberB.getNickname(), memberA.getNickname());
-
-            MemberDailyResultResponse responseB = response.members().stream()
-                    .filter(m -> memberB.getNickname().equals(m.nickname()))
-                    .findFirst()
-                    .orElseThrow();
-
-            softly.assertThat(responseB.dailyProgresses())
-                    .hasSize(3)
-                    .extracting("status")
-                    .containsExactlyInAnyOrder(ChallengeDailyStatus.COMPLETE, ChallengeDailyStatus.SHIELD,
-                            ChallengeDailyStatus.COMPLETE);
-
-            softly.assertThat(responseB.dailyProgresses())
-                    .extracting("date")
-                    .containsExactly(
-                            LocalDate.now(),
-                            LocalDate.now().plusDays(1),
-                            LocalDate.now().plusDays(2)
-                    );
-        });
-    }
-
-    @Test
-    void 팀_챌린지_진행상황_조회_실패_참가정보_없음 () {
-        // given
-        Long nonExistentChallengeId = 0L;
-
-        // when & then
-        assertThatThrownBy(
-                () -> challengeProgressService.getTeamProgress(nonExistentChallengeId, member))
-                .isInstanceOf(CIllegalArgumentException.class)
-                .satisfies(e -> {
-                    CIllegalArgumentException exception = (CIllegalArgumentException) e;
-                    assertThat(exception.getContext().get(ErrorContextKeys.ENTITY_TYPE.getKey()))
-                            .isEqualTo("challenge");
-                });
-    }
-
-    @Test
-    void 팀_챌린지_진행상황_조회_실패_팀_없음() {
-            // given
-            Member newMember = memberRepository.save(TestFixture.createUniqueMember("new", "new"));
-
-            // when & then
-            assertThatThrownBy(() -> challengeProgressService.getTeamProgress(challenge.getId(), newMember))
-                            .isInstanceOf(CIllegalArgumentException.class)
-                            .satisfies(e -> {
-                                    CIllegalArgumentException exception = (CIllegalArgumentException) e;
-                                    assertThat(exception.getContext().get(ErrorContextKeys.ENTITY_TYPE.getKey()))
-                                                    .isEqualTo("challengeParticipant");
-                            });
     }
 
     @Test
@@ -334,6 +231,117 @@ class ChallengeProgressServiceTest {
             ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId())
                             .orElseThrow();
             assertThat(updatedParticipant.isSurvived()).isFalse();
+    }
+
+    @Test
+    void 특정_팀_진행상황을_조회한다() {
+        // given
+        ChallengeTeam team = challengeTeamRepository.save(createChallengeTeam(challenge.getId(), 77));
+
+        Member memberA = memberRepository.save(TestFixture.createUniqueMember("userA", "A"));
+        Member memberB = memberRepository.save(TestFixture.createUniqueMember("userB", "B"));
+
+        ChallengeParticipant participant1 = challengeParticipantRepository.save(
+                createTeamParticipant(challenge.getId(), memberA.getId(), team.getId(), 2, false));
+        ChallengeParticipant participant2 = challengeParticipantRepository.save(
+                createTeamParticipant(challenge.getId(), memberB.getId(), team.getId(), 3, true));
+
+        ChallengeDailyResult result1 = createChallengeDailyResult(participant1.getId(), LocalDate.now(),
+                ChallengeDailyStatus.SHIELD);
+        ChallengeDailyResult result2 = createChallengeDailyResult(participant1.getId(), LocalDate.now().plusDays(1),
+                ChallengeDailyStatus.COMPLETE);
+        ChallengeDailyResult result3 = createChallengeDailyResult(participant2.getId(), LocalDate.now(),
+                ChallengeDailyStatus.COMPLETE);
+        ChallengeDailyResult result4 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(1),
+                ChallengeDailyStatus.SHIELD);
+        ChallengeDailyResult result5 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(2),
+                ChallengeDailyStatus.COMPLETE);
+        challengeDailyResultRepository.saveAll(List.of(result1, result2, result3, result4, result5));
+
+        // when
+        TeamChallengeProgressResponse response = challengeProgressService.getTeamProgressByTeamId(
+                challenge.getId(), team.getId(), memberA);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.teamSummary().achievementAverage()).isEqualTo(77);
+            softly.assertThat(response.members()).hasSize(2);
+
+            // 정렬 순서 검증 (completedDays DESC)
+            softly.assertThat(response.members())
+                    .extracting("nickname")
+                    .containsExactly(memberB.getNickname(), memberA.getNickname());
+        });
+    }
+
+    @Test
+    void 특정_팀_진행상황_조회_실패_참가하지_않음() {
+        // given
+        ChallengeTeam team = challengeTeamRepository.save(createChallengeTeam(challenge.getId(), 77));
+        Member nonParticipant = memberRepository.save(TestFixture.createUniqueMember("nonParticipant", "NP"));
+
+        // when & then
+        assertThatThrownBy(() -> challengeProgressService.getTeamProgressByTeamId(
+                challenge.getId(), team.getId(), nonParticipant))
+                .isInstanceOf(UnauthorizedException.class)
+                .satisfies(e -> {
+                    UnauthorizedException exception = (UnauthorizedException) e;
+                    assertThat(exception.getErrorDetail()).isEqualTo(ErrorDetail.FORBIDDEN_RESOURCE);
+                });
+    }
+
+    @Test
+    void 특정_팀_진행상황_조회_실패_챌린지_없음() {
+        // given
+        ChallengeTeam team = challengeTeamRepository.save(createChallengeTeam(challenge.getId(), 77));
+        Long nonExistentChallengeId = 0L;
+
+        // when & then
+        assertThatThrownBy(() -> challengeProgressService.getTeamProgressByTeamId(
+                nonExistentChallengeId, team.getId(), member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .satisfies(e -> {
+                    CIllegalArgumentException exception = (CIllegalArgumentException) e;
+                    assertThat(exception.getContext().get(ErrorContextKeys.ENTITY_TYPE.getKey()))
+                            .isEqualTo("challenge");
+                });
+    }
+
+    @Test
+    void 특정_팀_진행상황_조회_실패_팀_없음() {
+        // given
+        Long nonExistentTeamId = 0L;
+
+        // when & then
+        assertThatThrownBy(() -> challengeProgressService.getTeamProgressByTeamId(
+                challenge.getId(), nonExistentTeamId, member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .satisfies(e -> {
+                    CIllegalArgumentException exception = (CIllegalArgumentException) e;
+                    assertThat(exception.getContext().get(ErrorContextKeys.ENTITY_TYPE.getKey()))
+                            .isEqualTo("challengeTeam");
+                });
+    }
+
+    @Test
+    void 특정_팀_진행상황_조회_실패_팀이_챌린지에_속하지_않음() {
+        // given
+        Challenge otherChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Other Challenge",
+                LocalDate.now().minusDays(5),
+                LocalDate.now().plusDays(5),
+                10));
+        ChallengeTeam otherTeam = challengeTeamRepository.save(createChallengeTeam(otherChallenge.getId(), 50));
+
+        // when & then
+        assertThatThrownBy(() -> challengeProgressService.getTeamProgressByTeamId(
+                challenge.getId(), otherTeam.getId(), member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .satisfies(e -> {
+                    CIllegalArgumentException exception = (CIllegalArgumentException) e;
+                    assertThat(exception.getContext().get(ErrorContextKeys.ENTITY_TYPE.getKey()))
+                            .isEqualTo("challengeTeam");
+                });
     }
 
     private ChallengeParticipant createTeamParticipant(Long challengeId, Long memberId, Long teamId,

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -12,13 +12,16 @@ import me.bombom.api.v1.challenge.domain.ChallengeNewsletter;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
 import me.bombom.api.v1.challenge.domain.EligibilityReason;
+import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.dto.response.ChallengeDetailResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeEligibilityResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeNewsletterRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeTeamRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
@@ -66,6 +69,9 @@ class ChallengeServiceTest {
     @Autowired
     private SubscribeRepository subscribeRepository;
 
+    @Autowired
+    private ChallengeTeamRepository challengeTeamRepository;
+
     private Member member;
     private List<Category> categories;
     private List<Newsletter> newsletters;
@@ -74,6 +80,7 @@ class ChallengeServiceTest {
     @BeforeEach
     void setUp() {
         challengeParticipantRepository.deleteAllInBatch();
+        challengeTeamRepository.deleteAllInBatch();
         challengeNewsletterRepository.deleteAllInBatch();
         challengeRepository.deleteAllInBatch();
         subscribeRepository.deleteAllInBatch();
@@ -610,5 +617,126 @@ class ChallengeServiceTest {
         assertThatThrownBy(() -> challengeService.cancelChallenge(challenge.getId(), member))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .hasMessage(ErrorDetail.ENTITY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 팀_목록_조회_시_내_팀_포함() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        ChallengeTeam team1 = TestFixture.createChallengeTeam(challenge.getId(), 50);
+        ChallengeTeam team2 = TestFixture.createChallengeTeam(challenge.getId(), 60);
+        ChallengeTeam team3 = TestFixture.createChallengeTeam(challenge.getId(), 70);
+        challengeTeamRepository.saveAll(List.of(team1, team2, team3));
+
+        ChallengeParticipant participant = TestFixture.createChallengeParticipantWithTeam(
+                challenge.getId(),
+                member.getId(),
+                team2.getId(),  // team2에 속함
+                5,
+                0
+        );
+        challengeParticipantRepository.save(participant);
+
+        // when
+        ChallengeTeamListResponse result = challengeService.getTeamList(challenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.totalTeamCount()).isEqualTo(3);
+            softly.assertThat(result.myTeamId()).isEqualTo(team2.getId());
+            softly.assertThat(result.teams()).hasSize(3);
+            softly.assertThat(result.teams().get(0).teamId()).isEqualTo(team1.getId());
+            softly.assertThat(result.teams().get(0).displayOrder()).isEqualTo(1);
+            softly.assertThat(result.teams().get(0).isMyTeam()).isFalse();
+            softly.assertThat(result.teams().get(1).teamId()).isEqualTo(team2.getId());
+            softly.assertThat(result.teams().get(1).displayOrder()).isEqualTo(2);
+            softly.assertThat(result.teams().get(1).isMyTeam()).isTrue();
+            softly.assertThat(result.teams().get(2).teamId()).isEqualTo(team3.getId());
+            softly.assertThat(result.teams().get(2).displayOrder()).isEqualTo(3);
+            softly.assertThat(result.teams().get(2).isMyTeam()).isFalse();
+        });
+    }
+
+    @Test
+    void 팀_목록_조회_시_내_팀이_null인_경우() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        ChallengeTeam team1 = TestFixture.createChallengeTeam(challenge.getId(), 50);
+        ChallengeTeam team2 = TestFixture.createChallengeTeam(challenge.getId(), 60);
+        challengeTeamRepository.saveAll(List.of(team1, team2));
+
+        // 참가는 했지만 팀에 배정되지 않은 경우
+        ChallengeParticipant participant = TestFixture.createChallengeParticipant(
+                challenge.getId(),
+                member.getId(),
+                5
+        );
+        challengeParticipantRepository.save(participant);
+
+        // when
+        ChallengeTeamListResponse result = challengeService.getTeamList(challenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.totalTeamCount()).isEqualTo(2);
+            softly.assertThat(result.myTeamId()).isNull();
+            softly.assertThat(result.teams()).hasSize(2);
+            softly.assertThat(result.teams().get(0).isMyTeam()).isFalse();
+            softly.assertThat(result.teams().get(1).isMyTeam()).isFalse();
+        });
+    }
+
+    @Test
+    void 팀_목록_조회_시_팀이_없는_경우() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        // when
+        ChallengeTeamListResponse result = challengeService.getTeamList(challenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.totalTeamCount()).isEqualTo(0);
+            softly.assertThat(result.myTeamId()).isNull();
+            softly.assertThat(result.teams()).isEmpty();
+        });
+    }
+
+    @Test
+    void 존재하지_않는_챌린지_ID로_팀_목록_조회_시_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> challengeService.getTeamList(0L, member))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasMessage(ErrorDetail.ENTITY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 팀_목록_조회_시_displayOrder가_올바르게_계산된다() {
+        // given
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
+        challengeRepository.save(challenge);
+
+        ChallengeTeam team1 = TestFixture.createChallengeTeam(challenge.getId(), 50);
+        ChallengeTeam team2 = TestFixture.createChallengeTeam(challenge.getId(), 60);
+        ChallengeTeam team3 = TestFixture.createChallengeTeam(challenge.getId(), 70);
+        ChallengeTeam team4 = TestFixture.createChallengeTeam(challenge.getId(), 80);
+        challengeTeamRepository.saveAll(List.of(team1, team2, team3, team4));
+
+        // when
+        ChallengeTeamListResponse result = challengeService.getTeamList(challenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.teams()).hasSize(4);
+            softly.assertThat(result.teams().get(0).displayOrder()).isEqualTo(1);
+            softly.assertThat(result.teams().get(1).displayOrder()).isEqualTo(2);
+            softly.assertThat(result.teams().get(2).displayOrder()).isEqualTo(3);
+            softly.assertThat(result.teams().get(3).displayOrder()).isEqualTo(4);
+        });
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -648,13 +648,13 @@ class ChallengeServiceTest {
             softly.assertThat(result.myTeamId()).isEqualTo(team2.getId());
             softly.assertThat(result.teams()).hasSize(3);
             softly.assertThat(result.teams().get(0).teamId()).isEqualTo(team1.getId());
-            softly.assertThat(result.teams().get(0).displayOrder()).isEqualTo(1);
+            softly.assertThat(result.teams().get(0).teamNumber()).isEqualTo(1);
             softly.assertThat(result.teams().get(0).isMyTeam()).isFalse();
             softly.assertThat(result.teams().get(1).teamId()).isEqualTo(team2.getId());
-            softly.assertThat(result.teams().get(1).displayOrder()).isEqualTo(2);
+            softly.assertThat(result.teams().get(1).teamNumber()).isEqualTo(2);
             softly.assertThat(result.teams().get(1).isMyTeam()).isTrue();
             softly.assertThat(result.teams().get(2).teamId()).isEqualTo(team3.getId());
-            softly.assertThat(result.teams().get(2).displayOrder()).isEqualTo(3);
+            softly.assertThat(result.teams().get(2).teamNumber()).isEqualTo(3);
             softly.assertThat(result.teams().get(2).isMyTeam()).isFalse();
         });
     }
@@ -716,7 +716,7 @@ class ChallengeServiceTest {
     }
 
     @Test
-    void 팀_목록_조회_시_displayOrder가_올바르게_계산된다() {
+    void 팀_목록_조회_시_teamNumber가_올바르게_계산된다() {
         // given
         Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15));
         challengeRepository.save(challenge);
@@ -733,10 +733,10 @@ class ChallengeServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(result.teams()).hasSize(4);
-            softly.assertThat(result.teams().get(0).displayOrder()).isEqualTo(1);
-            softly.assertThat(result.teams().get(1).displayOrder()).isEqualTo(2);
-            softly.assertThat(result.teams().get(2).displayOrder()).isEqualTo(3);
-            softly.assertThat(result.teams().get(3).displayOrder()).isEqualTo(4);
+            softly.assertThat(result.teams().get(0).teamNumber()).isEqualTo(1);
+            softly.assertThat(result.teams().get(1).teamNumber()).isEqualTo(2);
+            softly.assertThat(result.teams().get(2).teamNumber()).isEqualTo(3);
+            softly.assertThat(result.teams().get(3).teamNumber()).isEqualTo(4);
         });
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

챌린지 팀 진행도 조회 API를 팀 목록 조회와 특정 팀 진행도 조회로 분리하여, UI에서 팀을 선택한 후 해당 팀의 진행도를 조회할 수 있도록 변경했습니다.

기존 `GET /api/v1/challenges/{id}/progress/team` API를 삭제하고, 다음 두 개의 API를 새로 구현했습니다:
- `GET /api/v1/challenges/{id}/teams` - 챌린지 팀 목록 조회
- `GET /api/v1/challenges/{id}/progress/teams/{teamId}` - 특정 팀 진행도 조회

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

요구사항에 따라 사용자는 챌린지 내 모든 팀 중 원하는 팀을 선택하여 해당 팀의 진행도를 조회할 수 있어야 했습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

**기존:**
```
GET /api/v1/challenges/{id}/progress/team  // 내 팀 진행도만 조회
```

**변경 후:**
```
GET /api/v1/challenges/{id}/teams                    // 팀 목록 조회
GET /api/v1/challenges/{id}/progress/teams/{teamId}  // 특정 팀 진행도 조회
```

### 기능 흐름
팀목록 조회하여 각 팀에 대한 탭을 띄우고 탭을 누르면 각 팀에 대한 현황판을 조회
<img width="1944" height="1202" alt="image" src="https://github.com/user-attachments/assets/f2bcbf99-1ad8-42d1-8453-b7eddf5bb882" />

1. **팀 목록 조회** (`GET /api/v1/challenges/{id}/teams`)
   - 챌린지에 참가한 사용자가 호출 가능
   - 모든 팀 목록을 ID 기준 오름차순으로 조회
   - 각 팀에 대해 `teamId`, `displayOrder`(1부터 시작), `isMyTeam` 정보 제공
   - 응답에 `totalTeamCount`, `myTeamId` 포함

**팀 목록 조회 응답:**
```json
{
  "totalTeamCount": 3,
  "myTeamId": 10,
  "teams": [
    {
      "teamId": 1,
      "displayOrder": 1,
      "isMyTeam": false
    },
    {
      "teamId": 10,
      "displayOrder": 2,
      "isMyTeam": true
    },
    {
      "teamId": 12,
      "displayOrder": 3,
      "isMyTeam": false
    }
  ]
}
```

2. **특정 팀 진행도 조회** (`GET /api/v1/challenges/{id}/progress/teams/{teamId}`)
   - 팀 목록 조회에서 얻은 `teamId`를 사용하여 호출
   - 챌린지에 참가한 사용자만 조회 가능 (권한 검증)
   - 해당 팀의 진행도 및 팀원들의 일자별 진행 상황 반환
   - 응답 형식은 내 팀 진행도 조회와 동일

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 팀목록 조회에 대한 부분은 progress 말고 comment나 다른 부분에서도 충분히 쓰일만한 기능이라고 생각해서 ChallengeController 로 위치시켰는데 적절할까요
- 서비스나 레파지토리 로직에서 개선할 사항이 있는지
