### PR TITLE
[BOM-889] hotfix: 검색 결과에서 최근 아티클도 조회할 수 있도록 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/RecentArticle.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/domain/RecentArticle.java
@@ -5,8 +5,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Lob;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -23,6 +21,9 @@ public class RecentArticle extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(nullable = false)
+    private Long articleId;
 
     @Column(nullable = false)
     private String title;
@@ -57,6 +58,7 @@ public class RecentArticle extends BaseEntity {
     @Builder
     public RecentArticle(
             Long id,
+            @NonNull Long articleId,
             @NonNull String title,
             @NonNull String contents,
             @NonNull String contentsText,
@@ -69,6 +71,7 @@ public class RecentArticle extends BaseEntity {
             @NonNull LocalDateTime arrivedDateTime
     ) {
         this.id = id;
+        this.articleId = articleId;
         this.title = title;
         this.contents = contents;
         this.contentsText = contentsText;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
@@ -8,11 +8,12 @@ import static me.bombom.api.v1.newsletter.domain.QNewsletter.newsletter;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Path;
-import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -22,17 +23,15 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.article.dto.request.ArticleSearchOptionsRequest;
+import me.bombom.api.v1.article.dto.request.ArticlesOptionsRequest;
 import me.bombom.api.v1.article.dto.response.ArticleCountPerNewsletterResponse;
 import me.bombom.api.v1.article.dto.response.ArticleResponse;
 import me.bombom.api.v1.article.dto.response.QArticleCountPerNewsletterResponse;
 import me.bombom.api.v1.article.dto.response.QArticleResponse;
-import me.bombom.api.v1.article.dto.request.ArticlesOptionsRequest;
-import me.bombom.api.v1.article.dto.request.ArticleSearchOptionsRequest;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.newsletter.dto.QNewsletterSummaryResponse;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.Query;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -40,7 +39,7 @@ import org.springframework.util.StringUtils;
 
 @Slf4j
 @RequiredArgsConstructor
-public class ArticleRepositoryImpl implements CustomArticleRepository{
+public class ArticleRepositoryImpl implements CustomArticleRepository {
 
     private static final int RECENT_DAYS = 5;
 
@@ -60,10 +59,10 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
             Long memberId,
             ArticlesOptionsRequest options,
             Pageable pageable
-    ){
-            JPAQuery<Long> totalQuery = getTotalQuery(memberId, options);
-            List<ArticleResponse> content = getContent(memberId, options, pageable);
-            return PageableExecutionUtils.getPage(content, pageable, totalQuery::fetchOne);
+    ) {
+        JPAQuery<Long> totalQuery = getTotalQuery(memberId, options);
+        List<ArticleResponse> content = getContent(memberId, options, pageable);
+        return PageableExecutionUtils.getPage(content, pageable, totalQuery::fetchOne);
     }
 
     @Override
@@ -97,7 +96,7 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
             // recent_article 테이블에 데이터가 없으면 article 테이블만 사용
             content = findArticlesFromArticleOnly(memberId, options, pageable, fiveDaysAgoDate);
         }
-        
+
         return PageableExecutionUtils.getPage(content, pageable, () -> total);
     }
 
@@ -127,44 +126,43 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
 
     private List<ArticleCountPerNewsletterResponse> countWithKeyword(Long memberId, String keyword) {
         String sql = """
-            SELECT 
-                merged.newsletterId,
-                merged.name,
-                merged.imageUrl,
-                SUM(merged.articleCount) AS articleCount
-            FROM (
-                SELECT 
-                    n.id AS newsletterId,
-                    n.name AS name,
-                    COALESCE(n.image_url, '') AS imageUrl,
-                    COUNT(a.id) AS articleCount
-                FROM article a
-                JOIN newsletter n ON n.id = a.newsletter_id
-                WHERE a.member_id = :memberId
-                  AND a.arrived_date_time < DATE_SUB(NOW(), INTERVAL :recentDays DAY)
-                  AND (
-                        LOWER(a.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                     OR LOWER(a.contents_text) LIKE LOWER(CONCAT('%', :keyword, '%'))
-                  )
-                GROUP BY n.id
-        
-                UNION ALL
-        
-                -- 최근 아티클 검색 (recent_article)
-                SELECT
-                    n.id AS newsletterId,
-                    n.name AS name,
-                    COALESCE(n.image_url, '') AS imageUrl,
-                    COUNT(ra.id) AS articleCount
-                FROM recent_article ra
-                JOIN newsletter n ON n.id = ra.newsletter_id
-                WHERE ra.member_id = :memberId
-                  AND MATCH(ra.title, ra.contents_text) AGAINST(:keyword)
-                GROUP BY n.id
-            ) AS merged
-            GROUP BY merged.newsletterId, merged.name, merged.imageUrl
-        """;
-
+                    SELECT 
+                        merged.newsletterId,
+                        merged.name,
+                        merged.imageUrl,
+                        SUM(merged.articleCount) AS articleCount
+                    FROM (
+                        SELECT 
+                            n.id AS newsletterId,
+                            n.name AS name,
+                            COALESCE(n.image_url, '') AS imageUrl,
+                            COUNT(a.id) AS articleCount
+                        FROM article a
+                        JOIN newsletter n ON n.id = a.newsletter_id
+                        WHERE a.member_id = :memberId
+                          AND a.arrived_date_time < DATE_SUB(NOW(), INTERVAL :recentDays DAY)
+                          AND (
+                                LOWER(a.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                             OR LOWER(a.contents_text) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                          )
+                        GROUP BY n.id
+                
+                        UNION ALL
+                
+                        -- 최근 아티클 검색 (recent_article)
+                        SELECT
+                            n.id AS newsletterId,
+                            n.name AS name,
+                            COALESCE(n.image_url, '') AS imageUrl,
+                            COUNT(ra.id) AS articleCount
+                        FROM recent_article ra
+                        JOIN newsletter n ON n.id = ra.newsletter_id
+                        WHERE ra.member_id = :memberId
+                          AND MATCH(ra.title, ra.contents_text) AGAINST(:keyword)
+                        GROUP BY n.id
+                    ) AS merged
+                    GROUP BY merged.newsletterId, merged.name, merged.imageUrl
+                """;
 
         List<Object[]> rows = entityManager.createNativeQuery(sql)
                 .setParameter("memberId", memberId)
@@ -186,33 +184,33 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
     private long getRecentTotalCountNative(Long memberId, ArticleSearchOptionsRequest options, LocalDate fiveDaysAgoDate) {
         StringBuilder sql = new StringBuilder();
         List<Object> params = new ArrayList<>();
-        
+
         sql.append("SELECT COUNT(*) ")
-           .append("FROM recent_article ra ")
-           .append("INNER JOIN newsletter n ON n.id = ra.newsletter_id ")
-           .append("INNER JOIN category c ON c.id = n.category_id ")
-           .append("WHERE ra.member_id = ? ")
-           .append("AND ra.arrived_date_time >= ? ");
+                .append("FROM recent_article ra ")
+                .append("INNER JOIN newsletter n ON n.id = ra.newsletter_id ")
+                .append("INNER JOIN category c ON c.id = n.category_id ")
+                .append("WHERE ra.member_id = ? ")
+                .append("AND ra.arrived_date_time >= ? ");
         params.add(memberId);
         params.add(fiveDaysAgoDate.atStartOfDay());
-        
+
         if (StringUtils.hasText(options.keyword())) {
             String keyword = options.keyword().strip();
             sql.append("AND MATCH(ra.title, ra.contents_text) AGAINST(?) ");
             params.add(keyword);
         }
-        
+
         if (options.newsletterId() != null) {
             sql.append("AND ra.newsletter_id = ? ");
             params.add(options.newsletterId());
         }
-        
+
         try {
             Query nativeQuery = entityManager.createNativeQuery(sql.toString());
             for (int i = 0; i < params.size(); i++) {
                 nativeQuery.setParameter(i + 1, params.get(i));
             }
-            
+
             Object result = nativeQuery.getSingleResult();
             return result instanceof Number ? ((Number) result).longValue() : 0L;
         } catch (Exception e) {
@@ -220,7 +218,7 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
             return 0L;
         }
     }
-    
+
     /**
      * article 테이블만 사용하여 조회
      */
@@ -232,60 +230,60 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
     ) {
         StringBuilder sql = new StringBuilder();
         List<Object> params = new ArrayList<>();
-        
+
         // 정렬 조건
         String orderBy = buildOrderByClause(pageable);
-        
+
         // 페이징
         int pageSize = pageable.getPageSize();
         int offset = (int) pageable.getOffset();
-        
+
         sql.append("SELECT ")
-           .append("a.id as article_id, ")
-           .append("a.title, ")
-           .append("a.contents_summary, ")
-           .append("a.arrived_date_time, ")
-           .append("a.thumbnail_url, ")
-           .append("a.expected_read_time, ")
-           .append("a.is_read, ")
-           .append("CASE WHEN EXISTS(SELECT 1 FROM bookmark b WHERE b.article_id = a.id AND b.member_id = ?) THEN 1 ELSE 0 END as is_bookmarked, ")
-           .append("n.name as newsletter_name, ")
-           .append("COALESCE(n.image_url, '') as newsletter_image_url, ")
-           .append("c.name as category_name ")
-           .append("FROM article a ")
-           .append("INNER JOIN newsletter n ON n.id = a.newsletter_id ")
-           .append("INNER JOIN category c ON c.id = n.category_id ")
-           .append("WHERE a.member_id = ? ");
+                .append("a.id as article_id, ")
+                .append("a.title, ")
+                .append("a.contents_summary, ")
+                .append("a.arrived_date_time, ")
+                .append("a.thumbnail_url, ")
+                .append("a.expected_read_time, ")
+                .append("a.is_read, ")
+                .append("CASE WHEN EXISTS(SELECT 1 FROM bookmark b WHERE b.article_id = a.id AND b.member_id = ?) THEN 1 ELSE 0 END as is_bookmarked, ")
+                .append("n.name as newsletter_name, ")
+                .append("COALESCE(n.image_url, '') as newsletter_image_url, ")
+                .append("c.name as category_name ")
+                .append("FROM article a ")
+                .append("INNER JOIN newsletter n ON n.id = a.newsletter_id ")
+                .append("INNER JOIN category c ON c.id = n.category_id ")
+                .append("WHERE a.member_id = ? ");
         params.add(memberId); // bookmark 서브쿼리용
         params.add(memberId); // member_id
-        
+
         if (StringUtils.hasText(options.keyword())) {
             String keyword = options.keyword().strip().toLowerCase();
             sql.append("AND (LOWER(a.title) LIKE ? OR LOWER(a.contents_text) LIKE ?) ");
             params.add("%" + keyword + "%");
             params.add("%" + keyword + "%");
         }
-        
+
         if (options.newsletterId() != null) {
             sql.append("AND a.newsletter_id = ? ");
             params.add(options.newsletterId());
         }
-        
+
         sql.append("ORDER BY ").append(orderBy).append(" ")
-           .append("LIMIT ? OFFSET ?");
+                .append("LIMIT ? OFFSET ?");
         params.add(pageSize);
         params.add(offset);
-        
+
         // Native Query 실행
         try {
             Query nativeQuery = entityManager.createNativeQuery(sql.toString());
             for (int i = 0; i < params.size(); i++) {
                 nativeQuery.setParameter(i + 1, params.get(i));
             }
-            
+
             @SuppressWarnings("unchecked")
             List<Object[]> results = nativeQuery.getResultList();
-            
+
             // 결과를 ArticleResponse로 매핑
             return results.stream()
                     .map(row -> mapToArticleResponse(row))
@@ -295,10 +293,9 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
             throw e;
         }
     }
-    
+
     /**
-     * UNION 쿼리를 사용하여 두 테이블을 합쳐서 DB에서 정렬/페이징 처리
-     * 성능 최적화: DB 레벨에서 정렬/페이징 처리하여 메모리 사용 최소화
+     * UNION 쿼리를 사용하여 두 테이블을 합쳐서 DB에서 정렬/페이징 처리 성능 최적화: DB 레벨에서 정렬/페이징 처리하여 메모리 사용 최소화
      */
     private List<ArticleResponse> findArticlesWithUnion(
             Long memberId,
@@ -308,102 +305,102 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
     ) {
         StringBuilder sql = new StringBuilder();
         List<Object> params = new ArrayList<>();
-        
+
         // 정렬 조건
         String orderBy = buildOrderByClause(pageable);
-        
+
         // 페이징
         int pageSize = pageable.getPageSize();
         int offset = (int) pageable.getOffset();
-        
+
         // UNION 쿼리를 서브쿼리로 감싸서 ORDER BY 적용
         sql.append("SELECT * FROM (");
-        
+
         // UNION 쿼리 구성 - RecentArticle (최근 5일)
         sql.append("SELECT ")
-           .append("ra.id as article_id, ")
-           .append("ra.title, ")
-           .append("ra.contents_summary, ")
-           .append("ra.arrived_date_time, ")
-           .append("ra.thumbnail_url, ")
-           .append("ra.expected_read_time, ")
-           .append("ra.is_read, ")
-           .append("CASE WHEN EXISTS(SELECT 1 FROM bookmark b WHERE b.article_id = ra.id AND b.member_id = ?) THEN 1 ELSE 0 END as is_bookmarked, ")
-           .append("n.name as newsletter_name, ")
-           .append("COALESCE(n.image_url, '') as newsletter_image_url, ")
-           .append("c.name as category_name ")
-           .append("FROM recent_article ra ")
-           .append("INNER JOIN newsletter n ON n.id = ra.newsletter_id ")
-           .append("INNER JOIN category c ON c.id = n.category_id ")
-           .append("WHERE ra.member_id = ? ")
-           .append("AND ra.arrived_date_time >= ? ");
+                .append("ra.article_id as article_id, ")
+                .append("ra.title, ")
+                .append("ra.contents_summary, ")
+                .append("ra.arrived_date_time, ")
+                .append("ra.thumbnail_url, ")
+                .append("ra.expected_read_time, ")
+                .append("ra.is_read, ")
+                .append("CASE WHEN EXISTS(SELECT 1 FROM bookmark b WHERE b.article_id = ra.article_id AND b.member_id = ?) THEN 1 ELSE 0 END as is_bookmarked, ")
+                .append("n.name as newsletter_name, ")
+                .append("COALESCE(n.image_url, '') as newsletter_image_url, ")
+                .append("c.name as category_name ")
+                .append("FROM recent_article ra ")
+                .append("INNER JOIN newsletter n ON n.id = ra.newsletter_id ")
+                .append("INNER JOIN category c ON c.id = n.category_id ")
+                .append("WHERE ra.member_id = ? ")
+                .append("AND ra.arrived_date_time >= ? ");
         params.add(memberId); // bookmark 서브쿼리용
         params.add(memberId); // member_id
         params.add(fiveDaysAgoDate.atStartOfDay());
-        
+
         if (StringUtils.hasText(options.keyword())) {
             String keyword = options.keyword().strip();
             sql.append("AND MATCH(ra.title, ra.contents_text) AGAINST(?) ");
             params.add(keyword);
         }
-        
+
         if (options.newsletterId() != null) {
             sql.append("AND ra.newsletter_id = ? ");
             params.add(options.newsletterId());
         }
-        
+
         // UNION ALL - Article (5일 이전)
         sql.append("UNION ALL ")
-           .append("SELECT ")
-           .append("a.id as article_id, ")
-           .append("a.title, ")
-           .append("a.contents_summary, ")
-           .append("a.arrived_date_time, ")
-           .append("a.thumbnail_url, ")
-           .append("a.expected_read_time, ")
-           .append("a.is_read, ")
-           .append("CASE WHEN EXISTS(SELECT 1 FROM bookmark b WHERE b.article_id = a.id AND b.member_id = ?) THEN 1 ELSE 0 END as is_bookmarked, ")
-           .append("n.name as newsletter_name, ")
-           .append("COALESCE(n.image_url, '') as newsletter_image_url, ")
-           .append("c.name as category_name ")
-           .append("FROM article a ")
-           .append("INNER JOIN newsletter n ON n.id = a.newsletter_id ")
-           .append("INNER JOIN category c ON c.id = n.category_id ")
-           .append("WHERE a.member_id = ? ")
-           .append("AND a.arrived_date_time < ? ");
+                .append("SELECT ")
+                .append("a.id as article_id, ")
+                .append("a.title, ")
+                .append("a.contents_summary, ")
+                .append("a.arrived_date_time, ")
+                .append("a.thumbnail_url, ")
+                .append("a.expected_read_time, ")
+                .append("a.is_read, ")
+                .append("CASE WHEN EXISTS(SELECT 1 FROM bookmark b WHERE b.article_id = a.id AND b.member_id = ?) THEN 1 ELSE 0 END as is_bookmarked, ")
+                .append("n.name as newsletter_name, ")
+                .append("COALESCE(n.image_url, '') as newsletter_image_url, ")
+                .append("c.name as category_name ")
+                .append("FROM article a ")
+                .append("INNER JOIN newsletter n ON n.id = a.newsletter_id ")
+                .append("INNER JOIN category c ON c.id = n.category_id ")
+                .append("WHERE a.member_id = ? ")
+                .append("AND a.arrived_date_time < ? ");
         params.add(memberId); // bookmark 서브쿼리용
         params.add(memberId); // member_id
         params.add(fiveDaysAgoDate.atStartOfDay());
-        
+
         if (StringUtils.hasText(options.keyword())) {
             String keyword = options.keyword().strip().toLowerCase();
             sql.append("AND (LOWER(a.title) LIKE ? OR LOWER(a.contents_text) LIKE ?) ");
             params.add("%" + keyword + "%");
             params.add("%" + keyword + "%");
         }
-        
+
         if (options.newsletterId() != null) {
             sql.append("AND a.newsletter_id = ? ");
             params.add(options.newsletterId());
         }
-        
+
         // 서브쿼리 닫고 ORDER BY 적용
         sql.append(") AS combined ")
-           .append("ORDER BY ").append(orderBy).append(" ")
-           .append("LIMIT ? OFFSET ?");
+                .append("ORDER BY ").append(orderBy).append(" ")
+                .append("LIMIT ? OFFSET ?");
         params.add(pageSize);
         params.add(offset);
-        
+
         // Native Query 실행
         try {
             Query nativeQuery = entityManager.createNativeQuery(sql.toString());
             for (int i = 0; i < params.size(); i++) {
                 nativeQuery.setParameter(i + 1, params.get(i));
             }
-            
+
             @SuppressWarnings("unchecked")
             List<Object[]> results = nativeQuery.getResultList();
-            
+
             // 결과를 ArticleResponse로 매핑
             return results.stream()
                     .map(this::mapToArticleResponse)
@@ -413,17 +410,17 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
             throw e;
         }
     }
-    
+
     private ArticleResponse mapToArticleResponse(Object[] row) {
         // MySQL의 EXISTS는 TINYINT(1)로 반환되므로 Number로 처리
         boolean isRead = row[6] instanceof Number ? ((Number) row[6]).intValue() == 1 : (Boolean) row[6];
         boolean isBookmarked = row[7] instanceof Number ? ((Number) row[7]).intValue() == 1 : (Boolean) row[7];
-        
+
         // expected_read_time은 NULL일 수 있음
-        Integer expectedReadTime = row[5] != null && row[5] instanceof Number 
-                ? ((Number) row[5]).intValue() 
+        Integer expectedReadTime = row[5] != null && row[5] instanceof Number
+                ? ((Number) row[5]).intValue()
                 : null;
-        
+
         return new ArticleResponse(
                 ((Number) row[0]).longValue(), // article_id
                 (String) row[1], // title
@@ -440,26 +437,26 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
                 )
         );
     }
-    
+
     private String buildOrderByClause(Pageable pageable) {
         if (!pageable.getSort().isSorted()) {
             return "arrived_date_time DESC";
         }
-        
+
         StringBuilder orderBy = new StringBuilder();
         boolean first = true;
-        
+
         for (org.springframework.data.domain.Sort.Order order : pageable.getSort()) {
             if (!first) {
                 orderBy.append(", ");
             }
-            
+
             String property = order.getProperty();
             if (!StringUtils.hasText(property)) {
                 throw new CIllegalArgumentException(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION)
                         .addContext("message", "정렬 필드가 비어있습니다.");
             }
-            
+
             String column = switch (property.strip()) {
                 case "arrivedDateTime" -> "arrived_date_time";
                 case "title" -> "title";
@@ -471,17 +468,17 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
                             .addContext("message", "허용되지 않는 정렬 필드입니다: " + property);
                 }
             };
-            
+
             orderBy.append(column);
             if (order.isDescending()) {
                 orderBy.append(" DESC");
             } else {
                 orderBy.append(" ASC");
             }
-            
+
             first = false;
         }
-        
+
         return orderBy.toString();
     }
 
@@ -491,7 +488,7 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
                 date.atTime(LocalTime.MIN),
                 date.atTime(LocalTime.MAX)
         );
-        
+
         Long count = jpaQueryFactory.select(article.count())
                 .from(article)
                 .where(createMemberWhereClause(memberId))
@@ -574,7 +571,8 @@ public class ArticleRepositoryImpl implements CustomArticleRepository{
                 .exists();
     }
 
-    private JPAQuery<Long> getOldTotalQueryForSearch(Long memberId, ArticleSearchOptionsRequest options, LocalDate fiveDaysAgoDate) {
+    private JPAQuery<Long> getOldTotalQueryForSearch(Long memberId, ArticleSearchOptionsRequest options,
+                                                     LocalDate fiveDaysAgoDate) {
         return jpaQueryFactory.select(article.count())
                 .from(article)
                 .join(newsletter).on(article.newsletterId.eq(newsletter.id))

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
@@ -571,8 +571,11 @@ public class ArticleRepositoryImpl implements CustomArticleRepository {
                 .exists();
     }
 
-    private JPAQuery<Long> getOldTotalQueryForSearch(Long memberId, ArticleSearchOptionsRequest options,
-                                                     LocalDate fiveDaysAgoDate) {
+    private JPAQuery<Long> getOldTotalQueryForSearch(
+            Long memberId,
+            ArticleSearchOptionsRequest options,
+            LocalDate fiveDaysAgoDate
+    ) {
         return jpaQueryFactory.select(article.count())
                 .from(article)
                 .join(newsletter).on(article.newsletterId.eq(newsletter.id))

--- a/backend/bom-bom-server/src/main/resources/db/migration/V20.0.0__add_article_id_to_recent_article.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V20.0.0__add_article_id_to_recent_article.sql
@@ -1,0 +1,3 @@
+-- RecentArticle 테이블에 article_id 컬럼 추가
+ALTER TABLE `recent_article` 
+ADD COLUMN `article_id` BIGINT NOT NULL AFTER `id`;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -264,7 +264,13 @@ public final class TestFixture {
      */
     public static RecentArticle createRecentArticle(String title, Long memberId, Long newsletterId,
                                                     LocalDateTime arrivedTime) {
+        return createRecentArticle(title, memberId, newsletterId, arrivedTime, memberId);
+    }
+
+    public static RecentArticle createRecentArticle(String title, Long memberId, Long newsletterId,
+                                                    LocalDateTime arrivedTime, Long articleId) {
         return RecentArticle.builder()
+                .articleId(articleId)
                 .title(title)
                 .contents("<h1>" + title + "</h1>")
                 .contentsText(title)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/service/ArticleServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/service/ArticleServiceTest.java
@@ -812,11 +812,14 @@ class ArticleServiceTest {
         // given
         Newsletter targetNewsletter = newsletters.get(0); // 뉴스픽
         LocalDateTime now = LocalDateTime.now();
+        Article article = TestFixture.createArticle("최근 아티클 검색 테스트", member.getId(), targetNewsletter.getId(), now);
+        articleRepository.save(article);
         RecentArticle recentArticle = TestFixture.createRecentArticle(
                 "최근 아티클 검색 테스트",
                 member.getId(),
                 targetNewsletter.getId(),
-                now
+                now,
+                article.getId()
         );
         recentArticleRepository.save(recentArticle);
 
@@ -840,19 +843,22 @@ class ArticleServiceTest {
         Newsletter targetNewsletter = newsletters.get(0); // 뉴스픽
         LocalDateTime now = LocalDateTime.now();
 
-        // recent_article 테이블에 최근 데이터 저장
-        RecentArticle recentArticle = TestFixture.createRecentArticle(
-                "통합 검색 테스트",
-                member.getId(),
-                targetNewsletter.getId(),
-                now
-        );
-        recentArticleRepository.save(recentArticle);
-
         // article 테이블에 5일 이전 데이터 저장
         LocalDateTime sixDaysAgo = now.minusDays(6);
         Article article = TestFixture.createArticle("통합 검색 테스트", member.getId(), targetNewsletter.getId(), sixDaysAgo);
         articleRepository.save(article);
+
+        // recent_article 테이블에 최근 데이터 저장
+        Article recentArticleSource = TestFixture.createArticle("통합 검색 테스트", member.getId(), targetNewsletter.getId(), now);
+        articleRepository.save(recentArticleSource);
+        RecentArticle recentArticle = TestFixture.createRecentArticle(
+                "통합 검색 테스트",
+                member.getId(),
+                targetNewsletter.getId(),
+                now,
+                recentArticleSource.getId()
+        );
+        recentArticleRepository.save(recentArticle);
 
         // when
         List<ArticleCountPerNewsletterResponse> result = articleRepository.countPerNewsletter(member.getId(), "통합");


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
검색 후 최근 아티클에 한해 아티클 디테일에 접근이 되지 않는 문제 발생

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
최근 아티클 id를 통해서 디테일 페이지에 접근하려고하지만 기존 API는 articleId기반으로 만들어져있음

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
최근 아티클 엔티티에  articleId를 넣어놓은 뒤에 반환할 때 recentArticleId가 아닌 articleId를 반환하도록 수정
이를 통해 모든 아티클이 articleId를 기반으로 조회도록 설정합니다. 

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- articleRepositoryImpl은 321, 328만 봐주시면 됩니다.  이전에 컨벤션이 적용이 되지 않았나 봅니다. 