### PR TITLE
hotfix: 챌린지에서 주말에는 읽기 체크가 되지 않도록 수정 

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
@@ -1,12 +1,17 @@
 package me.bombom.api.v1.challenge.service;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -16,7 +21,21 @@ public class ChallengeDailyTodoService {
 
     @Transactional
     public void updateChallengeDailyTodo(Long memberId, Long articleId, LocalDate today) {
+        if (isWeekend(today)) {
+            log.info("오늘은 {}입니다. 주말에는 챌린지를 진행하지 않습니다.", today.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN));
+            return;
+        }
+
         challengeDailyTodoRepository.insertTodayReadTodoIfMissing(
-                memberId, articleId, today, ChallengeTodoType.READ.name());
+                memberId,
+                articleId,
+                today,
+                ChallengeTodoType.READ.name()
+        );
+    }
+
+    private boolean isWeekend(LocalDate today) {
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -9,9 +9,6 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
@@ -37,6 +34,9 @@ import me.bombom.support.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 
 @IntegrationTest
 class ChallengeDailyGuideServiceTest {
@@ -132,7 +132,7 @@ class ChallengeDailyGuideServiceTest {
     private int calculateDayIndex(LocalDate startDate, LocalDate today) {
         DayOfWeek dayOfWeek = today.getDayOfWeek();
         boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
-        
+
         if (isWeekend) {
             return 0;
         }
@@ -189,7 +189,7 @@ class ChallengeDailyGuideServiceTest {
     void 데일리_가이드_댓글_작성_성공() {
         // given - guide.getDayIndex()가 0(주말)이 아닌 경우만 테스트
         int dayIndex = guide.getDayIndex();
-        
+
         if (dayIndex == 0) {
             // 주말인 경우 유효한 dayIndex로 가이드 재생성
             challengeDailyGuideRepository.deleteAll();
@@ -205,7 +205,7 @@ class ChallengeDailyGuideServiceTest {
                     )
             );
         }
-        
+
         final Long finalGuideId = guide.getId();
 
         DailyGuideCommentRequest request = new DailyGuideCommentRequest("뉴스레터 읽기 팁을 공유합니다");
@@ -472,13 +472,20 @@ class ChallengeDailyGuideServiceTest {
         );
         DailyGuideCommentRequest request = new DailyGuideCommentRequest("첫날 코멘트");
 
+        // 평일 날짜 사용 (주말에는 updateChallengeDailyTodo가 동작하지 않음)
+        LocalDate tempWeekday = today;
+        while (tempWeekday.getDayOfWeek() == DayOfWeek.SATURDAY || tempWeekday.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            tempWeekday = tempWeekday.plusDays(1);
+        }
+        final LocalDate weekday = tempWeekday;
+
         // when
         challengeDailyGuideService.createDailyGuideComment(
                 challenge.getId(),
                 1,
                 member.getId(),
                 request,
-                today
+                weekday
         );
 
         // then - 코멘트 생성 확인
@@ -487,17 +494,17 @@ class ChallengeDailyGuideServiceTest {
 
         // then - READ todo 생성 확인
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), today, readTodo.getId());
+                participant.getId(), weekday, readTodo.getId());
         assertThat(readTodoExists).isTrue();
 
         // then - COMMENT todo 생성 확인
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), today, commentTodo.getId());
+                participant.getId(), weekday, commentTodo.getId());
         assertThat(commentTodoExists).isTrue();
 
         // then - progress 처리 확인: ChallengeDailyResult 생성 확인
         boolean dailyResultExists = challengeDailyResultRepository.existsByParticipantIdAndDate(
-                participant.getId(), today);
+                participant.getId(), weekday);
         assertThat(dailyResultExists).isTrue();
 
         // then - progress 처리 확인: completedDays 증가 확인
@@ -558,11 +565,18 @@ class ChallengeDailyGuideServiceTest {
                 )
         );
 
+        // 평일 날짜 사용 (주말에는 updateChallengeDailyTodo가 동작하지 않음)
+        LocalDate tempWeekday = today;
+        while (tempWeekday.getDayOfWeek() == DayOfWeek.SATURDAY || tempWeekday.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            tempWeekday = tempWeekday.plusDays(1);
+        }
+        final LocalDate weekday = tempWeekday;
+
         // 이미 READ todo 생성
         challengeDailyTodoRepository.save(
                 TestFixture.createChallengeDailyTodo(
                         participant.getId(),
-                        today,
+                        weekday,
                         readTodo.getId()
                 )
         );
@@ -575,20 +589,20 @@ class ChallengeDailyGuideServiceTest {
                 1,
                 member.getId(),
                 request,
-                today
+                weekday
         );
 
         // then - READ todo는 1개만 존재 (중복 생성 안 됨)
         List<ChallengeDailyTodo> readTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
                 .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
