### PR TITLE
feat: 데일리 가이드 코멘트 목록 조회 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
@@ -60,10 +60,11 @@ public class ChallengeDailyGuideController implements ChallengeDailyGuideControl
     @Override
     @GetMapping("/{challengeId}/daily-guides/{dayIndex}/comments")
     public Page<DailyGuideCommentResponse> getDailyGuideComments(
+            @LoginMember Member member,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @PathVariable @Positive(message = "index는 1 이상의 값이어야 합니다.") int dayIndex,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return challengeDailyGuideService.getTotalComments(challengeId, dayIndex, pageable);
+        return challengeDailyGuideService.getTotalComments(challengeId, dayIndex, member.getId(), pageable);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
@@ -6,10 +6,15 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.challenge.service.ChallengeDailyGuideService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,5 +55,15 @@ public class ChallengeDailyGuideController implements ChallengeDailyGuideControl
     ) {
         LocalDate today = LocalDate.now(SEOUL_ZONE);
         challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request, today);
+    }
+
+    @Override
+    @GetMapping("/{challengeId}/daily-guides/{dayIndex}/comments")
+    public Page<DailyGuideCommentResponse> getDailyGuideComments(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
+            @PathVariable @Positive(message = "index는 1 이상의 값이어야 합니다.") int dayIndex,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return challengeDailyGuideService.getTotalComments(challengeId, dayIndex, pageable);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
@@ -9,9 +9,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Challenge Daily Guide", description = "챌린지 데일리 가이드 관련 API")
@@ -33,6 +36,21 @@ public interface ChallengeDailyGuideControllerApi {
     TodayDailyGuideResponse getTodayDailyGuide(
             @Parameter(hidden = true) @LoginMember Member member,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId
+    );
+
+    @Operation(
+            summary = "데일리 가이드 코멘트 목록 조회",
+            description = "특정 챌린지의 특정 일차 데일리 가이드에 작성된 코멘트 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "코멘트 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 ID)", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지 또는 데일리 가이드를 찾을 수 없음", content = @Content)
+    })
+    Page<DailyGuideCommentResponse> getDailyGuideComments(
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
+            @Parameter(description = "일차 인덱스 (1부터 시작)") @PathVariable @Positive(message = "index는 1 이상의 값이어야 합니다.") int dayIndex,
+            @Parameter(description = "페이징 관련 요청 (예: ?page=0&size=20&sort=createdAt,desc)") Pageable pageable
     );
 
     @Operation(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
@@ -48,6 +48,7 @@ public interface ChallengeDailyGuideControllerApi {
             @ApiResponse(responseCode = "404", description = "챌린지 또는 데일리 가이드를 찾을 수 없음", content = @Content)
     })
     Page<DailyGuideCommentResponse> getDailyGuideComments(
+            @Parameter(hidden = true) @LoginMember Member member,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(description = "일차 인덱스 (1부터 시작)") @PathVariable @Positive(message = "index는 1 이상의 값이어야 합니다.") int dayIndex,
             @Parameter(description = "페이징 관련 요청 (예: ?page=0&size=20&sort=createdAt,desc)") Pageable pageable

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/DailyGuideCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/DailyGuideCommentResponse.java
@@ -1,0 +1,21 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record DailyGuideCommentResponse(
+
+        @NotNull
+        String nickname,
+
+        @NotNull
+        String comment,
+
+        @NotNull
+        LocalDateTime createdAt
+) {
+
+    public static DailyGuideCommentResponse of(String nickname, String comment, LocalDateTime createdAt) {
+        return new DailyGuideCommentResponse(nickname, comment, createdAt);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
@@ -11,15 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChallengeDailyGuideCommentRepository extends JpaRepository<ChallengeDailyGuideComment, Long> {
 
-    @Query("""
-                SELECT c FROM ChallengeDailyGuideComment c
-                WHERE c.guideId = :guideId
-                AND c.participantId = :participantId
-            """)
-    Optional<ChallengeDailyGuideComment> findByGuideIdAndParticipantId(
-            @Param("guideId") Long guideId,
-            @Param("participantId") Long participantId
-    );
+    Optional<ChallengeDailyGuideComment> findByGuideIdAndParticipantId(Long guideId, Long participantId);
 
     @Query("""
             SELECT new me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
@@ -2,6 +2,9 @@ package me.bombom.api.v1.challenge.repository;
 
 import java.util.Optional;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
+import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,13 +12,26 @@ import org.springframework.data.repository.query.Param;
 public interface ChallengeDailyGuideCommentRepository extends JpaRepository<ChallengeDailyGuideComment, Long> {
 
     @Query("""
-        SELECT c FROM ChallengeDailyGuideComment c
-        WHERE c.guideId = :guideId
-        AND c.participantId = :participantId
-    """)
+                SELECT c FROM ChallengeDailyGuideComment c
+                WHERE c.guideId = :guideId
+                AND c.participantId = :participantId
+            """)
     Optional<ChallengeDailyGuideComment> findByGuideIdAndParticipantId(
             @Param("guideId") Long guideId,
             @Param("participantId") Long participantId
     );
+
+    @Query("""
+            SELECT new me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse(
+                            m.nickname,
+                            c.content,
+                            c.createdAt
+                        )
+            FROM ChallengeDailyGuideComment c
+            JOIN ChallengeParticipant cp on cp.id = c.participantId
+            JOIN Member m on m.id = cp.memberId
+            WHERE c.guideId = :guideId
+            """)
+    Page<DailyGuideCommentResponse> findByGuideId(@Param("guideId") Long guideId, Pageable pageable);
 }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -82,13 +82,20 @@ public class ChallengeDailyGuideService {
         );
     }
 
-    public Page<DailyGuideCommentResponse> getTotalComments(Long challengeId, int dayIndex, Pageable pageable) {
+    public Page<DailyGuideCommentResponse> getTotalComments(Long challengeId, int dayIndex, Long memberId, Pageable pageable) {
         Challenge challenge = challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
 
-        if (dayIndex > challenge.getTotalDays()) {
+        if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId);
+        }
+
+        if (dayIndex != 0 && (dayIndex < 1 || dayIndex > challenge.getTotalDays())) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
                     .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -11,6 +11,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse.MyCommentResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
@@ -21,6 +22,8 @@ import me.bombom.api.v1.challenge.repository.TodayDailyGuideRow;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -44,7 +47,7 @@ public class ChallengeDailyGuideService {
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
-        
+
         if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
             throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
@@ -78,6 +81,30 @@ public class ChallengeDailyGuideService {
                 myComment
         );
     }
+
+    public Page<DailyGuideCommentResponse> getTotalComments(Long challengeId, int dayIndex, Pageable pageable) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+
+        if (dayIndex > challenge.getTotalDays()) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext("dayIndex", dayIndex)
+                    .addContext("reason", "유효하지 않은 일차 인덱스입니다.");
+        }
+
+        ChallengeDailyGuide guide = challengeDailyGuideRepository.findByChallengeIdAndDayIndex(challengeId, dayIndex)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                        .addContext("dayIndex", dayIndex));
+
+        return challengeDailyGuideCommentRepository.findByGuideId(guide.getId(), pageable);
+    }
+
 
     @Transactional
     public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
