### PR TITLE
[BOM-856] fix: 주말에 한 줄 코멘트 추가 시 예외처리 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -1,5 +1,7 @@
 package me.bombom.api.v1.challenge.service;
 
+import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +38,7 @@ public class ChallengeCommentService {
     private final ArticleRepository articleRepository;
     private final HighlightRepository highlightRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final Clock clock;
 
     @Value("${challenge.highlight.truncate-ratio}")
     private double highlightTruncateRatio;
@@ -75,6 +78,8 @@ public class ChallengeCommentService {
             Long challengeId,
             ChallengeCommentRequest request
     ) {
+        validateCommentAvailableDay(memberId, challengeId);
+
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.MEMBER_ID, memberId)
@@ -111,5 +116,20 @@ public class ChallengeCommentService {
                 highlightTruncateRatio,
                 pageable
         );
+    }
+
+    private void validateCommentAvailableDay(Long memberId, Long challengeId) {
+        if (isWeekend(LocalDate.now(clock))) {
+            throw new CIllegalArgumentException(ErrorDetail.PRECONDITION_FAILED)
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext(ErrorContextKeys.OPERATION, "createChallengeComment")
+                    .addContext(ErrorContextKeys.DETAIL, "주말에는 챌린지 코멘트를 작성할 수 없습니다.");
+        }
+    }
+
+    private boolean isWeekend(LocalDate today) {
+        DayOfWeek dayOfWeek = today.getDayOfWeek();
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/TimeConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/TimeConfig.java
@@ -1,0 +1,17 @@
+package me.bombom.api.v1.common.config;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(SEOUL_ZONE);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
@@ -144,7 +144,7 @@ class ChallengeCommentControllerTest {
                 )
         );
 
-        setToday(LocalDate.of(2026, 1, 9)); // weekday default
+        setToday(LocalDate.of(2026, 1, 9)); // 평일 default
     }
 
     @Test
@@ -210,7 +210,7 @@ class ChallengeCommentControllerTest {
                 "quote",
                 "챌린지 한 줄 코멘트로 20자 이상의 댓글을 작성했습니다."
         );
-        setToday(LocalDate.of(2026, 1, 9)); // Friday
+        setToday(LocalDate.of(2026, 1, 9)); // 금요일
 
         // when & then
         mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments", 1L)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerTest.java
@@ -1,13 +1,16 @@
 package me.bombom.api.v1.challenge.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.article.domain.Article;
@@ -37,11 +40,14 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @IntegrationTest
 @AutoConfigureMockMvc
 class ChallengeCommentControllerTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     @Autowired
     private MockMvc mockMvc;
@@ -72,6 +78,9 @@ class ChallengeCommentControllerTest {
 
     @Autowired
     private HighlightRepository highlightRepository;
+
+    @MockitoBean
+    private Clock clock;
 
     private Member member;
     private List<Newsletter> newsletters;
@@ -134,6 +143,8 @@ class ChallengeCommentControllerTest {
                         "comment"
                 )
         );
+
+        setToday(LocalDate.of(2026, 1, 9)); // weekday default
     }
 
     @Test
@@ -199,6 +210,7 @@ class ChallengeCommentControllerTest {
                 "quote",
                 "챌린지 한 줄 코멘트로 20자 이상의 댓글을 작성했습니다."
         );
+        setToday(LocalDate.of(2026, 1, 9)); // Friday
 
         // when & then
         mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments", 1L)
@@ -263,5 +275,10 @@ class ChallengeCommentControllerTest {
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content[0].text").value("ABCDEFGH..."));
+    }
+
+    private void setToday(LocalDate date) {
+        given(clock.instant()).willReturn(date.atStartOfDay(SEOUL_ZONE).toInstant());
+        given(clock.getZone()).willReturn(SEOUL_ZONE);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
@@ -3,9 +3,12 @@ package me.bombom.api.v1.challenge.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.article.domain.Article;
@@ -20,6 +23,8 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorContextKeys;
+import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.highlight.domain.Color;
 import me.bombom.api.v1.highlight.domain.Highlight;
 import me.bombom.api.v1.highlight.domain.HighlightLocation;
@@ -38,9 +43,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 class ChallengeCommentServiceTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     @Autowired
     private ChallengeCommentService challengeCommentService;
@@ -68,6 +76,9 @@ class ChallengeCommentServiceTest {
 
     @Autowired
     private HighlightRepository highlightRepository;
+
+    @MockitoBean
+    private Clock clock;
 
     private Member member;
     private Article article;
@@ -109,6 +120,8 @@ class ChallengeCommentServiceTest {
                         0
                 )
         );
+
+        setToday(LocalDate.of(2026, 1, 9)); // default 평일
     }
 
     @Test
