### PR TITLE
[BOM-859] hotfix: 챌린지 탈락 처리 스케줄러 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -70,5 +71,22 @@ public class Challenge extends BaseEntity {
 
     public boolean hasStarted(LocalDate now) {
         return !now.isBefore(this.startDate);
+    }
+
+    public int calculatePassedDays(LocalDate targetDate) {
+        int passedDays = 0;
+        LocalDate currentDate = this.startDate;
+        while (!currentDate.isAfter(targetDate)) {
+            if (isWeekend(currentDate)) {
+                passedDays++;
+            }
+            currentDate = currentDate.plusDays(1);
+        }
+        return passedDays;
+    }
+
+    private boolean isWeekend(LocalDate currentDate) {
+        DayOfWeek dayOfWeek = currentDate.getDayOfWeek();
+        return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
@@ -77,7 +77,7 @@ public class Challenge extends BaseEntity {
         int passedDays = 0;
         LocalDate currentDate = this.startDate;
         while (!currentDate.isAfter(targetDate)) {
-            if (isWeekend(currentDate)) {
+            if (isWeekday(currentDate)) {
                 passedDays++;
             }
             currentDate = currentDate.plusDays(1);
@@ -85,7 +85,7 @@ public class Challenge extends BaseEntity {
         return passedDays;
     }
 
-    private boolean isWeekend(LocalDate currentDate) {
+    private boolean isWeekday(LocalDate currentDate) {
         DayOfWeek dayOfWeek = currentDate.getDayOfWeek();
         return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY;
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -1,7 +1,6 @@
 package me.bombom.api.v1.challenge.service;
 
 import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -68,12 +67,14 @@ public class ChallengeProgressService {
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                         .addContext(ErrorContextKeys.OPERATION, "getTeamProgress"));
 
-        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, member.getId())
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId,
+                        member.getId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
                         .addContext(ErrorContextKeys.OPERATION, "getTeamProgress"));
 
-        List<TeamChallengeProgressFlat> progressList = challengeParticipantRepository.findTeamProgress(participant.getChallengeTeamId());
+        List<TeamChallengeProgressFlat> progressList = challengeParticipantRepository.findTeamProgress(
+                participant.getChallengeTeamId());
 
         return TeamChallengeProgressResponse.of(challenge, progressList);
     }
@@ -110,12 +111,11 @@ public class ChallengeProgressService {
     }
 
     private void checkFailure(ChallengeParticipant participant, Challenge challenge, LocalDate yesterday) {
-        // 종료 일은 포함하지 않아서 +1
         int totalDays = challenge.getTotalDays();
         int requiredSuccessDays = (int) Math.ceil(totalDays * SUCCESS_REQUIRED_RATIO);
         int maxAllowedAbsent = totalDays - requiredSuccessDays;
 
-        int daysSinceStart = (int) (ChronoUnit.DAYS.between(challenge.getStartDate(), yesterday) + 1);
+        int daysSinceStart = challenge.calculatePassedDays(yesterday);
         int currentAbsent = daysSinceStart - participant.getCompletedDays();
         if (currentAbsent > maxAllowedAbsent) {
             participant.markAsFailed();

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/domain/ChallengeTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/domain/ChallengeTest.java
@@ -1,0 +1,78 @@
+package me.bombom.api.v1.challenge.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import org.junit.jupiter.api.Test;
+
+class ChallengeTest {
+
+    @Test
+    void 시작일과_종료일_사이에_주말이_포함되어_있으면_주말을_제외하고_계산한다() {
+        // given
+        // 금요일 시작
+        LocalDate startDate = LocalDate.of(2024, 1, 5);
+        // 다음주 월요일까지 계산 (금, 토, 일, 월) -> 4일 경과
+        LocalDate targetDate = LocalDate.of(2024, 1, 8);
+
+        Challenge challenge = Challenge.builder()
+                .name("Test Challenge")
+                .startDate(startDate)
+                .endDate(startDate.plusDays(10))
+                .build();
+
+        // when
+        int passedDays = challenge.calculatePassedDays(targetDate);
+
+        // then
+        // 금(1) + 월(1) = 2일
+        assertSoftly(softly -> {
+            softly.assertThat(passedDays).isEqualTo(2);
+
+            int passedDaysWithWeekend = (int) (ChronoUnit.DAYS.between(challenge.getStartDate(), targetDate) + 1);
+            softly.assertThat(passedDays).isNotEqualTo(passedDaysWithWeekend);
+        });
+    }
+
+    @Test
+    void 시작일과_종료일이_모두_평일이고_주말이_없으면_날짜_차이만큼_계산한다() {
+        // given
+        // 월요일 시작
+        LocalDate startDate = LocalDate.of(2024, 1, 8);
+        // 수요일까지 (월, 화, 수) -> 3일
+        LocalDate targetDate = LocalDate.of(2024, 1, 10);
+
+        Challenge challenge = Challenge.builder()
+                .name("Test Challenge")
+                .startDate(startDate)
+                .endDate(startDate.plusDays(10))
+                .build();
+
+        // when
+        int passedDays = challenge.calculatePassedDays(targetDate);
+
+        // then
+        assertThat(passedDays).isEqualTo(3);
+    }
+
+    @Test
+    void 타겟_날짜가_시작일보다_전이면_0을_반환한다() {
+        // given
+        LocalDate startDate = LocalDate.of(2024, 1, 8);
+        LocalDate targetDate = LocalDate.of(2024, 1, 7);
+
+        Challenge challenge = Challenge.builder()
+                .name("Test Challenge")
+                .startDate(startDate)
+                .endDate(startDate.plusDays(10))
+                .build();
+
+        // when
+        int passedDays = challenge.calculatePassedDays(targetDate);
+
+        // then
+        assertThat(passedDays).isEqualTo(0);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -95,7 +95,8 @@ class ChallengeProgressServiceTest {
         ChallengeTodo readTodo = TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ);
         challengeTodoRepository.save(readTodo);
 
-        ChallengeTodo commentTodo = TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.COMMENT);
+        ChallengeTodo commentTodo = TestFixture.createChallengeTodo(challenge.getId(),
+                ChallengeTodoType.COMMENT);
         challengeTodoRepository.save(commentTodo);
 
         ChallengeDailyTodo dailyTodo = TestFixture.createChallengeDailyTodo(
@@ -120,16 +121,17 @@ class ChallengeProgressServiceTest {
             softly.assertThat(response.todayTodos()).hasSize(2);
 
             softly.assertThat(response.todayTodos())
-                    .extracting(TodayTodoResponse::challengeTodoType, TodayTodoResponse::challengeTodoStatus)
+                    .extracting(TodayTodoResponse::challengeTodoType,
+                            TodayTodoResponse::challengeTodoStatus)
                     .contains(
                             tuple(ChallengeTodoType.READ, ChallengeTodoStatus.COMPLETE),
-                            tuple(ChallengeTodoType.COMMENT, ChallengeTodoStatus.INCOMPLETE)
-                    );
+                            tuple(ChallengeTodoType.COMMENT,
+                                    ChallengeTodoStatus.INCOMPLETE));
         });
     }
 
     @Test
-    void 팀_챌린지_진행상황을_조회한다 () {
+    void 팀_챌린지_진행상황을_조회한다() {
         // given
         ChallengeTeam team = challengeTeamRepository.save(createChallengeTeam(challenge.getId(), 77));
 
@@ -142,27 +144,27 @@ class ChallengeProgressServiceTest {
                         memberA.getId(),
                         team.getId(),
                         2,
-                        false
-                )
-        );
+                        false));
         ChallengeParticipant participant2 = challengeParticipantRepository.save(
                 createTeamParticipant(
                         challenge.getId(),
                         memberB.getId(),
                         team.getId(),
                         3,
-                        true)
-        );
+                        true));
 
         ChallengeDailyResult result1 = createChallengeDailyResult(participant1.getId(), LocalDate.now(),
                 ChallengeDailyStatus.SHIELD);
-        ChallengeDailyResult result2 = createChallengeDailyResult(participant1.getId(), LocalDate.now().plusDays(1),
+        ChallengeDailyResult result2 = createChallengeDailyResult(participant1.getId(),
+                LocalDate.now().plusDays(1),
                 ChallengeDailyStatus.COMPLETE);
         ChallengeDailyResult result3 = createChallengeDailyResult(participant2.getId(), LocalDate.now(),
                 ChallengeDailyStatus.COMPLETE);
-        ChallengeDailyResult result4 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(1),
+        ChallengeDailyResult result4 = createChallengeDailyResult(participant2.getId(),
+                LocalDate.now().plusDays(1),
                 ChallengeDailyStatus.SHIELD);
-        ChallengeDailyResult result5 = createChallengeDailyResult(participant2.getId(), LocalDate.now().plusDays(2),
+        ChallengeDailyResult result5 = createChallengeDailyResult(participant2.getId(),
+                LocalDate.now().plusDays(2),
                 ChallengeDailyStatus.COMPLETE);
         challengeDailyResultRepository.saveAll(List.of(result1, result2, result3, result4, result5));
 
@@ -175,7 +177,7 @@ class ChallengeProgressServiceTest {
             softly.assertThat(response.teamSummary().achievementAverage()).isEqualTo(77);
             softly.assertThat(response.members()).hasSize(2);
 
-            //정렬 순서 검증
+            // 정렬 순서 검증
             softly.assertThat(response.members())
                     .extracting("nickname")
                     .containsExactly(memberB.getNickname(), memberA.getNickname());
@@ -188,7 +190,8 @@ class ChallengeProgressServiceTest {
             softly.assertThat(responseB.dailyProgresses())
                     .hasSize(3)
                     .extracting("status")
-                    .containsExactlyInAnyOrder(ChallengeDailyStatus.COMPLETE, ChallengeDailyStatus.SHIELD,
+                    .containsExactlyInAnyOrder(ChallengeDailyStatus.COMPLETE,
+                            ChallengeDailyStatus.SHIELD,
                             ChallengeDailyStatus.COMPLETE);
 
             softly.assertThat(responseB.dailyProgresses())
@@ -196,13 +199,12 @@ class ChallengeProgressServiceTest {
                     .containsExactly(
                             LocalDate.now(),
                             LocalDate.now().plusDays(1),
-                            LocalDate.now().plusDays(2)
-                    );
+                            LocalDate.now().plusDays(2));
         });
     }
 
     @Test
-    void 팀_챌린지_진행상황_조회_실패_참가정보_없음 () {
+    void 팀_챌린지_진행상황_조회_실패_참가정보_없음() {
         // given
         Long nonExistentChallengeId = 0L;
 
@@ -219,121 +221,122 @@ class ChallengeProgressServiceTest {
 
     @Test
     void 팀_챌린지_진행상황_조회_실패_팀_없음() {
-            // given
-            Member newMember = memberRepository.save(TestFixture.createUniqueMember("new", "new"));
+        // given
+        Member newMember = memberRepository.save(TestFixture.createUniqueMember("new", "new"));
 
-            // when & then
-            assertThatThrownBy(() -> challengeProgressService.getTeamProgress(challenge.getId(), newMember))
-                            .isInstanceOf(CIllegalArgumentException.class)
-                            .satisfies(e -> {
-                                    CIllegalArgumentException exception = (CIllegalArgumentException) e;
-                                    assertThat(exception.getContext().get(ErrorContextKeys.ENTITY_TYPE.getKey()))
-                                                    .isEqualTo("challengeParticipant");
-                            });
+        // when & then
+        assertThatThrownBy(() -> challengeProgressService.getTeamProgress(challenge.getId(), newMember))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .satisfies(e -> {
+                    CIllegalArgumentException exception = (CIllegalArgumentException) e;
+                    assertThat(exception.getContext().get(ErrorContextKeys.ENTITY_TYPE.getKey()))
+                            .isEqualTo("challengeParticipant");
+                });
     }
 
     @Test
     void 쉴드를_보유한_참가자는_결석_시_쉴드를_사용하여_생존한다() {
-            // given
-            LocalDate yesterday = LocalDate.now().minusDays(1);
+        // given
+        LocalDate yesterday = LocalDate.now().minusDays(1);
 
-            // Challenge: 총 10일. 80% = 8일. 최대 결석 = 2일
-            Challenge survivalChallenge = challengeRepository.save(TestFixture.createChallenge(
-                            "Survival Challenge",
-                            yesterday.minusDays(4),
-                            yesterday.plusDays(5),
-                            10));
+        // Challenge: 총 10일. 80% = 8일. 최대 결석 = 2일
+        Challenge survivalChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Survival Challenge",
+                yesterday.minusDays(4),
+                yesterday.plusDays(5),
+                10));
 
-            ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
-                            .challengeId(survivalChallenge.getId())
-                            .memberId(member.getId())
-                            .completedDays(3)
-                            .shield(1)
-                            .isSurvived(true)
-                            .build());
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(survivalChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .shield(1)
+                .isSurvived(true)
+                .build());
 
-            // when
-            challengeProgressService.proceedDailySurvivalCheck(survivalChallenge, yesterday);
+        // when
+        challengeProgressService.proceedDailySurvivalCheck(survivalChallenge, yesterday);
 
-            // then
-            ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId())
-                            .orElseThrow();
+        // then
+        ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId())
+                .orElseThrow();
 
-            assertSoftly(softly -> {
-                    softly.assertThat(updatedParticipant.getShield()).isEqualTo(participant.getShield() - 1);
-                    softly.assertThat(updatedParticipant.getCompletedDays()).isEqualTo(participant.getCompletedDays() + 1);
-                    softly.assertThat(updatedParticipant.isSurvived()).isTrue();
+        assertSoftly(softly -> {
+            softly.assertThat(updatedParticipant.getShield()).isEqualTo(participant.getShield() - 1);
+            softly.assertThat(updatedParticipant.getCompletedDays())
+                    .isEqualTo(participant.getCompletedDays() + 1);
+            softly.assertThat(updatedParticipant.isSurvived()).isTrue();
 
-                    List<ChallengeDailyResult> results = challengeDailyResultRepository.findAll();
-                    softly.assertThat(results).hasSize(1);
-                    softly.assertThat(results.getFirst().getStatus()).isEqualTo(ChallengeDailyStatus.SHIELD);
-                    softly.assertThat(results.getFirst().getDate()).isEqualTo(yesterday);
-            });
+            List<ChallengeDailyResult> results = challengeDailyResultRepository.findAll();
+            softly.assertThat(results).hasSize(1);
+            softly.assertThat(results.getFirst().getStatus()).isEqualTo(ChallengeDailyStatus.SHIELD);
+            softly.assertThat(results.getFirst().getDate()).isEqualTo(yesterday);
+        });
     }
 
     @Test
     void 쉴드가_없어도_결석_허용일_이내라면_생존한다() {
-            // given
-            LocalDate yesterday = LocalDate.now().minusDays(1);
+        // given
+        LocalDate yesterday = LocalDate.now().minusDays(1);
 
-            // Challenge: 총 10일. 80% = 8일. 최대 결석 = 2일
-            Challenge survivalChallenge = challengeRepository.save(TestFixture.createChallenge(
-                            "Survival Challenge 2",
-                            yesterday.minusDays(4),
-                            yesterday.plusDays(5),
-                            10));
+        // Challenge: 총 10일. 80% = 8일. 최대 결석 = 2일
+        Challenge survivalChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Survival Challenge 2",
+                yesterday.minusDays(4),
+                yesterday.plusDays(5),
+                10));
 
-            // Participant: 챌린지 3일 수행
-            // 챌린지 시작한지 5일 지남, currentAbsent = 5 - 3 = 2, 2 >= 2 -> 생존.
-            ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
-                            .challengeId(survivalChallenge.getId())
-                            .memberId(member.getId())
-                            .completedDays(3)
-                            .shield(0)
-                            .isSurvived(true)
-                            .build());
+        // Participant: 챌린지 3일 수행
+        // 챌린지 시작한지 5일 지남, currentAbsent = 5 - 3 = 2, 2 >= 2 -> 생존.
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(survivalChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .shield(0)
+                .isSurvived(true)
+                .build());
 
