### PR TITLE
[BOM-868] feat: COMING_SOON 상태 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
@@ -29,10 +29,8 @@ public class Challenge extends BaseEntity {
     @Column(nullable = false)
     private int generation;
 
-    @Column(nullable = false)
     private LocalDate startDate;
 
-    @Column(nullable = false)
     private LocalDate endDate;
 
     @Column(nullable = false)
@@ -43,8 +41,8 @@ public class Challenge extends BaseEntity {
             Long id,
             @NonNull String name,
             int generation,
-            @NonNull LocalDate startDate,
-            @NonNull LocalDate endDate,
+            LocalDate startDate,
+            LocalDate endDate,
             int totalDays
     ) {
         this.id = id;
@@ -56,6 +54,9 @@ public class Challenge extends BaseEntity {
     }
 
     public ChallengeStatus getStatus(LocalDate now) {
+        if (this.startDate == null) {
+            return ChallengeStatus.COMING_SOON;
+        }
         if (now.isBefore(this.startDate)) {
             return ChallengeStatus.BEFORE_START;
         }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeStatus.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeStatus.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.challenge.domain;
 
 public enum ChallengeStatus {
 
+    COMING_SOON,
     BEFORE_START,
     ONGOING,
     COMPLETED,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -71,7 +71,7 @@ public class ChallengeService {
                 .filter(challenge -> {
                     ChallengeStatus status = challenge.getStatus(LocalDate.now());
                     boolean isJoined = myParticipation.containsKey(challenge.getId());
-                    return status == ChallengeStatus.BEFORE_START || isJoined;
+                    return status == ChallengeStatus.COMING_SOON || status == ChallengeStatus.BEFORE_START || isJoined;
                 })
                 .map(challenge -> toChallengeResponse(
                         challenge,

--- a/backend/bom-bom-server/src/main/resources/db/migration/V17.0.3__modify_challenge_dates_nullable.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V17.0.3__modify_challenge_dates_nullable.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge MODIFY COLUMN start_date DATE NULL;
+ALTER TABLE challenge MODIFY COLUMN end_date DATE NULL;


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 시작/종료일이 없는 상태를 지원하고, 해당 상태를 표현하는 챌린지 상태(COMING_SOON)를 추가했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 생성 시 일정이 확정되지 않은 경우를 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- Challenge의 startDate, endDate를 nullable로 변경하고 DB 컬럼도 NULL 허용하도록 마이그레이션을 추가했습니다.
- 시작일이 없는 경우 COMING_SOON 상태를 반환하도록 ChallengeStatus와 상태 계산 로직을 확장했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
상태 추가에 따라서 추가로 변경되어야 하는 로직 있을지?