### PR TITLE
[BOM-849] fix: 한 줄 코멘트 목록 조회 시 팀 구분 제거

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
@@ -12,28 +12,28 @@ import org.springframework.data.repository.query.Param;
 public interface ChallengeCommentRepository extends JpaRepository<ChallengeComment, Long> {
 
     @Query("""
-        SELECT new me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse(
-            m.nickname,
-            n.name,
-            CASE
-                WHEN s.id IS NULL THEN false
-                ELSE true
-            END,
-            cc.articleTitle,
-            cc.quotation,
-            cc.comment,
-            cc.createdAt
-        )
-        FROM ChallengeComment cc
-        JOIN ChallengeParticipant cp ON cc.participantId = cp.id
-        LEFT JOIN Member m ON cp.memberId = m.id
-        JOIN Newsletter n ON cc.newsletterId = n.id
-        LEFT JOIN Subscribe s ON s.newsletterId = cc.newsletterId AND s.memberId = :currentMemberId
-        WHERE cp.challengeTeamId = :teamId
-        AND FUNCTION('DATE', cc.createdAt) BETWEEN :startDate AND :endDate
-    """)
-    Page<ChallengeCommentResponse> findAllByTeamInDuration(
-            @Param("teamId") Long teamId,
+                SELECT new me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse(
+                    m.nickname,
+                    n.name,
+                    CASE
+                        WHEN s.id IS NULL THEN false
+                        ELSE true
+                    END,
+                    cc.articleTitle,
+                    cc.quotation,
+                    cc.comment,
+                    cc.createdAt
+                )
+                FROM ChallengeComment cc
+                JOIN ChallengeParticipant cp ON cc.participantId = cp.id
+                LEFT JOIN Member m ON cp.memberId = m.id
+                JOIN Newsletter n ON cc.newsletterId = n.id
+                LEFT JOIN Subscribe s ON s.newsletterId = cc.newsletterId AND s.memberId = :currentMemberId
+                WHERE cp.challengeId = :challengeId
+                AND FUNCTION('DATE', cc.createdAt) BETWEEN :startDate AND :endDate
+            """)
+    Page<ChallengeCommentResponse> findAllInDuration(
+            @Param("challengeId") Long challengeId,
             @Param("currentMemberId") Long currentMemberId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -46,13 +46,14 @@ public class ChallengeCommentService {
             ChallengeCommentOptionsRequest request,
             Pageable pageable
     ) {
-        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
-                        .addContext(ErrorContextKeys.MEMBER_ID, memberId)
-                        .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
+        if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
+            throw new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.OPERATION, "existsByChallengeIdAndMemberId");
+        }
 
         return challengeCommentRepository.findAllInDuration(
-                participant.getChallengeId(),
+                challengeId,
                 memberId,
                 request.start(),
                 request.end(),

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -50,8 +50,9 @@ public class ChallengeCommentService {
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
                         .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                         .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
-        return challengeCommentRepository.findAllByTeamInDuration(
-                participant.getChallengeTeamId(),
+
+        return challengeCommentRepository.findAllInDuration(
+                participant.getChallengeId(),
                 memberId,
                 request.start(),
                 request.end(),

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
@@ -112,7 +112,7 @@ class ChallengeCommentServiceTest {
     }
 
     @Test
-    void 같은_팀_댓글만_기간_내_조회_성공() {
+    void 같은_챌린지_참여자들_댓글만_기간_내_조회_성공() {
         // given
         LocalDate start = LocalDate.now().minusDays(1);
         LocalDate end = LocalDate.now().plusDays(1);
@@ -122,7 +122,7 @@ class ChallengeCommentServiceTest {
 
         ChallengeParticipant otherTeamParticipant = challengeParticipantRepository.save(
                 TestFixture.createChallengeParticipantWithTeam(
-                        2L,
+                        1L,
                         otherMember.getId(),
                         20L,
                         0,
@@ -159,7 +159,7 @@ class ChallengeCommentServiceTest {
         );
 
         // then
-        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getTotalElements()).isEqualTo(2);
         assertThat(result.getContent().get(0).comment()).isEqualTo(otherTeamComment.getComment());
     }
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
한 줄 코멘트 목록 조회 시 팀 구분을 제거합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 참여자들이 본인 팀 외에 더 다양한 참여자들의 코멘트를 읽어볼 수 있기 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 회의에서 나왔다시피, 한 줄 코멘트 목록을 조회할 때 팀 구분 없이 모든 참여자들의 코멘트를 볼 수 있으면 좋겠다는 피드백을 반영합니다.
- UI는 변동사항 없으며, 백에서만 기존 팀원들의 코멘트만 보여주던 것을 해당 챌린지 참여자 전체로 나오도록 수정했습니다.
  - UI상 팀 구분은 현재로서는 필요 없다고 판단했으며, 만약 태그가 있으면 좋겠다는 피드백이 올 경우 그 때 반영될 것 같습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 코멘트 목록 조회 쿼리에서 WHERE 절이 teamId에서 challengeId로만 변경됐습니다. 그 부분만 잘 봐주시면 됩니다. (style indent 때문에 변경 사항이 쓸데없이 많이 잡히네요..)