@@ -252,6 +265,7 @@ class ChallengeCommentServiceTest {
                 null, // 인용구 optional 테스트
                 "챌린지 한 줄 코멘트로 20자 이상의 댓글을 작성했습니다."
         );
+        setToday(LocalDate.of(2026, 1, 9)); // 금요일
 
         // when
         challengeCommentService.createChallengeComment(
@@ -279,6 +293,7 @@ class ChallengeCommentServiceTest {
                 "quote",
                 "챌린지 한 줄 코멘트로 20자 이상의 댓글을 작성했습니다."
         );
+        setToday(LocalDate.of(2026, 1, 9)); // 금요일
 
         // when & then
         assertThatThrownBy(() -> challengeCommentService.createChallengeComment(
@@ -286,6 +301,28 @@ class ChallengeCommentServiceTest {
                 999L,
                 request
         )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 주말에는_챌린지_댓글_생성이_실패한다() {
+        // given
+        ChallengeCommentRequest request = new ChallengeCommentRequest(
+                article.getId(),
+                null,
+                "챌린지 한 줄 코멘트로 20자 이상의 댓글을 작성했습니다."
+        );
+        setToday(LocalDate.of(2026, 1, 10)); // 토요일
+
+        // when & then
+        assertThatThrownBy(() -> challengeCommentService.createChallengeComment(
+                member.getId(),
+                participant.getChallengeId(),
+                request
+        )).isInstanceOfSatisfying(CIllegalArgumentException.class, ex -> assertSoftly(softly -> {
+            softly.assertThat(ex.getErrorDetail()).isEqualTo(ErrorDetail.PRECONDITION_FAILED);
+            softly.assertThat(ex.getContext().get(ErrorContextKeys.DETAIL.getKey()))
+                    .isEqualTo("주말에는 챌린지 코멘트를 작성할 수 없습니다.");
+        }));
     }
 
     @Test
@@ -332,5 +369,10 @@ class ChallengeCommentServiceTest {
             softly.assertThat(result.getTotalElements()).isEqualTo(1);
             softly.assertThat(result.getContent().getFirst().text()).isEqualTo("01234567...");
         });
+    }
+
+    private void setToday(LocalDate date) {
+        given(clock.instant()).willReturn(date.atStartOfDay(SEOUL_ZONE).toInstant());
+        given(clock.getZone()).willReturn(SEOUL_ZONE);
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
주말에 챌린지 한 줄 코멘트 추가를 시도할 시 예외처리합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
주말에는 챌린지 코멘트가 활성화 되지 않습니다.
만약 시도할 경우 잘못된 Todo result가 insert 될 수 있으므로 예외처리가 필요합니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 챌린지 한 줄 코멘트 작성 API를 호출하는 날이 주말일 경우 예외를 발생합니다.
 - 주말일 경우 애초에 UI부터 코멘트 작성이 비활성화 되므로, 주말에 코멘트 작성을 시도하는 것 자체가 비정상적인 케이스라고 판단해 예외처리 했습니다.

### `TimeConfig` 추가
- 주말 여부 판단을 위해 서비스 로직에서 `LocalDate.now()`를 사용해야했고, 주말에는 코멘트 작성이 실패하는 케이스를 안정적으로 테스트하려고 했습니다.
- 해결 방법으로는 (1) `mockito-inline`을 추가해 `LocalDate.now()` 같은 static 메서드를 모킹하거나, (2) `Clock`을 주입해 시간을 제어하는 방법이 있습니다.
- static mocking은 빠르게 적용 가능하지만 전역 상태에 영향을 줄 수 있어, 같은 JVM을 사용하는 테스트들이 공통으로 `LocalDate.now()`를 사용할 경우 예상치 못한 오류가 발생할 수 있습니다.
- 따라서 운영/테스트 환경 모두에서 재사용 가능하고, 타임존/시간 정책 확장에도 유리한 `Clock` 주입 방식을 채택했습니다.
- 이를 위해 `TimeConfig`에서 `Clock` 빈을 제공해 서비스에서는 `LocalDate.now(clock)`로 한국 시간 기준의 날짜를 일관되게 사용하도록 구성했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- service 로직에서 주말인지 체크하는 코드, 예외 던지는 부분을 봐주시면 좋을 것 같습니다.