-                .filter(todo -> todo.getTodoDate().equals(today))
+                .filter(todo -> todo.getTodoDate().equals(weekday))
                 .toList();
         assertThat(readTodos).hasSize(1);
 
         // then - COMMENT todo 생성 확인
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), today, commentTodo.getId());
+                participant.getId(), weekday, commentTodo.getId());
         assertThat(commentTodoExists).isTrue();
     }
 
@@ -606,11 +620,18 @@ class ChallengeDailyGuideServiceTest {
                 )
         );
 
+        // 평일 날짜 사용 (주말에는 updateChallengeDailyTodo가 동작하지 않음)
+        LocalDate tempWeekday = today;
+        while (tempWeekday.getDayOfWeek() == DayOfWeek.SATURDAY || tempWeekday.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            tempWeekday = tempWeekday.plusDays(1);
+        }
+        final LocalDate weekday = tempWeekday;
+
         // 이미 COMMENT todo 생성
         challengeDailyTodoRepository.save(
                 TestFixture.createChallengeDailyTodo(
                         participant.getId(),
-                        today,
+                        weekday,
                         commentTodo.getId()
                 )
         );
@@ -623,20 +644,20 @@ class ChallengeDailyGuideServiceTest {
                 1,
                 member.getId(),
                 request,
-                today
+                weekday
         );
 
         // then - COMMENT todo는 1개만 존재 (중복 생성 안 됨)
         List<ChallengeDailyTodo> commentTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
                 .filter(todo -> todo.getChallengeTodoId().equals(commentTodo.getId()))
-                .filter(todo -> todo.getTodoDate().equals(today))
+                .filter(todo -> todo.getTodoDate().equals(weekday))
                 .toList();
         assertThat(commentTodos).hasSize(1);
 
         // then - READ todo 생성 확인
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), today, readTodo.getId());
+                participant.getId(), weekday, readTodo.getId());
         assertThat(readTodoExists).isTrue();
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
@@ -1,7 +1,9 @@
 package me.bombom.api.v1.challenge.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -55,10 +57,14 @@ class ChallengeDailyTodoServiceTest {
     @Autowired
     private ArticleRepository articleRepository;
 
+    @Autowired
+    private ChallengeDailyTodoService challengeDailyTodoService;
+
     private Member member;
     private Challenge challenge;
     private ChallengeTodo readTodo;
     private Article todayArticle;
+    private LocalDate today;
 
     @BeforeEach
     void setUp() {
@@ -71,7 +77,13 @@ class ChallengeDailyTodoServiceTest {
 
         member = memberRepository.save(TestFixture.createUniqueMember("tester", "12345"));
 
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        // 평일로 고정 (주말 체크 로직 때문에)
+        LocalDate now = LocalDate.now(SEOUL_ZONE);
+        while (now.getDayOfWeek() == DayOfWeek.SATURDAY || now.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            now = now.plusDays(1);
+        }
+        today = now;
+        
         challenge = challengeRepository.save(TestFixture.createChallenge(
                 "테스트 챌린지",
                 today.minusDays(5),
@@ -96,7 +108,7 @@ class ChallengeDailyTodoServiceTest {
                         "오늘 뉴스레터",
                         member.getId(),
                         1L,
-                        LocalDateTime.now(SEOUL_ZONE)
+                        LocalDateTime.of(today, java.time.LocalTime.now(SEOUL_ZONE))
                 )
         );
     }
@@ -104,8 +116,45 @@ class ChallengeDailyTodoServiceTest {
     @Test
     @Transactional
     void 아티클_읽기시_챌린지_투두_업데이트() {
-        // given
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        // given - 실제 오늘이 주말이 아니어야 함 (ChallengeParticipantTodoListener가 실제 날짜 사용)
+        LocalDate actualToday = LocalDate.now(SEOUL_ZONE);
+        if (actualToday.getDayOfWeek() == DayOfWeek.SATURDAY || actualToday.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            // 주말이면 todo가 생성되지 않으므로 테스트 스킵
+            return;
+        }
+
+        // 실제 오늘 날짜에 맞는 데이터 재생성
+        challengeDailyTodoRepository.deleteAllInBatch();
+        articleRepository.deleteAllInBatch();
+        
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "테스트 챌린지",
+                actualToday.minusDays(5),
+                actualToday.plusDays(5),
+                10
+        ));
+        
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member.getId(),
+                        0
+                )
+        );
+
+        readTodo = challengeTodoRepository.save(
+                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
+        );
+
+        todayArticle = articleRepository.save(
+                TestFixture.createArticle(
+                        "오늘 뉴스레터",
+                        member.getId(),
+                        1L,
+                        LocalDateTime.of(actualToday, java.time.LocalTime.now(SEOUL_ZONE))
+                )
+        );
+
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                 challenge.getId(), member.getId()).orElseThrow();
 