-            // when
-            challengeProgressService.proceedDailySurvivalCheck(survivalChallenge, yesterday);
+        // when
+        challengeProgressService.proceedDailySurvivalCheck(survivalChallenge, yesterday);
 
-            // then
-            ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId())
-                            .orElseThrow();
-            assertSoftly(softly -> {
-                    softly.assertThat(updatedParticipant.isSurvived()).isTrue();
-                    softly.assertThat(updatedParticipant.getCompletedDays()).isEqualTo(3);
-            });
+        // then
+        ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId())
+                .orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(updatedParticipant.isSurvived()).isTrue();
+            softly.assertThat(updatedParticipant.getCompletedDays()).isEqualTo(3);
+        });
     }
 
     @Test
     void 결석_허용일을_초과하면_생존에_실패한다() {
-            // given
-            LocalDate yesterday = LocalDate.now().minusDays(1);
+        // given
+        LocalDate yesterday = LocalDate.now().minusDays(1);
 
-            // Challenge: 총 10일. 80% = 8일. 최대 결석 = 2일
-            Challenge survivalChallenge = challengeRepository.save(TestFixture.createChallenge(
-                            "Survival Challenge 3",
-                            yesterday.minusDays(4),
-                            yesterday.plusDays(5),
-                            10));
+        // Challenge: 총 10일. 80% = 8일. 최대 결석 = 2일
+        Challenge survivalChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Survival Challenge 3",
+                yesterday.minusDays(4),
+                yesterday.plusDays(5),
+                10));
 
