### PR TITLE
[BOM-890] hotifx: 최근 아티클 생성할 때 article id 주입

### DIFF
--- a/backend/mail-server/src/main/java/news/bombomemail/article/domain/RecentArticle.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/domain/RecentArticle.java
@@ -23,6 +23,9 @@ public class RecentArticle extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
+    private Long articleId;
+
+    @Column(nullable = false)
     private String title;
 
     @Column(nullable = false, columnDefinition = "mediumtext")
@@ -55,6 +58,7 @@ public class RecentArticle extends BaseEntity {
     @Builder
     public RecentArticle(
             Long id,
+            @NonNull Long articleId,
             @NonNull String title,
             @NonNull String contents,
             @NonNull String contentsText,
@@ -67,6 +71,7 @@ public class RecentArticle extends BaseEntity {
             @NonNull LocalDateTime arrivedDateTime
     ) {
         this.id = id;
+        this.articleId = articleId;
         this.title = title;
         this.contents = contents;
         this.contentsText = contentsText;

--- a/backend/mail-server/src/main/java/news/bombomemail/article/event/RecentArticleEventListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/event/RecentArticleEventListener.java
@@ -16,8 +16,13 @@ public class RecentArticleEventListener {
     @TransactionalEventListener
     public void onArticleArrived(ArticleArrivedEvent event) {
         try {
-            recentArticleService.save(event.articleId(), event.message(), event.contents(), event.memberId(),
-                    event.newsletterId());
+            recentArticleService.save(
+                    event.articleId(),
+                    event.message(),
+                    event.contents(),
+                    event.memberId(),
+                    event.newsletterId()
+            );
 
             log.info("최신 아티클 저장 완료: 멤버 ID={}, 뉴스레터 ={}, 아티클 제목={}",
                     event.memberId(), event.newsletterName(), event.articleTitle());

--- a/backend/mail-server/src/main/java/news/bombomemail/article/event/RecentArticleEventListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/event/RecentArticleEventListener.java
@@ -16,7 +16,8 @@ public class RecentArticleEventListener {
     @TransactionalEventListener
     public void onArticleArrived(ArticleArrivedEvent event) {
         try {
-            recentArticleService.save(event.message(), event.contents(), event.memberId(), event.newsletterId());
+            recentArticleService.save(event.articleId(), event.message(), event.contents(), event.memberId(),
+                    event.newsletterId());
 
             log.info("최신 아티클 저장 완료: 멤버 ID={}, 뉴스레터 ={}, 아티클 제목={}",
                     event.memberId(), event.newsletterName(), event.articleTitle());

--- a/backend/mail-server/src/main/java/news/bombomemail/article/service/RecentArticleService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/service/RecentArticleService.java
@@ -25,18 +25,20 @@ public class RecentArticleService {
     private final RecentArticleRepository recentArticleRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void save(MimeMessage message, String contents, Long memberId, Long newsletterId)
+    public void save(Long articleId, MimeMessage message, String contents, Long memberId, Long newsletterId)
             throws MessagingException {
-        recentArticleRepository.save(buildRecentArticle(message, contents, memberId, newsletterId));
+        recentArticleRepository.save(buildRecentArticle(articleId, message, contents, memberId, newsletterId));
     }
 
     private RecentArticle buildRecentArticle(
+            Long articleId,
             MimeMessage message,
             String contents,
             Long memberId,
             Long newsletterId
     ) throws MessagingException {
         return RecentArticle.builder()
+                .articleId(articleId)
                 .title(message.getSubject())
                 .contents(contents)
                 .contentsText(htmlTagCleaner.clean(contents))

--- a/backend/mail-server/src/main/java/news/bombomemail/article/service/RecentArticleService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/service/RecentArticleService.java
@@ -25,7 +25,13 @@ public class RecentArticleService {
     private final RecentArticleRepository recentArticleRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void save(Long articleId, MimeMessage message, String contents, Long memberId, Long newsletterId)
+    public void save(
+            Long articleId,
+            MimeMessage message,
+            String contents,
+            Long memberId,
+            Long newsletterId
+    )
             throws MessagingException {
         recentArticleRepository.save(buildRecentArticle(articleId, message, contents, memberId, newsletterId));
     }

--- a/backend/mail-server/src/test/java/news/bombomemail/article/event/RecentArticleEventListenerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/event/RecentArticleEventListenerTest.java
@@ -62,6 +62,7 @@ class RecentArticleEventListenerTest {
             List<RecentArticle> all = recentArticleRepository.findAll();
             softly.assertThat(all).hasSize(1);
             RecentArticle recentArticle = all.get(0);
+            softly.assertThat(recentArticle.getArticleId()).isEqualTo(articleId);
             softly.assertThat(recentArticle.getTitle()).isEqualTo("테스트 이메일 제목");
             softly.assertThat(recentArticle.getContents()).isEqualTo(contents);
             softly.assertThat(recentArticle.getMemberId()).isEqualTo(memberId);
@@ -103,6 +104,8 @@ class RecentArticleEventListenerTest {
             softly.assertThat(all).hasSize(2);
             softly.assertThat(all).extracting(RecentArticle::getTitle)
                     .containsExactly("첫 번째 제목", "두 번째 제목");
+            softly.assertThat(all).extracting(RecentArticle::getArticleId)
+                    .containsExactly(1L, 2L);
         });
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
@@ -1,6 +1,6 @@
 package news.bombomemail.article.service;
 
-import static org.assertj.core.api.SoftAssertions.*;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -8,10 +8,10 @@ import java.util.List;
 import java.util.Properties;
 import news.bombomemail.article.domain.RecentArticle;
 import news.bombomemail.article.repository.RecentArticleRepository;
+import news.bombomemail.article.util.html.HtmlCleanerConfig;
 import news.bombomemail.email.extractor.EmailContentExtractor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import news.bombomemail.article.util.html.HtmlCleanerConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
@@ -29,12 +29,14 @@ class RecentArticleServiceTest {
     RecentArticleRepository recentArticleRepository;
 
     private Session session;
+    private Long articleId;
     private Long memberId;
     private Long newsletterId;
 
     @BeforeEach
     void setup() {
         session = Session.getDefaultInstance(new Properties());
+        articleId = 1L;
         memberId = 1L;
         newsletterId = 1L;
         recentArticleRepository.deleteAll();
@@ -49,13 +51,14 @@ class RecentArticleServiceTest {
         String content = EmailContentExtractor.extractContents(msg);
 
         // when
-        recentArticleService.save(msg, content, memberId, newsletterId);
+        recentArticleService.save(articleId, msg, content, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
             List<RecentArticle> all = recentArticleRepository.findAll();
             softly.assertThat(all).hasSize(1);
             RecentArticle recentArticle = all.get(0);
+            softly.assertThat(recentArticle.getArticleId()).isEqualTo(articleId);
             softly.assertThat(recentArticle.getTitle()).isEqualTo("테스트 이메일 제목");
             softly.assertThat(recentArticle.getContents()).contains("테스트용 이메일 본문입니다");
             softly.assertThat(recentArticle.getContentsText()).contains("테스트용 이메일 본문입니다");
@@ -76,11 +79,12 @@ class RecentArticleServiceTest {
         String content = EmailContentExtractor.extractContents(msg);
 
         // when
-        recentArticleService.save(msg, content, memberId, newsletterId);
+        recentArticleService.save(articleId, msg, content, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
             RecentArticle recentArticle = recentArticleRepository.findAll().get(0);
+            softly.assertThat(recentArticle.getArticleId()).isEqualTo(articleId);
             softly.assertThat(recentArticle.getContents()).contains("<html>");
             softly.assertThat(recentArticle.getContentsText()).isEqualTo("이것은 HTML 본문입니다.");
             softly.assertThat(recentArticle.getContentsText()).doesNotContain("<html>", "<b>", "</b>");
@@ -96,11 +100,12 @@ class RecentArticleServiceTest {
         String content = EmailContentExtractor.extractContents(msg);
 
         // when
-        recentArticleService.save(msg, content, memberId, newsletterId);
+        recentArticleService.save(articleId, msg, content, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
             RecentArticle recentArticle = recentArticleRepository.findAll().get(0);
+            softly.assertThat(recentArticle.getArticleId()).isEqualTo(articleId);
             softly.assertThat(recentArticle.getContents()).isEmpty();
             softly.assertThat(recentArticle.getContentsText()).isEmpty();
             softly.assertThat(recentArticle.getExpectedReadTime()).isZero();
@@ -123,11 +128,12 @@ class RecentArticleServiceTest {
         String content = EmailContentExtractor.extractContents(msg);
 
         // when
-        recentArticleService.save(msg, content, memberId, newsletterId);
+        recentArticleService.save(articleId, msg, content, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
             RecentArticle recentArticle = recentArticleRepository.findAll().get(0);
+            softly.assertThat(recentArticle.getArticleId()).isEqualTo(articleId);
             softly.assertThat(recentArticle.getContentsSummary()).hasSize(103);
             softly.assertThat(recentArticle.getContentsSummary()).endsWith("...");
         });
@@ -147,8 +153,8 @@ class RecentArticleServiceTest {
         String content2 = EmailContentExtractor.extractContents(msg2);
 
         // when
-        recentArticleService.save(msg1, content1, memberId, newsletterId);
-        recentArticleService.save(msg2, content2, memberId, newsletterId);
+        recentArticleService.save(1L, msg1, content1, memberId, newsletterId);
+        recentArticleService.save(2L, msg2, content2, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
@@ -156,6 +162,8 @@ class RecentArticleServiceTest {
             softly.assertThat(all).hasSize(2);
             softly.assertThat(all).extracting(RecentArticle::getTitle)
                     .containsExactly("첫 번째 제목", "두 번째 제목");
+            softly.assertThat(all).extracting(RecentArticle::getArticleId)
+                    .containsExactly(1L, 2L);
         });
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
운영서에서 최근 아티클 엔티티에 articleId 추가를 했기에 이메일서버에도 적용이 필요

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
최근 아티클을 저장하는 동작을 이메일 서버에서 하기 때문에 수정이 필요


## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
최근 아티클을 저장할 때 articleId도 같이 저장되도록 수정


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- [#633](https://github.com/woowacourse-teams/2025-bom-bom/pull/633)랑 연관된 PR입니다.