### PR TITLE
[BOM-908] fix: 챌린지 전체 조회 중도 탈락 필드 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeDetailResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeDetailResponse.java
@@ -20,13 +20,11 @@ public record ChallengeDetailResponse(
         return new ChallengeDetailResponse(false, 0, null, null);
     }
 
-    public static ChallengeDetailResponse ongoing(int progress) {
-        return new ChallengeDetailResponse(true, progress, null, null);
+    public static ChallengeDetailResponse ongoing(int progress, boolean isSurvived) {
+        return new ChallengeDetailResponse(true, progress, null, isSurvived);
     }
 
-    public static ChallengeDetailResponse ended(int progress, boolean isSurvived) {
-        ChallengeGrade grade = ChallengeGrade.calculate(progress, isSurvived);
-        boolean isSuccess = grade != ChallengeGrade.FAIL;
-        return new ChallengeDetailResponse(true, progress, grade, isSuccess);
+    public static ChallengeDetailResponse ended(int progress, boolean isSurvived, ChallengeGrade grade) {
+        return new ChallengeDetailResponse(true, progress, grade, isSurvived);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -14,6 +14,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeGrade;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
@@ -249,13 +250,15 @@ public class ChallengeService {
             return ChallengeDetailResponse.notJoined();
         }
 
-        int progress = myParticipant.calculateProgress(challenge.getTotalDays());
         boolean isEnded = challenge.isEnded(LocalDate.now());
+        boolean isSurvived = myParticipant.isSurvived();
+        int progress = myParticipant.calculateProgress(challenge.getTotalDays());
 
         if (isEnded) {
-            return ChallengeDetailResponse.ended(progress, myParticipant.isSurvived());
+            ChallengeGrade grade = ChallengeGrade.calculate(progress, isSurvived);
+            return ChallengeDetailResponse.ended(progress, isSurvived, grade);
         }
-        return ChallengeDetailResponse.ongoing(progress);
+        return ChallengeDetailResponse.ongoing(progress, isSurvived);
     }
 
     private RuntimeException createApplyException(Long challengeId, Member member, EligibilityReason reason) {


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 조회 시에 중도 탈락에 대한 고려가 없어서 탈락시에도 "달성 중"으로 표시되는 문제 

<img width="436" height="197" alt="image" src="https://github.com/user-attachments/assets/24a41cf3-f4d6-4907-8845-bbf5d614d3eb" />

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
중도 탈락 시에도 UI적으로 별도의 처리를 하기 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
기존에 isSuccess 필드를 사용해서 챌린지 종료 후 성공 여부를 나타냈는데, 해당 필드를 isSurvived로 수정하여 챌린지 생존 여부를 나타내도록 수정하였습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
필드 명만 바뀌었고 로직적으로 바뀐 부분은 없습니다.