@@ -118,14 +167,14 @@ class ChallengeDailyTodoServiceTest {
         List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
                 .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
-                .filter(todo -> todo.getTodoDate().equals(today))
+                .filter(todo -> todo.getTodoDate().equals(actualToday))
                 .toList();
 
         assertSoftly(softly -> {
             softly.assertThat(dailyTodos).hasSize(1);
             softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
             softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
-            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(today);
+            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(actualToday);
         });
     }
 
@@ -133,7 +182,6 @@ class ChallengeDailyTodoServiceTest {
     @Transactional
     void 이미_존재하는_챌린지_투두_중복_생성_안함() {
         // given
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                 challenge.getId(), member.getId()).orElseThrow();
 
@@ -163,6 +211,154 @@ class ChallengeDailyTodoServiceTest {
             softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
             softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
             softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(today);
+        });
+    }
+
+    @Test
+    @Transactional
+    void 주말_토요일에는_투두_생성되지_않음() {
+        // given
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        LocalDate tempSaturday = today;
+        
+        // 토요일로 조정
+        while (tempSaturday.getDayOfWeek() != DayOfWeek.SATURDAY) {
+            tempSaturday = tempSaturday.plusDays(1);
+        }
+        final LocalDate saturday = tempSaturday;
+        
+        // 챌린지 기간에 포함되도록 조정
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "주말 테스트 챌린지",
+                saturday.minusDays(5),
+                saturday.plusDays(5),
+                10
+        ));
+        
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member.getId(),
+                        0
+                )
+        );
+
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                challenge.getId(), member.getId()).orElseThrow();
+
+        // when
+        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null, saturday);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then - todo가 생성되지 않아야 함
+        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
+                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
+                .filter(todo -> todo.getTodoDate().equals(saturday))
+                .toList();
+
+        assertThat(dailyTodos).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    void 주말_일요일에는_투두_생성되지_않음() {
+        // given
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        LocalDate tempSunday = today;
+        
+        // 일요일로 조정
+        while (tempSunday.getDayOfWeek() != DayOfWeek.SUNDAY) {
+            tempSunday = tempSunday.plusDays(1);
+        }
+        final LocalDate sunday = tempSunday;
+        
+        // 챌린지 기간에 포함되도록 조정
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "주말 테스트 챌린지",
+                sunday.minusDays(5),
+                sunday.plusDays(5),
+                10
+        ));
+        
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member.getId(),
+                        0
+                )
+        );
+
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                challenge.getId(), member.getId()).orElseThrow();
+
+        // when
+        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null, sunday);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then - todo가 생성되지 않아야 함
+        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
+                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
+                .filter(todo -> todo.getTodoDate().equals(sunday))
+                .toList();
+
+        assertThat(dailyTodos).isEmpty();
+    }
+
+    @Test
+    @Transactional
+    void 평일에는_정상적으로_투두_생성됨() {
+        // given
+        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        LocalDate tempWeekday = today;
+        
+        // 평일로 조정 (월요일~금요일)
+        while (tempWeekday.getDayOfWeek() == DayOfWeek.SATURDAY || tempWeekday.getDayOfWeek() == DayOfWeek.SUNDAY) {
+            tempWeekday = tempWeekday.plusDays(1);
+        }
+        final LocalDate weekday = tempWeekday;
+        
+        // 챌린지 기간에 포함되도록 조정
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "평일 테스트 챌린지",
+                weekday.minusDays(5),
+                weekday.plusDays(5),
+                10
+        ));
+        
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        member.getId(),
+                        0
+                )
+        );
+
+        readTodo = challengeTodoRepository.save(
+                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
+        );
+
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                challenge.getId(), member.getId()).orElseThrow();
+
+        // when
+        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null, weekday);
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then - todo가 정상적으로 생성되어야 함
+        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
+                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
+                .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
+                .filter(todo -> todo.getTodoDate().equals(weekday))
+                .toList();
+
+        assertSoftly(softly -> {
+            softly.assertThat(dailyTodos).hasSize(1);
+            softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
+            softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
+            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(weekday);
         });
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
주말에도 읽기 체크가 되는 문제 발생
<img width="1451" height="675" alt="image" src="https://github.com/user-attachments/assets/f37a3577-39e2-469a-8e2e-56b8383ba8dc" />

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
비즈니스상 주말에는 뉴스레터를 읽어도 챌린지 읽기 체크가 되면 안된다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
주말이면 해당 메서드가 동작하지 않고 로그를 남기도록 수정

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 주말 차단은 오류가 아니라 정책 분기라서 예외를 던지지 않고 서비스 내부에서 조용히 종료하도록 했습니다