-            // Participant: 챌린지 2일 수행
-            // 챌린지 시작한지 5일 지남, currentAbsent = 5 - 2 = 3, 3 > 2 -> 탈락.
-            ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
-                            .challengeId(survivalChallenge.getId())
-                            .memberId(member.getId())
-                            .completedDays(2)
-                            .shield(0)
-                            .isSurvived(true)
-                            .build());
+        // Participant: 챌린지 2일 수행
+        // 챌린지 시작한지 5일 지남, currentAbsent = 5 - 2 = 3, 3 > 2 -> 탈락.
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(survivalChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(2)
+                .shield(0)
+                .isSurvived(true)
+                .build());
 
-            // when
-            challengeProgressService.proceedDailySurvivalCheck(survivalChallenge, yesterday);
+        // when
+        challengeProgressService.proceedDailySurvivalCheck(survivalChallenge, yesterday);
 
-            // then
-            ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId())
-                            .orElseThrow();
-            assertThat(updatedParticipant.isSurvived()).isFalse();
+        // then
+        ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId())
+                .orElseThrow();
+        assertThat(updatedParticipant.isSurvived()).isFalse();
     }
 
     private ChallengeParticipant createTeamParticipant(Long challengeId, Long memberId, Long teamId,
@@ -362,5 +365,43 @@ class ChallengeProgressServiceTest {
                 .date(date)
                 .status(status)
                 .build();
+    }
+
+    @Test
+    void 주말을_제외한_평일만_계산하여_생존_처리한다() {
+        // given
+        // 금요일(1일차) 시작
+        LocalDate friday = LocalDate.of(2024, 1, 5);
+        // 다음주 월요일(4일차)에 체크 (어제인 월요일까지의 생존 여부 판단)
+        LocalDate monday = LocalDate.of(2024, 1, 8);
+
+        // 총 10일 (영업일 기준). 2024-01-05 ~ 2024-01-18 (금요일~다음다음 목요일, 14일간, 주말 4일 제외 = 10일)
+        Challenge weekendChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Weekend Challenge",
+                friday,
+                friday.plusDays(13), // 2 weeks
+                10 // total days (business only)
+        ));
+
+        // User completed 0 days.
+        // 금요일(1일) + 월요일(1일) = 총 2일 경과.
+        // 결석 = 2일.
+        // 전체 10일의 80% = 8일 출석 필요 -> 최대 2일 결석 허용.
+        // 2일 결석 <= 2일 허용 -> 생존해야 함.
+        ChallengeParticipant participant = challengeParticipantRepository.save(
+                ChallengeParticipant.builder()
+                        .challengeId(weekendChallenge.getId())
+                        .memberId(member.getId())
+                        .completedDays(0)
+                        .isSurvived(true)
+                        .build()
+        );
+
+        // when
+        challengeProgressService.proceedDailySurvivalCheck(weekendChallenge, monday);
+
+        // then
+        ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).get();
+        assertThat(updated.isSurvived()).isTrue();
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 탈락 처리 스케줄러의 챌린지가 진행된 날짜 수 계산 로직에서 주말은 계산되지 않도록 수정했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
주말은 챌린지 수행일이 아닌데도 결석으로 취급되는 오류가 있었음

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
기존에는 전체 지나간 일자를 아래처럼 계산했습니다. 이는 단순히 현재 날짜와 챌린지 시작 날짜의 차이만 계산하는 것입니다.
```java
    int passedDaysWithWeekend = (int) (ChronoUnit.DAYS.between(challenge.getStartDate(), targetDate) + 1);
```

주말은 지나간 날짜 계산에서 제외하기 위해 챌린지 엔티티 내부에 아래처럼 메서드를 추가했습니다.
```java
public int calculatePassedDays(LocalDate targetDate) {
        int passedDays = 0;
        LocalDate currentDate = this.startDate;
        while (!currentDate.isAfter(targetDate)) {
            if (isWeekend(currentDate)) {
                passedDays++;
            }
            currentDate = currentDate.plusDays(1);
        }
        return passedDays;
    }
```

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

더 효율적인 로직이 없을지!