### PR TITLE
[BOM-900] feat: 이메일 처리 방식 개선

### DIFF
--- a/backend/mail-server/src/main/java/news/bombomemail/common/SchedulingConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package news.bombomemail.common;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/email/EmailIntegrationConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/email/EmailIntegrationConfig.java
@@ -7,14 +7,18 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
+import org.springframework.integration.channel.DirectChannel;
 import org.springframework.integration.config.EnableIntegration;
 import org.springframework.integration.core.MessageSource;
 import org.springframework.integration.dsl.IntegrationFlow;
 import org.springframework.integration.dsl.Pollers;
 import org.springframework.integration.file.FileReadingMessageSource;
+import org.springframework.integration.file.dsl.Files;
 import org.springframework.integration.file.filters.AcceptOnceFileListFilter;
 import org.springframework.integration.file.filters.CompositeFileListFilter;
 import org.springframework.integration.file.filters.SimplePatternFileListFilter;
+import org.springframework.integration.handler.advice.ExpressionEvaluatingRequestHandlerAdvice;
+import org.springframework.messaging.MessageChannel;
 
 @Slf4j
 @Profile("!test")
@@ -22,21 +26,42 @@ import org.springframework.integration.file.filters.SimplePatternFileListFilter;
 @EnableIntegration
 public class EmailIntegrationConfig {
 
-    @Value("${integration.file.maildir}")
-    private String mailDir;
+    private static final String DIR_NEW = "new";
+    private static final String DIR_IN_PROGRESS = "in-progress";
+    private static final String DIR_PROCESSED = "processed";
+    private static final String DIR_FAILED = "parsing-failed";
+
+    /**
+     * maildir의 base 디렉터리. 예) /maildir
+     */
+    @Value("${maildir.base-dir}")
+    private String mailBaseDir;
 
     @PostConstruct
     public void logMailDir() {
-        log.info("▶▶▶ integration.file.maildir = {}", mailDir);
-        File dir = new File(mailDir);
+        log.info("▶▶▶ maildir.base-dir = {}", mailBaseDir);
+        File dir = new File(mailBaseDir);
         log.info("▶▶▶ 실제 디렉토리: {} (exists: {}, writable: {})",
                 dir.getAbsolutePath(), dir.exists(), dir.canWrite());
     }
 
     @Bean
-    public MessageSource<File> mailFileSource() {
+    public MessageChannel processedChannel() {
+        return new DirectChannel();
+    }
+
+    @Bean
+    public MessageChannel failedChannel() {
+        return new DirectChannel();
+    }
+
+    /**
+     * maildir/new 를 읽어오는 소스.
+     */
+    @Bean
+    public MessageSource<File> newMailFileSource() {
         FileReadingMessageSource source = new FileReadingMessageSource();
-        source.setDirectory(new File(mailDir));
+        source.setDirectory(new File(mailBaseDir, DIR_NEW));
         source.setAutoCreateDirectory(true);
 
         CompositeFileListFilter<File> filter = new CompositeFileListFilter<>();
@@ -48,11 +73,61 @@ public class EmailIntegrationConfig {
     }
 
     @Bean
+    public ExpressionEvaluatingRequestHandlerAdvice emailProcessingAdvice() {
+        ExpressionEvaluatingRequestHandlerAdvice advice = new ExpressionEvaluatingRequestHandlerAdvice();
+
+        // 성공: 원본 payload(File)를 그대로 processedChannel 로 전달
+        advice.setOnSuccessExpressionString("payload");
+        advice.setSuccessChannelName("processedChannel");
+
+        // 실패: ErrorMessage.payload.failedMessage.payload (원본 File)을 failedChannel 로 전달
+        advice.setOnFailureExpressionString("payload.failedMessage.payload");
+        advice.setFailureChannelName("failedChannel");
+
+        advice.setTrapException(true);
+
+        return advice;
+    }
+
+    /**
+     * maildir/new → maildir/in-progress 로 이동시키고, 이어서 처리까지 수행하는 플로우
+     */
+    @Bean
     public IntegrationFlow mailFileFlow() {
+        File inProgressDir = new File(mailBaseDir, DIR_IN_PROGRESS);
+
         return IntegrationFlow
-                .from(mailFileSource(),
+                .from(newMailFileSource(),
                         c -> c.poller(Pollers.fixedDelay(5000).getObject()))
-                .handle("emailService", "processEmailFile")
+                .handle(Files.outboundAdapter(inProgressDir)
+                        .autoCreateDirectory(true)
+                        .deleteSourceFiles(true))
+                .handle("emailService", "processEmailFile",
+                        e -> e.advice(emailProcessingAdvice()))
+                .get();
+    }
+
+    @Bean
+    public IntegrationFlow processedMoveFlow() {
+        File processedDir = new File(mailBaseDir, DIR_PROCESSED);
+
+        return IntegrationFlow
+                .from("processedChannel")
+                .handle(Files.outboundAdapter(processedDir)
+                        .autoCreateDirectory(true)
+                        .deleteSourceFiles(true))
+                .get();
+    }
+
+    @Bean
+    public IntegrationFlow failedMoveFlow() {
+        File failedDir = new File(mailBaseDir, DIR_FAILED);
+
+        return IntegrationFlow
+                .from("failedChannel")
+                .handle(Files.outboundAdapter(failedDir)
+                        .autoCreateDirectory(true)
+                        .deleteSourceFiles(true))
                 .get();
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/email/service/EmailService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/email/service/EmailService.java
@@ -8,6 +8,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombomemail.article.service.ArticleService;
@@ -20,54 +21,113 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailService {
 
+    private static final String DIR_IN_PROGRESS = "in-progress";
+    private static final String DIR_PROCESSED = "processed";
+    private static final String DIR_FAILED = "parsing-failed";
+
     private final Session mailSession;
     private final ArticleService articleService;
 
     public void processEmailFile(File emailFile) {
-        try (InputStream fileInputStream = new FileInputStream(emailFile)) {
-            MimeMessage mimeMessage = new MimeMessage(mailSession, fileInputStream);
-            String contents = EmailContentExtractor.extractContents(mimeMessage);
-            boolean saved = articleService.save(mimeMessage, contents);
-            if (saved) {
-                deleteEmailFile(emailFile);
-                return;
-            }
-        } catch (MessagingException | IOException e) {
-            log.error("이메일 파싱/입출력 오류: {}", emailFile.getName(), e);
-        } catch (DataAccessException e) {
-            log.error("DB 오류: {}", emailFile.getName(), e);
-        } catch (Exception e) {
-            log.error("예상치 못한 오류: {}", emailFile.getName(), e);
-        }
-        moveToFailedDir(emailFile);
-    }
-
-    private void deleteEmailFile(File emailFile) {
-        try {
-            Files.delete(emailFile.toPath());
-            log.debug("메일 삭제 mail file: {}", emailFile.getName());
-        } catch (IOException e) {
-            log.warn("메일을 삭제하는데 실패했습니다. mail file: {} - exists: {}, canWrite: {}, isFile: {}, Reason: {}",
-                    emailFile.getAbsolutePath(),
-                    emailFile.exists(),
-                    emailFile.canWrite(),
-                    emailFile.isFile(),
-                    e.getMessage());
-            moveToFailedDir(emailFile);
-        }
-    }
-
-    private void moveToFailedDir(File file) {
-        File failedDir = new File(file.getParentFile().getParent(), "parsing-failed");
-        if (!failedDir.exists()) {
-            failedDir.mkdirs();
-        }
-        File target = new File(failedDir, file.getName());
-        boolean success = file.renameTo(target);
-        if (success) {
-            log.warn("파싱 실패로 failed 디렉터리로 이동: {}", target.getAbsolutePath());
+        File inprogressFile = claimToInProgress(emailFile);
+        if (inprogressFile == null) {
             return;
         }
-        log.error("failed 디렉터리로 파일 이동 실패: {}", file.getAbsolutePath());
+
+        try {
+            Result result = processInProgressFile(inprogressFile);
+
+            String targetDir = (result == Result.PROCESSED) ? DIR_PROCESSED : DIR_FAILED;
+            File moved = move(inprogressFile, targetDir);
+            if (moved == null) {
+                log.error("{} 이동 실패: {}", targetDir, inprogressFile.getAbsolutePath());
+            }
+        } catch (MessagingException | IOException e) {
+            handleFailure(inprogressFile, "이메일 파싱/입출력 오류", e);
+        } catch (DataAccessException e) {
+            handleFailure(inprogressFile, "DB 오류", e);
+        } catch (Exception e) {
+            handleFailure(inprogressFile, "예상치 못한 오류", e);
+        }
     }
+
+    private Result processInProgressFile(File inprogressFile) throws MessagingException, IOException {
+        try (InputStream in = new FileInputStream(inprogressFile)) {
+            MimeMessage mimeMessage = new MimeMessage(mailSession, in);
+            String contents = EmailContentExtractor.extractContents(mimeMessage);
+
+            boolean saved = articleService.save(mimeMessage, contents);
+            return saved ? Result.PROCESSED : Result.FAILED;
+        }
+    }
+
+    private File claimToInProgress(File newFile) {
+        File moved = move(newFile, DIR_IN_PROGRESS);
+        if (moved == null) {
+            return null;
+        }
+
+        // stale 판정을 위해 "처리 시작 시점"으로 갱신
+        boolean touched = moved.setLastModified(System.currentTimeMillis());
+        if (!touched) {
+            log.debug("lastModified 갱신 실패(무시 가능): {}", moved.getAbsolutePath());
+        }
+        return moved;
+    }
+
+    private File move(File file, String dirName) {
+        File baseDir = file.getParentFile().getParentFile();
+        File dir = new File(baseDir, dirName);
+
+        if (!dir.exists() && !dir.mkdirs()) {
+            log.error("{} 디렉터리 생성 실패: {}", dirName, dir.getAbsolutePath());
+            return null;
+        }
+
+        File target = new File(dir, file.getName());
+
+        if (file.renameTo(target)) {
+            log.info("{}로 이동: {}", dirName, target.getAbsolutePath());
+            return target;
+        }
+
+        try {
+            Files.copy(
+                    file.toPath(),
+                    target.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING
+            );
+
+            if (!file.delete()) {
+                log.error("원본 삭제 실패(중복 위험): {}", file.getAbsolutePath());
+            }
+
+            log.info("{}로 복사+삭제 이동: {}", dirName, target.getAbsolutePath());
+            return target;
+
+        } catch (Exception e) {
+            log.error("{}로 이동 실패: {}", dirName, file.getAbsolutePath(), e);
+            return null;
+        }
+    }
+
+    private void handleFailure(File inprogressFile, String reason, Exception e) {
+        if (inprogressFile.getParentFile().getName().equals(DIR_FAILED)) {
+            log.warn("이미 failed에 있음: {}", inprogressFile.getAbsolutePath());
+            return;
+        }
+
+        if (e == null) {
+            log.warn("{}: {}", reason, inprogressFile.getAbsolutePath());
+        } else {
+            log.error("{}: {}", reason, inprogressFile.getName(), e);
+        }
+
+        File moved = move(inprogressFile, DIR_FAILED);
+        if (moved == null) {
+            log.error("failed 이동 실패: {}", inprogressFile.getAbsolutePath());
+        }
+    }
+
+    private enum Result {PROCESSED, FAILED}
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/email/service/EmailService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/email/service/EmailService.java
@@ -7,8 +7,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombomemail.article.service.ArticleService;
@@ -21,113 +19,36 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailService {
 
-    private static final String DIR_IN_PROGRESS = "in-progress";
-    private static final String DIR_PROCESSED = "processed";
-    private static final String DIR_FAILED = "parsing-failed";
-
     private final Session mailSession;
     private final ArticleService articleService;
 
-    public void processEmailFile(File emailFile) {
-        File inprogressFile = claimToInProgress(emailFile);
-        if (inprogressFile == null) {
-            return;
-        }
+    /**
+     * @throws MessagingException  이메일 파싱 실패
+     * @throws IOException         파일 입출력 실패
+     * @throws DataAccessException DB 처리 실패
+     */
+    public void processEmailFile(File inProgressFile)
+            throws MessagingException, IOException, DataAccessException {
 
-        try {
-            Result result = processInProgressFile(inprogressFile);
+        log.info("이메일 처리 시작: {}", inProgressFile.getAbsolutePath());
 
-            String targetDir = (result == Result.PROCESSED) ? DIR_PROCESSED : DIR_FAILED;
-            File moved = move(inprogressFile, targetDir);
-            if (moved == null) {
-                log.error("{} 이동 실패: {}", targetDir, inprogressFile.getAbsolutePath());
-            }
-        } catch (MessagingException | IOException e) {
-            handleFailure(inprogressFile, "이메일 파싱/입출력 오류", e);
-        } catch (DataAccessException e) {
-            handleFailure(inprogressFile, "DB 오류", e);
-        } catch (Exception e) {
-            handleFailure(inprogressFile, "예상치 못한 오류", e);
-        }
-    }
-
-    private Result processInProgressFile(File inprogressFile) throws MessagingException, IOException {
-        try (InputStream in = new FileInputStream(inprogressFile)) {
+        try (InputStream in = new FileInputStream(inProgressFile)) {
             MimeMessage mimeMessage = new MimeMessage(mailSession, in);
             String contents = EmailContentExtractor.extractContents(mimeMessage);
 
             boolean saved = articleService.save(mimeMessage, contents);
-            return saved ? Result.PROCESSED : Result.FAILED;
-        }
-    }
-
-    private File claimToInProgress(File newFile) {
-        File moved = move(newFile, DIR_IN_PROGRESS);
-        if (moved == null) {
-            return null;
-        }
-
-        // stale 판정을 위해 "처리 시작 시점"으로 갱신
-        boolean touched = moved.setLastModified(System.currentTimeMillis());
-        if (!touched) {
-            log.debug("lastModified 갱신 실패(무시 가능): {}", moved.getAbsolutePath());
-        }
-        return moved;
-    }
-
-    private File move(File file, String dirName) {
-        File baseDir = file.getParentFile().getParentFile();
-        File dir = new File(baseDir, dirName);
-
-        if (!dir.exists() && !dir.mkdirs()) {
-            log.error("{} 디렉터리 생성 실패: {}", dirName, dir.getAbsolutePath());
-            return null;
-        }
-
-        File target = new File(dir, file.getName());
-
-        if (file.renameTo(target)) {
-            log.info("{}로 이동: {}", dirName, target.getAbsolutePath());
-            return target;
-        }
-
-        try {
-            Files.copy(
-                    file.toPath(),
-                    target.toPath(),
-                    StandardCopyOption.REPLACE_EXISTING
-            );
-
-            if (!file.delete()) {
-                log.error("원본 삭제 실패(중복 위험): {}", file.getAbsolutePath());
+            if (!saved) {
+                throw new BusinessProcessingException("아티클 저장 실패: " + inProgressFile.getName());
             }
 
-            log.info("{}로 복사+삭제 이동: {}", dirName, target.getAbsolutePath());
-            return target;
-
-        } catch (Exception e) {
-            log.error("{}로 이동 실패: {}", dirName, file.getAbsolutePath(), e);
-            return null;
+            log.info("아티클 처리 완료: {}", inProgressFile.getAbsolutePath());
         }
     }
 
-    private void handleFailure(File inprogressFile, String reason, Exception e) {
-        if (inprogressFile.getParentFile().getName().equals(DIR_FAILED)) {
-            log.warn("이미 failed에 있음: {}", inprogressFile.getAbsolutePath());
-            return;
-        }
+    public static class BusinessProcessingException extends RuntimeException {
 
-        if (e == null) {
-            log.warn("{}: {}", reason, inprogressFile.getAbsolutePath());
-        } else {
-            log.error("{}: {}", reason, inprogressFile.getName(), e);
-        }
-
-        File moved = move(inprogressFile, DIR_FAILED);
-        if (moved == null) {
-            log.error("failed 이동 실패: {}", inprogressFile.getAbsolutePath());
+        public BusinessProcessingException(String message) {
+            super(message);
         }
     }
-
-    private enum Result {PROCESSED, FAILED}
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/maildir/DirectoryRetentionCleaner.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/maildir/DirectoryRetentionCleaner.java
@@ -1,0 +1,63 @@
+package news.bombomemail.maildir;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DirectoryRetentionCleaner {
+
+    private final Clock clock = Clock.systemDefaultZone();
+
+    public CleanupResult cleanup(Path dir, int retentionDays) {
+        if (!Files.isDirectory(dir)) {
+            log.debug("정리 대상 디렉터리 없음: {}", dir);
+            return CleanupResult.EMPTY;
+        }
+
+        Instant cutoff = Instant.now(clock).minus(retentionDays, ChronoUnit.DAYS);
+
+        int deleted = 0;
+        int failed = 0;
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(dir)) {
+            for (Path p : stream) {
+                if (!Files.isRegularFile(p)) {
+                    continue;
+                }
+
+                try {
+                    Instant lastModified = Files.getLastModifiedTime(p).toInstant();
+                    if (lastModified.isAfter(cutoff)) {
+                        continue;
+                    }
+
+                    Files.deleteIfExists(p);
+                    deleted++;
+                } catch (Exception e) {
+                    failed++;
+                    log.warn("파일 삭제 실패: {}", p, e);
+                }
+            }
+        } catch (IOException e) {
+            log.error("디렉터리 조회 실패: {}", dir, e);
+            return new CleanupResult(deleted, failed, true);
+        }
+
+        return new CleanupResult(deleted, failed, false);
+    }
+
+    public record CleanupResult(int deleted, int failed, boolean scanFailed) {
+        public static final CleanupResult EMPTY = new CleanupResult(0, 0, false);
+    }
+}
+

--- a/backend/mail-server/src/main/java/news/bombomemail/maildir/scheduler/InProgressRequeueScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/maildir/scheduler/InProgressRequeueScheduler.java
@@ -1,0 +1,74 @@
+package news.bombomemail.maildir.scheduler;
+
+import java.io.File;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class InProgressRequeueScheduler {
+
+    private static final String DIR_IN_PROGRESS = "in-progress";
+    private static final String DIR_NEW = "new";
+    private static final long MILLIS_PER_MINUTE = 60_000L;
+
+    @Value("${maildir.base-dir}")
+    private String baseDir;
+
+    @Value("${maildir.in-progress-stale-minutes:60}")
+    private long staleMinutes;
+
+    @Scheduled(fixedDelayString = "${maildir.in-progress-requeue-interval-ms:1800000}")
+    public void requeueStaleInProgress() {
+        File inProgressDir = resolveDir(DIR_IN_PROGRESS);
+        File newDir = resolveDir(DIR_NEW);
+
+        if (!inProgressDir.isDirectory()) {
+            return;
+        }
+        if (!ensureDirectory(newDir)) {
+            return;
+        }
+
+        long cutoffMillis = cutoffMillis(staleMinutes);
+
+        File[] files = inProgressDir.listFiles(File::isFile);
+        if (files == null) {
+            return;
+        }
+
+        for (File file : files) {
+            if (!isStale(file, cutoffMillis)) {
+                continue;
+            }
+
+            File target = new File(newDir, file.getName());
+            if (!file.renameTo(target)) {
+                log.warn("stale requeue 실패: {}", file.getAbsolutePath());
+                continue;
+            }
+            log.warn("stale requeue: {}", target.getAbsolutePath());
+        }
+    }
+
+    private File resolveDir(String dirName) {
+        return new File(baseDir, dirName);
+    }
+
+    private boolean ensureDirectory(File dir) {
+        return dir.exists() || dir.mkdirs();
+    }
+
+    private long cutoffMillis(long staleMinutes) {
+        return System.currentTimeMillis() - (staleMinutes * MILLIS_PER_MINUTE);
+    }
+
+    private boolean isStale(File file, long cutoffMillis) {
+        // 마지막 수정 시간이 cutoff보다 이전이면 stale로 판단
+        return file.lastModified() < cutoffMillis;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/maildir/scheduler/MaildirCleanupScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/maildir/scheduler/MaildirCleanupScheduler.java
@@ -1,0 +1,47 @@
+package news.bombomemail.maildir.scheduler;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombomemail.maildir.DirectoryRetentionCleaner;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MaildirCleanupScheduler {
+
+    private static final String TIME_ZONE = "Asia/Seoul";
+    private static final String DAILY_CRON = "0 0 1 * * *";
+
+    private final DirectoryRetentionCleaner cleaner;
+
+    @Value("${maildir.base-dir}")
+    private String baseDir;
+
+    @Value("${maildir.processed-retention-days:5}")
+    private int processedRetentionDays;
+
+    @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
+    public void cleanupProcessed() {
+        Path processedDir = Paths.get(baseDir, "processed");
+
+        DirectoryRetentionCleaner.CleanupResult result = cleaner.cleanup(processedDir, processedRetentionDays);
+
+        if (result.scanFailed()) {
+            log.error("processed 정리 실패(스캔 실패): dir={}, deleted={}, failed={}",
+                    processedDir, result.deleted(), result.failed());
+            return;
+        }
+
+        if (result.deleted() > 0 || result.failed() > 0) {
+            log.info("processed 정리 완료: dir={}, deleted={}, failed={}, retentionDays={}",
+                    processedDir, result.deleted(), result.failed(), processedRetentionDays);
+        } else {
+            log.debug("processed 정리 대상 없음: dir={}, retentionDays={}", processedDir, processedRetentionDays);
+        }
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
@@ -1,7 +1,14 @@
 package news.bombomemail.email.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import news.bombomemail.article.domain.Article;
@@ -9,9 +16,10 @@ import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
 import news.bombomemail.email.EmailConfig;
+import news.bombomemail.email.service.EmailService.BusinessProcessingException;
+import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
 import news.bombomemail.member.repository.MemberRepository;
-import news.bombomemail.member.domain.Gender;
 import news.bombomemail.newsletter.domain.Newsletter;
 import news.bombomemail.newsletter.repository.NewsletterRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -20,14 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-
-import java.io.File;
-import java.nio.file.StandardCopyOption;
 import org.springframework.test.context.ActiveProfiles;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.SoftAssertions.*;
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -49,23 +50,23 @@ class EmailServiceTest {
     @BeforeEach
     void setup() {
         memberRepository.save(Member.builder()
-            .email("test-member@example.com")
-            .nickname("테스트멤버")
-            .providerId("test")
-            .provider("google")
-            .gender(Gender.MALE)
-            .roleId(1L)
-            .birthDate(java.time.LocalDate.of(1990, 1, 1)) // 생년월일 추가
-            .build());
+                .email("test-member@example.com")
+                .nickname("테스트멤버")
+                .providerId("test")
+                .provider("google")
+                .gender(Gender.MALE)
+                .roleId(1L)
+                .birthDate(java.time.LocalDate.of(1990, 1, 1)) // 생년월일 추가
+                .build());
 
         newsletterRepository.save(Newsletter.builder()
-            .name("테스트뉴스레터")
-            .description("설명")
-            .imageUrl("이미지")
-            .email("test-newsletter@example.com")
-            .categoryId(1L)
-            .detailId(1L)
-            .build());
+                .name("테스트뉴스레터")
+                .description("설명")
+                .imageUrl("이미지")
+                .email("test-newsletter@example.com")
+                .categoryId(1L)
+                .detailId(1L)
+                .build());
     }
 
     @TempDir
@@ -112,7 +113,8 @@ class EmailServiceTest {
         File emlFile = target.toFile();
 
         // when
-        emailService.processEmailFile(emlFile);
+        assertThatThrownBy(() -> emailService.processEmailFile(emlFile))
+                .isInstanceOf(NullPointerException.class);
 
         // then
         assertThat(articleRepository.findAll()).isEmpty();
@@ -125,7 +127,6 @@ class EmailServiceTest {
         Path target = tempDir.resolve("sample_no_body.eml");
         Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
         File emlFile = target.toFile();
-
 
         // when
         emailService.processEmailFile(emlFile);
@@ -149,7 +150,8 @@ class EmailServiceTest {
         File emlFile = target.toFile();
 
         // when
-        emailService.processEmailFile(emlFile);
+        assertThatThrownBy(() -> emailService.processEmailFile(emlFile))
+                .isInstanceOf(BusinessProcessingException.class);
 
         // then
         assertThat(articleRepository.findAll()).isEmpty();
@@ -193,7 +195,8 @@ class EmailServiceTest {
         Files.writeString(file, eml, StandardOpenOption.CREATE);
 
         // when
-        emailService.processEmailFile(file.toFile());
+        assertThatThrownBy(() -> emailService.processEmailFile(file.toFile()))
+                .isInstanceOf(BusinessProcessingException.class);
 
         // then
         assertThat(articleRepository.findAll()).isEmpty();
@@ -212,7 +215,8 @@ class EmailServiceTest {
         Files.writeString(file, eml, StandardOpenOption.CREATE);
 
         // when
-        emailService.processEmailFile(file.toFile());
+        assertThatThrownBy(() -> emailService.processEmailFile(file.toFile()))
+                .isInstanceOf(BusinessProcessingException.class);
 
         // then
         assertThat(articleRepository.findAll()).isEmpty();
@@ -225,8 +229,8 @@ class EmailServiceTest {
 
         // when & then
         assertSoftly(soft -> {
-            assertThatCode(() -> emailService.processEmailFile(dir))
-                    .doesNotThrowAnyException();
+            assertThatThrownBy(() -> emailService.processEmailFile(dir))
+                    .isInstanceOf(FileNotFoundException.class);
             assertThat(articleRepository.findAll()).isEmpty();
         });
     }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- Maildir new/에 떨어진 이메일 파일 처리 방식을 개선했습니다.
- 처리 중/처리 완료/처리 실패 상태를 디렉터리로 명확히 구분하도록 in-progress/, processed/ 흐름을 추가했습니다.
- processed/ 보관 파일 자동 정리와, 서버 종료로 in-progress/에 남은 파일을 복구(requeue)하는 스케줄러를 추가했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

설계 때는 고려하였으나 돌아가는 쓰레기를 먼저 구현하기위해 메일이 정상적으로 저장되면 삭제하였습니다.
해서 원래 설계대로 메일이 DB에 저장되면 원본 메일 파일을 5일간 보관하였다가 삭제하는 방식으로 변경했습니다. 

- 클레임 기반 처리
  - 처리 시작 시 new → in-progress로 파일을 먼저 이동하여 중복 처리 가능성을 낮춤
- 처리 결과에 따른 분리
  - 저장 성공: processed/
  - 저장 실패 또는 예외: parsing-failed/
- 파일 이동 안정화
  - renameTo 우선 시도, 실패 시 copy → delete fallback
- 운영 자동화
  - processed/ 파일을 보관 기간 이후 자동 삭제(스케줄러)
  - in-progress/에 일정 시간 이상 남아있는 stale 파일을 new/로 되돌림(스케줄러)
 
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- Email 처리 로직 변경
 - 전체 흐름 : new(메일 도착) -> in-progress(이메일 처리 중) -> processed(이메일 처리 성공) or parsing-failed(이메일 처리 실패)
   - in-progress, processed 폴더 추가
   - 파일 이동은 spring integeration이 담당
- 스케줄러 추가
  - processed cleanup (메일을 DB에 저장 후 5일이 지나면 원본 파일 삭제)
  - in-progress stale requeue (n 시간이상 처리되지 않은 파일을 다시 new로 파일 이동)

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 한 번에 너무나 큰 변경은 위험할 것 같아서 일단 간단하게 구현해놓았습니다. 추후 더 보강할 예정입니다.