@@ -141,12 +168,12 @@ public class ChallengeDailyGuideService {
             challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
             // COMMENT todo 생성 (한 줄 코멘트 작성)
             challengeTodoService.insertCommentDone(participant, today);
-            
+
             // 이미 완료되지 않았으면 progress 처리
             // day1에 두 todo(READ, COMMENT)가 모두 생성되므로 바로 완료 처리
             if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
                 challengeTodoService.completeDailyTodo(participant, today);
-                
+
                 // 팀 progress 업데이트
                 if (participant.getChallengeTeamId() != null) {
                     var challengeTeam = challengeTeamService.getChallengeTeamByParticipant(participant);
@@ -159,7 +186,7 @@ public class ChallengeDailyGuideService {
     private int calculateDayIndex(LocalDate startDate, LocalDate today) {
         DayOfWeek dayOfWeek = today.getDayOfWeek();
         boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
-        
+
         if (isWeekend) {
             return 0;
         }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
@@ -175,9 +175,32 @@ class ChallengeDailyGuideControllerTest {
 
     @Test
     void 데일리_가이드_댓글_작성_성공() throws Exception {
-        // given
+        // given - dayIndex가 1이 아닌 값으로 설정 (day1일 때 ChallengeTodo 필요하므로)
+        challengeDailyGuideCommentRepository.deleteAll();
+        challengeDailyGuideRepository.deleteAll();
+        
+        // dayIndex를 1이 아닌 값으로 설정 (day1이면 ChallengeTodo가 필요함)
+        int dayIndex = 2;
+        if (dayIndex > challenge.getTotalDays()) {
+            dayIndex = challenge.getTotalDays();
+        }
+        // totalDays가 1이면 테스트 불가 (dayIndex 1은 ChallengeTodo 필요)
+        if (challenge.getTotalDays() <= 1) {
+            return;
+        }
+        
+        guide = challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        dayIndex,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day07.webp",
+                        "오늘은 팁을 남겨주세요",
+                        true
+                )
+        );
+
         DailyGuideCommentRequest request = new DailyGuideCommentRequest("뉴스레터 읽기 팁을 공유합니다");
-        int dayIndex = guide.getDayIndex();
 
         // when & then
         mockMvc.perform(post("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/my-comment",
@@ -263,11 +286,13 @@ class ChallengeDailyGuideControllerTest {
 
     @Test
     void 주말_가이드_조회_성공() throws Exception {
-        // given - 주말 가이드 생성 (dayIndex = 0)
-        ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
+        // given - 기존 guide 삭제하고 오늘 날짜에 맞는 가이드 생성
+        challengeDailyGuideRepository.deleteAll();
+        int actualDayIndex = calculateDayIndex(challenge.getStartDate(), today);
+        ChallengeDailyGuide actualGuide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
                         challenge.getId(),
-                        0,
+                        actualDayIndex,
                         DailyGuideType.COMMENT,
                         "https://example.com/weekend.webp",
                         "주말입니다",
@@ -275,23 +300,24 @@ class ChallengeDailyGuideControllerTest {
                 )
         );
 
-        // when & then - 주말에는 dayIndex 0으로 조회됨
-        // 실제로는 주말이어야 하지만, 가이드가 있으면 정상 조회됨
+        // when & then
         mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/today", challenge.getId())
                         .with(authentication(authToken)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.dayIndex").exists())
+                .andExpect(jsonPath("$.dayIndex").value(actualDayIndex))
                 .andExpect(jsonPath("$.type").exists())
                 .andExpect(jsonPath("$.imageUrl").exists());
     }
 
     @Test
     void 주말_가이드_댓글_작성_불가() throws Exception {
-        // given - 주말 가이드 생성 (dayIndex = 0, commentEnabled = false)
-        ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
+        // given - 기존 guide 삭제하고 commentEnabled = false인 가이드 생성
+        challengeDailyGuideRepository.deleteAll();
+        int actualDayIndex = calculateDayIndex(challenge.getStartDate(), today);
+        ChallengeDailyGuide disabledGuide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
                         challenge.getId(),
-                        0,
+                        actualDayIndex,
                         DailyGuideType.COMMENT,
                         "https://example.com/weekend.webp",
                         "주말입니다",
@@ -300,9 +326,9 @@ class ChallengeDailyGuideControllerTest {
         );
         DailyGuideCommentRequest request = new DailyGuideCommentRequest("주말 댓글 작성 시도");
 
-        // when & then - dayIndex 0으로 댓글 작성 시도 (댓글 작성 불가능하므로 400)
+        // when & then - commentEnabled = false이므로 댓글 작성 불가능 (400)
         mockMvc.perform(post("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/my-comment",
-                        challenge.getId(), 0)
+                        challenge.getId(), actualDayIndex)
                         .with(authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -311,7 +337,24 @@ class ChallengeDailyGuideControllerTest {
 
     @Test
     void 데일리_가이드_코멘트_목록_조회_성공() throws Exception {
-        // given
+        // given - guide.getDayIndex()가 0(주말)이 아닌 경우만 테스트
+        int dayIndex = guide.getDayIndex();
+        if (dayIndex == 0) {
+            // 주말인 경우 유효한 dayIndex로 가이드 재생성
+            challengeDailyGuideRepository.deleteAll();
+            dayIndex = 1;
+            guide = challengeDailyGuideRepository.save(
+                    TestFixture.createChallengeDailyGuide(
+                            challenge.getId(),
+                            dayIndex,
+                            DailyGuideType.COMMENT,
+                            "https://example.com/day07.webp",
+                            "오늘은 팁을 남겨주세요",
+                            true
+                    )
+            );
+        }
+
         challengeDailyGuideCommentRepository.save(
                 TestFixture.createChallengeDailyGuideComment(
                         guide.getId(),
@@ -322,7 +365,8 @@ class ChallengeDailyGuideControllerTest {
 
         // when & then
         mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comments",
-                        challenge.getId(), guide.getDayIndex()))
+                        challenge.getId(), dayIndex)
+                        .with(authentication(authToken)))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content").isArray())
                 .andExpect(jsonPath("$.content[0].nickname").exists())
@@ -332,9 +376,39 @@ class ChallengeDailyGuideControllerTest {
 
     @Test
     void 존재하지_않는_챌린지로_코멘트_목록_조회시_404_응답() throws Exception {
+        // given - guide.getDayIndex()가 0(주말)이 아닌 경우만 테스트
+        int dayIndex = guide.getDayIndex() == 0 ? 1 : guide.getDayIndex();
+
         // when & then
         mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comments",
-                        999L, guide.getDayIndex()))
+                        999L, dayIndex)
+                        .with(authentication(authToken)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void 코멘트_목록_조회시_챌린지에_참여하지_않은_경우_404_응답() throws Exception {
+        // given - guide.getDayIndex()가 0(주말)이 아닌 경우만 테스트
+        int dayIndex = guide.getDayIndex() == 0 ? 1 : guide.getDayIndex();
+
+        Member otherMember = TestFixture.createUniqueMember("other", "other");
+        memberRepository.save(otherMember);
+        Map<String, Object> attributes = Map.of(
+                "id", otherMember.getId().toString(),
+                "email", otherMember.getEmail(),
+                "name", otherMember.getNickname()
+        );
+        CustomOAuth2User otherUser = new CustomOAuth2User(attributes, otherMember, null, null);
+        OAuth2AuthenticationToken otherToken = new OAuth2AuthenticationToken(
+                otherUser,
+                otherUser.getAuthorities(),
+                "registrationId"
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comments",
+                        challenge.getId(), dayIndex)
+                        .with(authentication(otherToken)))
                 .andExpect(status().isNotFound());
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerTest.java
@@ -308,5 +308,34 @@ class ChallengeDailyGuideControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    void 데일리_가이드_코멘트_목록_조회_성공() throws Exception {
+        // given
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant.getId(),
+                        "테스트 코멘트"
+                )
+        );
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comments",
+                        challenge.getId(), guide.getDayIndex()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").isArray())
+                .andExpect(jsonPath("$.content[0].nickname").exists())
+                .andExpect(jsonPath("$.content[0].comment").exists())
+                .andExpect(jsonPath("$.content[0].createdAt").exists());
+    }
+
+    @Test
+    void 존재하지_않는_챌린지로_코멘트_목록_조회시_404_응답() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comments",
+                        999L, guide.getDayIndex()))
+                .andExpect(status().isNotFound());
+    }
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -9,6 +9,9 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
@@ -587,6 +590,148 @@ class ChallengeDailyGuideServiceTest {
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(), today, readTodo.getId());
         assertThat(readTodoExists).isTrue();
+    }
+
+    @Test
+    void 데일리_가이드_코멘트_목록_조회_성공() {
+        // given
+        Member member2 = TestFixture.createUniqueMember("member2", "member2");
+        memberRepository.save(member2);
+        ChallengeParticipant participant2 = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member2.getId(),
+                        0
+                )
+        );
+
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant.getId(),
+                        "첫 번째 코멘트"
+                )
+        );
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant2.getId(),
+                        "두 번째 코멘트"
+                )
+        );
+
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
+                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), pageable);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.getContent()).hasSize(2);
+            softly.assertThat(response.getTotalElements()).isEqualTo(2);
+            softly.assertThat(response.getTotalPages()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void 데일리_가이드_코멘트_목록_조회_페이징() {
+        // given
+        Member member2 = TestFixture.createUniqueMember("member2", "member2");
+        memberRepository.save(member2);
+        ChallengeParticipant participant2 = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member2.getId(),
+                        0
+                )
+        );
+
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant.getId(),
+                        "첫 번째 코멘트"
+                )
+        );
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant2.getId(),
+                        "두 번째 코멘트"
+                )
+        );
+
+        Pageable pageable = PageRequest.of(0, 1);
+
+        // when
+        Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
+                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), pageable);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.getContent()).hasSize(1);
+            softly.assertThat(response.getTotalElements()).isEqualTo(2);
+            softly.assertThat(response.getTotalPages()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void 존재하지_않는_챌린지로_코멘트_목록_조회시_예외_발생() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getTotalComments(
+                999L,
+                guide.getDayIndex(),
+                pageable
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 유효하지_않은_dayIndex로_코멘트_목록_조회시_예외_발생() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        int invalidDayIndex = challenge.getTotalDays() + 1;
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getTotalComments(
+                challenge.getId(),
+                invalidDayIndex,
+                pageable
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 존재하지_않는_가이드로_코멘트_목록_조회시_예외_발생() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+        int nonExistentDayIndex = guide.getDayIndex() + 10;
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getTotalComments(
+                challenge.getId(),
+                nonExistentDayIndex,
+                pageable
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 코멘트가_없는_경우_빈_목록_반환() {
+        // given
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
+                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), pageable);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.getContent()).isEmpty();
+            softly.assertThat(response.getTotalElements()).isEqualTo(0);
+            softly.assertThat(response.getTotalPages()).isEqualTo(0);
+        });
     }
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -187,9 +187,28 @@ class ChallengeDailyGuideServiceTest {
 
     @Test
     void 데일리_가이드_댓글_작성_성공() {
-        // given
-        DailyGuideCommentRequest request = new DailyGuideCommentRequest("뉴스레터 읽기 팁을 공유합니다");
+        // given - guide.getDayIndex()가 0(주말)이 아닌 경우만 테스트
         int dayIndex = guide.getDayIndex();
+        
+        if (dayIndex == 0) {
+            // 주말인 경우 유효한 dayIndex로 가이드 재생성
+            challengeDailyGuideRepository.deleteAll();
+            dayIndex = 1;
+            guide = challengeDailyGuideRepository.save(
+                    TestFixture.createChallengeDailyGuide(
+                            challenge.getId(),
+                            dayIndex,
+                            DailyGuideType.COMMENT,
+                            "https://example.com/day07.webp",
+                            "오늘은 팁을 남겨주세요",
+                            true
+                    )
+            );
+        }
+        
+        final Long finalGuideId = guide.getId();
+
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("뉴스레터 읽기 팁을 공유합니다");
 
         // when
         challengeDailyGuideService.createDailyGuideComment(
@@ -204,7 +223,7 @@ class ChallengeDailyGuideServiceTest {
         List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
         assertSoftly(softly -> {
             softly.assertThat(comments).hasSize(1);
-            softly.assertThat(comments.get(0).getGuideId()).isEqualTo(guide.getId());
+            softly.assertThat(comments.get(0).getGuideId()).isEqualTo(finalGuideId);
             softly.assertThat(comments.get(0).getParticipantId()).isEqualTo(participant.getId());
             softly.assertThat(comments.get(0).getContent()).isEqualTo("뉴스레터 읽기 팁을 공유합니다");
         });
@@ -322,7 +341,8 @@ class ChallengeDailyGuideServiceTest {
 
     @Test
     void 주말_가이드_조회_성공() {
-        // given - 주말 가이드 생성 (dayIndex = 0)
+        // given - 기존 guide 삭제하고 주말 가이드 생성 (dayIndex = 0)
+        challengeDailyGuideRepository.deleteAll();
         ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
                         challenge.getId(),
@@ -334,24 +354,50 @@ class ChallengeDailyGuideServiceTest {
                 )
         );
 
-        // when - 주말 가이드 조회 (실제로는 주말일 때만 dayIndex 0이 반환되지만,
-        // 가이드가 존재하면 정상 조회됨)
-        TodayDailyGuideResponse response = challengeDailyGuideService.getTodayDailyGuide(
-                challenge.getId(),
-                member.getId()
-        );
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(response.dayIndex()).isGreaterThanOrEqualTo(0);
-            softly.assertThat(response.type()).isNotNull();
-            softly.assertThat(response.imageUrl()).isNotNull();
-        });
+        // when - 주말 가이드 조회
+        // 실제로 오늘이 주말이 아니면 dayIndex가 0이 아니므로 예외가 발생할 수 있음
+        // 따라서 실제 주말일 때만 테스트하거나, 가이드를 실제 dayIndex로 생성해야 함
+        int actualDayIndex = calculateDayIndex(challenge.getStartDate(), today);
+        if (actualDayIndex == 0) {
+            // 실제 주말인 경우
+            TodayDailyGuideResponse response = challengeDailyGuideService.getTodayDailyGuide(
+                    challenge.getId(),
+                    member.getId()
+            );
+            assertSoftly(softly -> {
+                softly.assertThat(response.dayIndex()).isEqualTo(0);
+                softly.assertThat(response.type()).isEqualTo(DailyGuideType.COMMENT);
+                softly.assertThat(response.imageUrl()).isEqualTo("https://example.com/weekend.webp");
+            });
+        } else {
+            // 주말이 아닌 경우, 실제 dayIndex에 맞는 가이드를 생성
+            challengeDailyGuideRepository.deleteAll();
+            ChallengeDailyGuide actualGuide = challengeDailyGuideRepository.save(
+                    TestFixture.createChallengeDailyGuide(
+                            challenge.getId(),
+                            actualDayIndex,
+                            DailyGuideType.COMMENT,
+                            "https://example.com/weekend.webp",
+                            "주말입니다",
+                            false
+                    )
+            );
+            TodayDailyGuideResponse response = challengeDailyGuideService.getTodayDailyGuide(
+                    challenge.getId(),
+                    member.getId()
+            );
+            assertSoftly(softly -> {
+                softly.assertThat(response.dayIndex()).isEqualTo(actualDayIndex);
+                softly.assertThat(response.type()).isNotNull();
+                softly.assertThat(response.imageUrl()).isNotNull();
+            });
+        }
     }
 
     @Test
     void 주말_가이드에_댓글_작성_불가() {
-        // given - 주말 가이드 생성 (dayIndex = 0, commentEnabled = false)
+        // given - 기존 guide 삭제하고 주말 가이드 생성 (dayIndex = 0, commentEnabled = false)
+        challengeDailyGuideRepository.deleteAll();
         ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
                         challenge.getId(),
@@ -376,7 +422,9 @@ class ChallengeDailyGuideServiceTest {
 
     @Test
     void dayIndex_0_유효성_검증_통과() {
-        // given - 주말 가이드 생성 (dayIndex = 0, commentEnabled = true)
+        // given - 기존 guide와 comment 삭제하고 주말 가이드 생성 (dayIndex = 0, commentEnabled = true)
+        challengeDailyGuideCommentRepository.deleteAll();
+        challengeDailyGuideRepository.deleteAll();
         ChallengeDailyGuide weekendGuide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
                         challenge.getId(),
@@ -624,7 +672,7 @@ class ChallengeDailyGuideServiceTest {
 
         // when
         Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
-                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), pageable);
+                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), member.getId(), pageable);
 
         // then
         assertSoftly(softly -> {
@@ -666,7 +714,7 @@ class ChallengeDailyGuideServiceTest {
 
         // when
         Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
-                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), pageable);
+                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), member.getId(), pageable);
 
         // then
         assertSoftly(softly -> {
@@ -685,6 +733,7 @@ class ChallengeDailyGuideServiceTest {
         assertThatThrownBy(() -> challengeDailyGuideService.getTotalComments(
                 999L,
                 guide.getDayIndex(),
+                member.getId(),
                 pageable
         )).isInstanceOf(CIllegalArgumentException.class);
     }
@@ -699,6 +748,7 @@ class ChallengeDailyGuideServiceTest {
         assertThatThrownBy(() -> challengeDailyGuideService.getTotalComments(
                 challenge.getId(),
                 invalidDayIndex,
+                member.getId(),
                 pageable
         )).isInstanceOf(CIllegalArgumentException.class);
     }
@@ -707,12 +757,26 @@ class ChallengeDailyGuideServiceTest {
     void 존재하지_않는_가이드로_코멘트_목록_조회시_예외_발생() {
         // given
         Pageable pageable = PageRequest.of(0, 20);
-        int nonExistentDayIndex = guide.getDayIndex() + 10;
+        // 유효한 dayIndex 범위 내이지만 존재하지 않는 가이드를 조회
+        // setUp에서 guide 하나만 생성했으므로, guide.getDayIndex()와 다른 유효한 dayIndex를 사용
+        int currentDayIndex = guide.getDayIndex();
+        int nonExistentDayIndex;
+        if (currentDayIndex == 0) {
+            // 주말 가이드(dayIndex=0)인 경우, 1을 사용
+            nonExistentDayIndex = 1;
+        } else if (currentDayIndex < challenge.getTotalDays()) {
+            // 다음 dayIndex 사용
+            nonExistentDayIndex = currentDayIndex + 1;
+        } else {
+            // 마지막 dayIndex인 경우, 이전 dayIndex 사용
+            nonExistentDayIndex = Math.max(1, currentDayIndex - 1);
+        }
 
         // when & then
         assertThatThrownBy(() -> challengeDailyGuideService.getTotalComments(
                 challenge.getId(),
                 nonExistentDayIndex,
+                member.getId(),
                 pageable
         )).isInstanceOf(CIllegalArgumentException.class);
     }
@@ -724,7 +788,7 @@ class ChallengeDailyGuideServiceTest {
 
         // when
         Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
-                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), pageable);
+                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), member.getId(), pageable);
 
         // then
         assertSoftly(softly -> {
@@ -732,6 +796,22 @@ class ChallengeDailyGuideServiceTest {
             softly.assertThat(response.getTotalElements()).isEqualTo(0);
             softly.assertThat(response.getTotalPages()).isEqualTo(0);
         });
+    }
+
+    @Test
+    void 코멘트_목록_조회시_챌린지에_참여하지_않은_경우_예외_발생() {
+        // given
+        Member otherMember = TestFixture.createUniqueMember("other", "other");
+        memberRepository.save(otherMember);
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getTotalComments(
+                challenge.getId(),
+                guide.getDayIndex(),
+                otherMember.getId(),
+                pageable
+        )).isInstanceOf(CIllegalArgumentException.class);
     }
 }
 


