### PR TITLE
[BOM-886] feat: 사용자의 챌린지 데일리 가이드 코멘트 조회 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.challenge.service.ChallengeDailyGuideService;
 import me.bombom.api.v1.common.resolver.LoginMember;
@@ -42,6 +43,16 @@ public class ChallengeDailyGuideController implements ChallengeDailyGuideControl
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId
     ) {
         return challengeDailyGuideService.getTodayDailyGuide(challengeId, member.getId());
+    }
+
+    @Override
+    @GetMapping("/{challengeId}/daily-guides/{dayIndex}/my-comment")
+    public MemberDailyCommentResponse getDailyGuideComment(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
+            @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex
+    ) {
+        return challengeDailyGuideService.getDailyGuideComment(challengeId, dayIndex, member.getId());
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
@@ -70,4 +71,19 @@ public interface ChallengeDailyGuideControllerApi {
             @Parameter(description = "일차 인덱스 (1부터 시작)") @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,
             @Valid DailyGuideCommentRequest request
     );
+
+    @Operation(
+            summary = "데일리 가이드 내 댓글 조회",
+            description = "특정 챌린지의 특정 일차 데일리 가이드에 내가 작성한 댓글을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "댓글 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 (유효하지 않은 ID)", content = @Content),
+            @ApiResponse(responseCode = "403", description = "챌린지 참여 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지 또는 데일리 가이드를 찾을 수 없음", content = @Content)
+    })
+    MemberDailyCommentResponse getDailyGuideComment(
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
+            @Parameter(description = "일차 인덱스 (1부터 시작)") @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/DailyGuideType.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/DailyGuideType.java
@@ -4,5 +4,6 @@ public enum DailyGuideType {
 
     READ,
     COMMENT,
-    SHARING
+    SHARING,
+    REMIND
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MemberDailyCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MemberDailyCommentResponse.java
@@ -1,0 +1,10 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+
+public record MemberDailyCommentResponse(
+
+        @NotNull
+        String comment
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.challenge.repository;
 import java.util.Optional;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,5 +26,18 @@ public interface ChallengeDailyGuideCommentRepository extends JpaRepository<Chal
             WHERE c.guideId = :guideId
             """)
     Page<DailyGuideCommentResponse> findByGuideId(@Param("guideId") Long guideId, Pageable pageable);
-}
 
+    @Query("""
+            SELECT new me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse(c.content)
+            FROM ChallengeParticipant p
+            JOIN ChallengeDailyGuide g ON g.challengeId = p.challengeId AND g.dayIndex = :dayIndex
+            LEFT JOIN ChallengeDailyGuideComment c ON c.participantId = p.id AND c.guideId = g.id
+            WHERE p.challengeId = :challengeId
+            AND p.memberId = :memberId
+    """)
+    MemberDailyCommentResponse findMyComment(
+            @Param("challengeId") Long challengeId,
+            @Param("dayIndex") int dayIndex,
+            @Param("memberId") Long memberId
+    );
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -97,7 +97,6 @@ public class ChallengeDailyGuideService {
         return challengeDailyGuideCommentRepository.findByGuideId(guide.getId(), pageable);
     }
 
-
     @Transactional
     public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
                                         DailyGuideCommentRequest request, LocalDate today) {
@@ -196,23 +195,36 @@ public class ChallengeDailyGuideService {
     }
 
     private void validateDayIndex(Long challengeId, int dayIndex, Challenge challenge) {
-        if (dayIndex != 0 && (dayIndex < 1 || dayIndex > calculateDayIndex(challenge.getStartDate(), LocalDate.now(SEOUL_ZONE)))) {
+        int maxAllowedDayIndex = calculateMaxAllowedDayIndex(challenge.getStartDate(), LocalDate.now(clock));
+        if (dayIndex > maxAllowedDayIndex) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
                     .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
                     .addContext("dayIndex", dayIndex)
+                    .addContext("maxAllowedDayIndex", maxAllowedDayIndex)
                     .addContext("reason", "유효하지 않은 일차 인덱스입니다.");
         }
     }
 
     private int calculateDayIndex(LocalDate startDate, LocalDate today) {
-        DayOfWeek dayOfWeek = today.getDayOfWeek();
-        boolean isWeekend = dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
-
-        if (isWeekend) {
+        if (isWeekend(today)) {
             return 0;
         }
         return (int) DAYS.between(startDate, today) + 1;
+    }
+
+    private int calculateMaxAllowedDayIndex(LocalDate startDate, LocalDate today) {
+        LocalDate targetDate = today;
+        // 오늘이 주말이면 직전 금요일까지의 컨텐츠는 볼 수 있어야 함
+        while (isWeekend(targetDate) && !targetDate.isBefore(startDate)) {
+            targetDate = targetDate.minusDays(1);
+        }
+        return (int) DAYS.between(startDate, targetDate) + 1;
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 
     private MyCommentResponse createMyCommentResponse(TodayDailyGuideRow row) {
@@ -220,7 +232,6 @@ public class ChallengeDailyGuideService {
         return new MyCommentResponse(
                 exists,
                 exists ? row.getMyCommentContent() : null,
-                exists ? row.getMyCommentCreatedAt() : null
-        );
+                exists ? row.getMyCommentCreatedAt() : null);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -2,9 +2,9 @@ package me.bombom.api.v1.challenge.service;
 
 import static java.time.temporal.ChronoUnit.DAYS;
 
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
@@ -33,7 +33,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ChallengeDailyGuideService {
 
-    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private final Clock clock;
 
     private final ChallengeRepository challengeRepository;
     private final ChallengeDailyGuideRepository challengeDailyGuideRepository;
@@ -48,7 +48,7 @@ public class ChallengeDailyGuideService {
 
         validateChallengeParticipant(challengeId, memberId);
 
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
+        LocalDate today = LocalDate.now(clock);
         if (today.isBefore(challenge.getStartDate()) || today.isAfter(challenge.getEndDate())) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -44,17 +44,9 @@ public class ChallengeDailyGuideService {
     private final ChallengeTeamService challengeTeamService;
 
     public TodayDailyGuideResponse getTodayDailyGuide(Long challengeId, Long memberId) {
-        Challenge challenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
-                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+        Challenge challenge = getChallenge(challengeId);
 
-        if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
-            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
-                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
-                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId);
-        }
+        validateChallengeParticipant(challengeId, memberId);
 
         LocalDate today = LocalDate.now(SEOUL_ZONE);
         if (today.isBefore(challenge.getStartDate()) || today.isAfter(challenge.getEndDate())) {
@@ -84,17 +76,9 @@ public class ChallengeDailyGuideService {
     }
 
     public Page<DailyGuideCommentResponse> getTotalComments(Long challengeId, int dayIndex, Long memberId, Pageable pageable) {
-        Challenge challenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
-                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+        Challenge challenge = getChallenge(challengeId);
 
-        if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
-            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
-                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
-                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId);
-        }
+        validateChallengeParticipant(challengeId, memberId);
 
         if (dayIndex != 0 && (dayIndex < 1 || dayIndex > challenge.getTotalDays())) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
@@ -117,10 +101,7 @@ public class ChallengeDailyGuideService {
     @Transactional
     public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
                                         DailyGuideCommentRequest request, LocalDate today) {
-        Challenge challenge = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
-                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+        Challenge challenge = getChallenge(challengeId);
 
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                         challengeId, memberId)
@@ -129,13 +110,7 @@ public class ChallengeDailyGuideService {
                         .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
 
-        if (dayIndex != 0 && (dayIndex < 1 || dayIndex > challenge.getTotalDays())) {
-            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
-                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
-                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
-                    .addContext("dayIndex", dayIndex)
-                    .addContext("reason", "유효하지 않은 일차 인덱스입니다.");
-        }
+        validateDayIndex(challengeId, dayIndex, challenge);
 
         ChallengeDailyGuide guide = challengeDailyGuideRepository.findByChallengeIdAndDayIndex(challengeId, dayIndex)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
@@ -192,29 +167,42 @@ public class ChallengeDailyGuideService {
     }
 
     public MemberDailyCommentResponse getDailyGuideComment(Long challengeId, int dayIndex, Long memberId) {
-        Challenge challenge = challengeRepository.findById(challengeId)
+        Challenge challenge = getChallenge(challengeId);
+        validateChallengeParticipant(challengeId, memberId);
+        validateDayIndex(challengeId, dayIndex, challenge);
+
+        MemberDailyCommentResponse response = challengeDailyGuideCommentRepository.findMyComment(
+                challengeId,
+                dayIndex,
+                memberId
+        );
+        return response != null ? response : new MemberDailyCommentResponse(null);
+    }
+
+    private Challenge getChallenge(Long challengeId) {
+        return challengeRepository.findById(challengeId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+    }
 
+    private void validateChallengeParticipant(Long challengeId, Long memberId) {
         if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
             throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
                     .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                     .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId);
         }
+    }
 
-        if (dayIndex < 1 || dayIndex > calculateDayIndex(challenge.getStartDate(), LocalDate.now())) {
+    private void validateDayIndex(Long challengeId, int dayIndex, Challenge challenge) {
+        if (dayIndex != 0 && (dayIndex < 1 || dayIndex > calculateDayIndex(challenge.getStartDate(), LocalDate.now(SEOUL_ZONE)))) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
                     .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
                     .addContext("dayIndex", dayIndex)
                     .addContext("reason", "유효하지 않은 일차 인덱스입니다.");
         }
-
-        MemberDailyCommentResponse response = challengeDailyGuideCommentRepository
-                .findMyComment(challengeId, dayIndex, memberId);
-        return response != null ? response : new MemberDailyCommentResponse(null);
     }
 
     private int calculateDayIndex(LocalDate startDate, LocalDate today) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -147,13 +147,13 @@ public class ChallengeDailyGuideService {
 
         // day1일 때만 체크리스트 자동 완료 처리
         if (dayIndex == 1) {
-            // READ todo 자동 생성 (뉴스레터 1개 읽기)
+            // READ 투두 자동 생성 (뉴스레터 1개 읽기)
             challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
-            // COMMENT todo 생성 (한 줄 코멘트 작성)
+            // COMMENT 투두 생성 (한 줄 코멘트 작성)
             challengeTodoService.insertCommentDone(participant, today);
 
             // 이미 완료되지 않았으면 progress 처리
-            // day1에 두 todo(READ, COMMENT)가 모두 생성되므로 바로 완료 처리
+            // day1에 두 투두(READ, COMMENT)가 모두 생성되므로 바로 완료 처리
             if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
                 challengeTodoService.completeDailyTodo(participant, today);
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -12,6 +12,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse.MyCommentResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
@@ -188,6 +189,32 @@ public class ChallengeDailyGuideService {
                 }
             }
         }
+    }
+
+    public MemberDailyCommentResponse getDailyGuideComment(Long challengeId, int dayIndex, Long memberId) {
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+
+        if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId);
+        }
+
+        if (dayIndex < 1 || dayIndex > calculateDayIndex(challenge.getStartDate(), LocalDate.now())) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext("dayIndex", dayIndex)
+                    .addContext("reason", "유효하지 않은 일차 인덱스입니다.");
+        }
+
+        MemberDailyCommentResponse response = challengeDailyGuideCommentRepository
+                .findMyComment(challengeId, dayIndex, memberId);
+        return response != null ? response : new MemberDailyCommentResponse(null);
     }
 
     private int calculateDayIndex(LocalDate startDate, LocalDate today) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -4,7 +4,9 @@ import static java.time.temporal.ChronoUnit.DAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -38,6 +40,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 class ChallengeDailyGuideServiceTest {
@@ -71,6 +74,9 @@ class ChallengeDailyGuideServiceTest {
     @Autowired
     private ChallengeDailyResultRepository challengeDailyResultRepository;
 
+    @MockitoBean
+    private Clock clock;
+
     private Member member;
     private Challenge challenge;
     private ChallengeParticipant participant;
@@ -93,13 +99,19 @@ class ChallengeDailyGuideServiceTest {
         member = TestFixture.normalMemberFixture();
         memberRepository.save(member);
 
-        today = LocalDate.now(SEOUL_ZONE);
+        // 무조건 평일로 설정 (2026-01-26 월요일)
+        today = LocalDate.of(2026, 1, 26);
+
+        given(clock.getZone()).willReturn(SEOUL_ZONE);
+        given(clock.instant()).willReturn(today.atStartOfDay(SEOUL_ZONE).toInstant());
+        today = LocalDate.now(clock);
         challenge = challengeRepository.save(TestFixture.createChallenge(
                 "테스트 챌린지",
                 today.minusDays(5),
                 today.plusDays(5),
                 10
-        ));
+                )
+        );
 
         participant = challengeParticipantRepository.save(
                 TestFixture.createChallengeParticipant(
@@ -110,12 +122,8 @@ class ChallengeDailyGuideServiceTest {
         );
 
         // READ, COMMENT 투두 생성
-        readTodo = challengeTodoRepository.save(
-                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
-        );
-        commentTodo = challengeTodoRepository.save(
-                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.COMMENT)
-        );
+        readTodo = challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ));
+        commentTodo = challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.COMMENT));
 
         int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
         guide = challengeDailyGuideRepository.save(
@@ -897,17 +905,4 @@ class ChallengeDailyGuideServiceTest {
                 futureDayIndex,
                 member.getId())).isInstanceOf(CIllegalArgumentException.class);
     }
-
-    @Test
-    void 유효하지_않은_dayIndex로_내_댓글_조회시_예외_발생() {
-        // given
-        int invalidDayIndex = -1;
-
-        // when & then
-        assertThatThrownBy(() -> challengeDailyGuideService.getDailyGuideComment(
-                challenge.getId(),
-                invalidDayIndex,
-                member.getId())).isInstanceOf(CIllegalArgumentException.class);
-    }
 }
-

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -19,6 +19,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.domain.DailyGuideType;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideRepository;
@@ -108,7 +109,7 @@ class ChallengeDailyGuideServiceTest {
                 )
         );
 
-        // READ, COMMENT todo 생성
+        // READ, COMMENT 투두 생성
         readTodo = challengeTodoRepository.save(
                 TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
         );
@@ -492,12 +493,12 @@ class ChallengeDailyGuideServiceTest {
         List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
         assertThat(comments).hasSize(1);
 
-        // then - READ todo 생성 확인
+        // then - READ 투두 생성 확인
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(), weekday, readTodo.getId());
         assertThat(readTodoExists).isTrue();
 
-        // then - COMMENT todo 생성 확인
+        // then - COMMENT 투두 생성 확인
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(), weekday, commentTodo.getId());
         assertThat(commentTodoExists).isTrue();
@@ -540,12 +541,12 @@ class ChallengeDailyGuideServiceTest {
         List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
         assertThat(comments).hasSize(1);
 
-        // then - READ todo 생성 안 됨 (아직 아티클을 읽지 않았으므로)
+        // then - READ 투두 생성 안 됨 (아직 아티클을 읽지 않았으므로)
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(), today, readTodo.getId());
         assertThat(readTodoExists).isFalse();
 
-        // then - COMMENT todo 생성 안 됨 (day1이 아니므로)
+        // then - COMMENT 투두 생성 안 됨 (day1이 아니므로)
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(), today, commentTodo.getId());
         assertThat(commentTodoExists).isFalse();
@@ -572,7 +573,7 @@ class ChallengeDailyGuideServiceTest {
         }
         final LocalDate weekday = tempWeekday;
 
-        // 이미 READ todo 생성
+        // 이미 READ 투두 생성
         challengeDailyTodoRepository.save(
                 TestFixture.createChallengeDailyTodo(
                         participant.getId(),
@@ -592,7 +593,7 @@ class ChallengeDailyGuideServiceTest {
                 weekday
         );
 
-        // then - READ todo는 1개만 존재 (중복 생성 안 됨)
+        // then - READ 투두는 1개만 존재 (중복 생성 안 됨)
         List<ChallengeDailyTodo> readTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
                 .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
@@ -600,7 +601,7 @@ class ChallengeDailyGuideServiceTest {
                 .toList();
         assertThat(readTodos).hasSize(1);
 
-        // then - COMMENT todo 생성 확인
+        // then - COMMENT 투두 생성 확인
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(), weekday, commentTodo.getId());
         assertThat(commentTodoExists).isTrue();
@@ -627,7 +628,7 @@ class ChallengeDailyGuideServiceTest {
         }
         final LocalDate weekday = tempWeekday;
 
-        // 이미 COMMENT todo 생성
+        // 이미 COMMENT 투두 생성
         challengeDailyTodoRepository.save(
                 TestFixture.createChallengeDailyTodo(
                         participant.getId(),
@@ -647,7 +648,7 @@ class ChallengeDailyGuideServiceTest {
                 weekday
         );
 
-        // then - COMMENT todo는 1개만 존재 (중복 생성 안 됨)
+        // then - COMMENT 투두는 1개만 존재 (중복 생성 안 됨)
         List<ChallengeDailyTodo> commentTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
                 .filter(todo -> todo.getChallengeTodoId().equals(commentTodo.getId()))
@@ -655,7 +656,7 @@ class ChallengeDailyGuideServiceTest {
                 .toList();
         assertThat(commentTodos).hasSize(1);
 
-        // then - READ todo 생성 확인
+        // then - READ 투두 생성 확인
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(), weekday, readTodo.getId());
         assertThat(readTodoExists).isTrue();
@@ -833,6 +834,80 @@ class ChallengeDailyGuideServiceTest {
                 otherMember.getId(),
                 pageable
         )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 데일리_가이드_내_댓글_조회_성공() {
+        // given
+        String content = "내 댓글 내용입니다.";
+        challengeDailyGuideCommentRepository.save(
+                TestFixture.createChallengeDailyGuideComment(
+                        guide.getId(),
+                        participant.getId(),
+                        content));
+
+        // when
+        MemberDailyCommentResponse response = challengeDailyGuideService.getDailyGuideComment(challenge.getId(),
+                guide.getDayIndex(), member.getId());
+
+        // then
+        assertThat(response.comment()).isEqualTo(content);
+    }
+
+    @Test
+    void 데일리_가이드_내_댓글이_없는_경우_빈_내용_반환() {
+        // when
+        MemberDailyCommentResponse response = challengeDailyGuideService.getDailyGuideComment(challenge.getId(),
+                guide.getDayIndex(), member.getId());
+
+        // then
+        assertThat(response.comment()).isNull();
+    }
+
+    @Test
+    void 존재하지_않는_챌린지에서_내_댓글_조회시_예외_발생() {
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getDailyGuideComment(
+                0L,
+                guide.getDayIndex(),
+                member.getId())).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 참여하지_않은_챌린지에서_내_댓글_조회시_예외_발생() {
+        // given
+        Member otherMember = TestFixture.createUniqueMember("other", "other");
+        memberRepository.save(otherMember);
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getDailyGuideComment(
+                challenge.getId(),
+                guide.getDayIndex(),
+                otherMember.getId())).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 미래의_데일리_가이드_내_댓글_조회시_예외_발생() {
+        // given
+        int futureDayIndex = calculateDayIndex(challenge.getStartDate(), today) + 1;
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getDailyGuideComment(
+                challenge.getId(),
+                futureDayIndex,
+                member.getId())).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 유효하지_않은_dayIndex로_내_댓글_조회시_예외_발생() {
+        // given
+        int invalidDayIndex = -1;
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.getDailyGuideComment(
+                challenge.getId(),
+                invalidDayIndex,
+                member.getId())).isInstanceOf(CIllegalArgumentException.class);
     }
 }
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 데일리 가이드에서 사용자가 작성한 코멘트를 단건 조회하는 기능을 구현하고, 관련 유효성 검증 로직을 강화했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
사용자가 데일리 가이드 페이지에 진입했을 때, 해당 일차에 자신이 남긴 코멘트를 확인할 수 있어야 합니다. 또한, 아직 도래하지 않은 미래의 가이드에 접근하는 것을 방지할 필요가 있었습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
**Service 로직 구현 (`getDailyGuideComment`)**
- 사용자가 작성한 코멘트를 조회하고, 코멘트가 없는 경우에도 에러가 아닌 빈 응답(comment: null)을 반환하여 프론트엔드 처리를 용이하게 했습니다.

**유효성 검증 로직 개선 및 리팩토링**
  - 미래 접근 방지: `calculateDayIndex`와 LocalDate.now(SEOUL_ZONE)을 사용하여, 사용자가 챌린지 시작일 기준 아직 열리지 않은 미래의 `dayIndex`에 접근하려 할 경우 예외를 발생시키도록 했습니다.
  - 주말 예외 처리: 주말을 나타내는 dayIndex=0인 경우에는 날짜 검증을 건너뛰도록 처리하여 유연성을 확보했습니다.
- Helper 메서드 분리: `validateChallengeParticipant`, `validateDayIndex`, `getChallenge` 등 반복되는 검증/조회 로직을 private 메서드로 추출하여 가독성을 높였습니다.


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 현재 검증 후 조회하는 방식이 적절한지 봐주시면 감사드리겠슴다.

### **아래와 같이 첫날 각오를 보여주기 위함입니다! 현재 계획으로는 작성한 사람만 뒤집는 버튼이 보이게 할 거 같습니다!**
**`ChallengeDailyGuide`의 `DailyGuideType`에 `REMIND`를 추가하여 타입이 `REMIND`일 경우에만 현재 구현한 API를 호출하는 동작입니다.**

https://github.com/user-attachments/assets/19a22535-beef-4778-b9b4-198d10186c4d