### PR DESCRIPTION
## 📌 What
특정일에 데일리 가이드 코멘트를 가져오는 API가 필요했음

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 참여자들이 본인 팀 외에 더 다양한 참여자들의 데일리 가이드 코멘트를 읽어볼 수 있기 위함입니다.

## 🔧 How

### API 사용되는 UI

아직 구체적 UI가 나오지 않아 회의에 사용했던 이미지로 갈음합니다. 
<img width="438" height="536" alt="image" src="https://github.com/user-attachments/assets/ea055256-6c1d-49c3-a3ec-3a095d1295a4" />

결과보기 버튼을 누르면 특정일의 모든 참여자의 데일리 가이드 코멘트를 가져오는데 이때 사용하는 GET API입니다. 

<img width="363" height="444" alt="image" src="https://github.com/user-attachments/assets/bd6e269d-b933-4cfb-88ea-9772ed273bc0" />

### 구현 사항 

`GET /api/v1/challenges/{challengeId}/daily-guides/{dayIndex}/comments`

- 특정 챌린지의 특정 일차 데일리 가이드에 작성된 모든 참여자의 코멘트를 페이징하여 조회합니다
- 조회된 코멘트는 작성일시 기준 내림차순으로 정렬됩니다 (기본값: size=20, sort=createdAt,DESC)
- 응답 형식: `Page<DailyGuideCommentResponse>` 
  - 각 코멘트는 작성자 닉네임(nickname), 코멘트 내용(comment), 작성 시간(createdAt)을 포함합니다


## 👀 Review Point (Optional)
- 단순 GET API라서 전체적으로 보셔도 큰 부담이 없으실 것 같습니다. 
- 현재 데일리 가이드 코멘트 다른 코드들이 조금 더러운데 해당 리팩터링은 다른 PR에서 진행하도록 하겠습니다.