### PR TITLE
[BOM-909] feat: 챌린지 코멘트 답글 작성/조회 기능 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyController.java
@@ -4,11 +4,17 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
 import me.bombom.api.v1.challenge.service.ChallengeCommentReplyService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,7 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/challenges/comments")
-public class ChallengeCommentReplyController implements ChallengeCommentReplyControllerApi{
+public class ChallengeCommentReplyController implements ChallengeCommentReplyControllerApi {
 
     private final ChallengeCommentReplyService challengeCommentReplyService;
 
@@ -31,7 +37,17 @@ public class ChallengeCommentReplyController implements ChallengeCommentReplyCon
             @LoginMember Member member,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @Valid @RequestBody CreateCommentReplyRequest request
-    ){
+    ) {
         challengeCommentReplyService.createCommentReply(commentId, member.getId(), request);
+    }
+
+    @Override
+    @GetMapping("/{commentId}/replies")
+    public Page<CommentReplyResponse> getCommentReplies(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
+    ) {
+        return challengeCommentReplyService.getCommentReplies(member.getId(), commentId, pageable);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyController.java
@@ -25,29 +25,31 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/challenges/comments")
+@RequestMapping("/api/v1/challenges")
 public class ChallengeCommentReplyController implements ChallengeCommentReplyControllerApi {
 
     private final ChallengeCommentReplyService challengeCommentReplyService;
 
     @Override
-    @PostMapping("/{commentId}/replies")
+    @PostMapping("{challengeId}/comments/{commentId}/replies")
     @ResponseStatus(HttpStatus.CREATED)
     public void createCommentReply(
             @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @Valid @RequestBody CreateCommentReplyRequest request
     ) {
-        challengeCommentReplyService.createCommentReply(commentId, member.getId(), request);
+        challengeCommentReplyService.createCommentReply(challengeId, commentId, member.getId(), request);
     }
 
     @Override
-    @GetMapping("/{commentId}/replies")
+    @GetMapping("{challengeId}/comments/{commentId}/replies")
     public Page<CommentReplyResponse> getCommentReplies(
             @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
     ) {
-        return challengeCommentReplyService.getCommentReplies(member.getId(), commentId, pageable);
+        return challengeCommentReplyService.getCommentReplies(member.getId(), challengeId, commentId, pageable);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyController.java
@@ -1,0 +1,37 @@
+package me.bombom.api.v1.challenge.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.challenge.service.ChallengeCommentReplyService;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/challenges/comments")
+public class ChallengeCommentReplyController implements ChallengeCommentReplyControllerApi{
+
+    private final ChallengeCommentReplyService challengeCommentReplyService;
+
+    @Override
+    @PostMapping("/{commentId}/replies")
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createCommentReply(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
+            @Valid @RequestBody CreateCommentReplyRequest request
+    ){
+        challengeCommentReplyService.createCommentReply(commentId, member.getId(), request);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
@@ -8,9 +8,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
 import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -34,5 +37,21 @@ public interface ChallengeCommentReplyControllerApi {
             @Parameter(hidden = true) @LoginMember Member member,
             @Parameter(description = "코멘트 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @Valid @RequestBody CreateCommentReplyRequest request
+    );
+
+    @Operation(
+            summary = "코멘트 답글 조회",
+            description = "특정 코멘트에 달린 답글 목록을 페이지네이션하여 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "답글 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값", content = @Content),
+            @ApiResponse(responseCode = "403", description = "답글 조회 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "코멘트를 찾을 수 없음", content = @Content)
+    })
+    Page<CommentReplyResponse> getCommentReplies(
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "코멘트 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
+            @Parameter(description = "페이지/정렬 정보 (page, size, sort)") Pageable pageable
     );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
@@ -8,8 +8,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
 import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
@@ -35,6 +35,7 @@ public interface ChallengeCommentReplyControllerApi {
     })
     void createCommentReply(
             @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(description = "코멘트 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @Valid @RequestBody CreateCommentReplyRequest request
     );
@@ -51,6 +52,7 @@ public interface ChallengeCommentReplyControllerApi {
     })
     Page<CommentReplyResponse> getCommentReplies(
             @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(description = "코멘트 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @Parameter(description = "페이지/정렬 정보 (page, size, sort)") Pageable pageable
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
@@ -1,0 +1,38 @@
+package me.bombom.api.v1.challenge.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Challenge Comment Reply", description = "챌린지 코멘트 답글 API")
+@ApiResponses({
+        @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content)
+})
+public interface ChallengeCommentReplyControllerApi {
+
+    @Operation(
+            summary = "코멘트 답글 생성",
+            description = "특정 코멘트에 대해 답글을 작성합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "코멘트 답글 생성 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값", content = @Content),
+            @ApiResponse(responseCode = "403", description = "코멘트 답글 작성 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "코멘트를 찾을 수 없음", content = @Content)
+    })
+    void createCommentReply(
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "코멘트 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
+            @Valid @RequestBody CreateCommentReplyRequest request
+    );
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeComment.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeComment.java
@@ -40,6 +40,9 @@ public class ChallengeComment extends BaseEntity {
     @Column(nullable = false)
     private int likeCount;
 
+    @Column(nullable = false)
+    private int replyCount;
+
     @Builder
     public ChallengeComment(
             Long id,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeCommentReply.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeCommentReply.java
@@ -1,0 +1,43 @@
+package me.bombom.api.v1.challenge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChallengeCommentReply extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long participantId;
+
+    @Column(nullable = false)
+    private Long commentId;
+
+    @Column(nullable = false, length = 500)
+    private String reply;
+
+    @Builder
+    public ChallengeCommentReply(
+            @NonNull Long participantId,
+            @NonNull Long commentId,
+            @NonNull String reply
+    ) {
+        this.participantId = participantId;
+        this.commentId = commentId;
+        this.reply = reply;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/CreateCommentReplyRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/CreateCommentReplyRequest.java
@@ -1,0 +1,12 @@
+package me.bombom.api.v1.challenge.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateCommentReplyRequest(
+
+        @NotNull
+        @Size(max = 500, message = "답글은 500자 이하로 작성 가능합니다.")
+        String reply
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeCommentResponse.java
@@ -38,6 +38,9 @@ public record ChallengeCommentResponse(
         int likeCount,
 
         @Schema(requiredMode = RequiredMode.REQUIRED)
-        boolean isLiked
+        boolean isLiked,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        int replyCount
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CommentReplyResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CommentReplyResponse.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record CommentReplyResponse(
+
+        @NotNull
+        Long replyId,
+
+        String nickname,
+
+        String profileImageUrl,
+
+        @NotNull
+        String reply,
+
+        @NotNull
+        LocalDateTime createdAt,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        boolean isMyReply
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
@@ -1,7 +1,36 @@
 package me.bombom.api.v1.challenge.repository;
 
 import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
+import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChallengeCommentReplyRepository extends JpaRepository<ChallengeCommentReply, Long> {
+    @Query("""
+                SELECT new me.bombom.api.v1.challenge.dto.response.CommentReplyResponse(
+                    cr.id,
+                    crMember.nickname,
+                    crMember.profileImageUrl,
+                    cr.reply,
+                    cr.createdAt,
+                    (crAuthor.memberId = :memberId)
+                )
+                FROM ChallengeCommentReply cr
+                JOIN ChallengeParticipant crAuthor ON cr.participantId = crAuthor.id
+                LEFT JOIN Member crMember ON crAuthor.memberId = crMember.id
+                JOIN ChallengeComment cc ON cr.commentId = cc.id
+                JOIN ChallengeParticipant ccAuthor ON cc.participantId = ccAuthor.id
+                JOIN ChallengeParticipant me
+                    ON me.memberId = :memberId
+                    AND me.challengeId = ccAuthor.challengeId
+                WHERE cr.commentId = :commentId
+            """)
+    Page<CommentReplyResponse> findAllByCommentId(
+            @Param("commentId") Long commentId,
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.challenge.repository;
+
+import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeCommentReplyRepository extends JpaRepository<ChallengeCommentReply, Long> {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
@@ -21,11 +21,6 @@ public interface ChallengeCommentReplyRepository extends JpaRepository<Challenge
                 FROM ChallengeCommentReply cr
                 JOIN ChallengeParticipant crAuthor ON cr.participantId = crAuthor.id
                 LEFT JOIN Member crMember ON crAuthor.memberId = crMember.id
-                JOIN ChallengeComment cc ON cr.commentId = cc.id
-                JOIN ChallengeParticipant ccAuthor ON cc.participantId = ccAuthor.id
-                JOIN ChallengeParticipant me
-                    ON me.memberId = :memberId
-                    AND me.challengeId = ccAuthor.challengeId
                 WHERE cr.commentId = :commentId
             """)
     Page<CommentReplyResponse> findAllByCommentId(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
@@ -80,9 +80,8 @@ public interface ChallengeCommentRepository extends JpaRepository<ChallengeComme
     @Modifying(flushAutomatically = true)
     @Query("""
                 UPDATE ChallengeComment c
-                   SET c.replyCount = c.replyCount + :amount
+                   SET c.replyCount = c.replyCount + 1
                  WHERE c.id = :commentId
-                   AND ( :amount >= 0 OR c.replyCount > 0 )
             """)
     void updateReplyCount(Long commentId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
@@ -64,4 +64,15 @@ public interface ChallengeCommentRepository extends JpaRepository<ChallengeComme
                    AND ( :amount >= 0 OR c.likeCount > 0 )
             """)
     void incrementLikeCountNotBelowZero(Long commentId, int amount);
+
+    @Query("""
+        SELECT CASE WHEN COUNT(ccParticipant) > 0 THEN true ELSE false END
+        FROM ChallengeComment cc
+        JOIN ChallengeParticipant ccAuthor ON ccAuthor.id = cc.participantId
+                JOIN ChallengeParticipant ccParticipant
+                    ON ccParticipant.challengeId = ccAuthor.challengeId
+                    AND ccParticipant.memberId = :memberId
+                WHERE cc.id = :commentId
+            """)
+    boolean existsVisibleToMember(@Param("commentId") Long commentId, @Param("memberId") Long memberId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
@@ -34,7 +34,8 @@ public interface ChallengeCommentRepository extends JpaRepository<ChallengeComme
                     CASE
                         WHEN ccl.id IS NOT NULL THEN true
                         ELSE false
-                    END
+                    END,
+                    cc.replyCount
                 )
                 FROM ChallengeComment cc
                 JOIN ChallengeParticipant cp ON cc.participantId = cp.id
@@ -66,13 +67,22 @@ public interface ChallengeCommentRepository extends JpaRepository<ChallengeComme
     void incrementLikeCountNotBelowZero(Long commentId, int amount);
 
     @Query("""
-        SELECT CASE WHEN COUNT(ccParticipant) > 0 THEN true ELSE false END
-        FROM ChallengeComment cc
-        JOIN ChallengeParticipant ccAuthor ON ccAuthor.id = cc.participantId
-                JOIN ChallengeParticipant ccParticipant
-                    ON ccParticipant.challengeId = ccAuthor.challengeId
-                    AND ccParticipant.memberId = :memberId
-                WHERE cc.id = :commentId
+            SELECT CASE WHEN COUNT(ccParticipant) > 0 THEN true ELSE false END
+            FROM ChallengeComment cc
+            JOIN ChallengeParticipant ccAuthor ON ccAuthor.id = cc.participantId
+                    JOIN ChallengeParticipant ccParticipant
+                        ON ccParticipant.challengeId = ccAuthor.challengeId
+                        AND ccParticipant.memberId = :memberId
+                    WHERE cc.id = :commentId
             """)
     boolean existsVisibleToMember(@Param("commentId") Long commentId, @Param("memberId") Long memberId);
+
+    @Modifying(flushAutomatically = true)
+    @Query("""
+                UPDATE ChallengeComment c
+                   SET c.replyCount = c.replyCount + :amount
+                 WHERE c.id = :commentId
+                   AND ( :amount >= 0 OR c.replyCount > 0 )
+            """)
+    void updateReplyCount(Long commentId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
@@ -66,17 +66,6 @@ public interface ChallengeCommentRepository extends JpaRepository<ChallengeComme
             """)
     void incrementLikeCountNotBelowZero(Long commentId, int amount);
 
-    @Query("""
-            SELECT CASE WHEN COUNT(ccParticipant) > 0 THEN true ELSE false END
-            FROM ChallengeComment cc
-            JOIN ChallengeParticipant ccAuthor ON ccAuthor.id = cc.participantId
-                    JOIN ChallengeParticipant ccParticipant
-                        ON ccParticipant.challengeId = ccAuthor.challengeId
-                        AND ccParticipant.memberId = :memberId
-                    WHERE cc.id = :commentId
-            """)
-    boolean existsVisibleToMember(@Param("commentId") Long commentId, @Param("memberId") Long memberId);
-
     @Modifying(flushAutomatically = true)
     @Query("""
                 UPDATE ChallengeComment c

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -93,4 +93,13 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
           )
     """)
     List<ChallengeParticipant> findAbsentees(@Param("challengeId") Long challengeId, @Param("date") LocalDate date);
+
+    @Query("""
+        SELECT cp
+        FROM ChallengeParticipant cp
+        JOIN ChallengeComment cc
+        ON cc.participantId = cp.id
+        WHERE cc.id = :commentId
+    """)
+    Optional<ChallengeParticipant> findAuthorByCommentId(@Param("commentId") Long commentId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
@@ -4,12 +4,15 @@ import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentReplyRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +40,12 @@ public class ChallengeCommentReplyService {
         );
     }
 
+    public Page<CommentReplyResponse> getCommentReplies(Long memberId, Long commentId, Pageable pageable) {
+        validateComment(commentId);
+        validateReplyVisible(commentId, memberId);
+        return challengeCommentReplyRepository.findAllByCommentId(commentId, memberId, pageable);
+    }
+
     private void validateComment(Long commentId) {
         if (!challengeCommentRepository.existsById(commentId)) {
             throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
@@ -60,5 +69,15 @@ public class ChallengeCommentReplyService {
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
                         .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
+    }
+
+    private void validateReplyVisible(Long commentId, Long memberId) {
+        if (!challengeCommentRepository.existsVisibleToMember(commentId, memberId)) {
+            throw new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
+                    .addContext(ErrorContextKeys.COMMENT_ID, commentId)
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.OPERATION, "existsVisibleToMember");
+
+        }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
@@ -26,10 +26,9 @@ public class ChallengeCommentReplyService {
     private final ChallengeParticipantRepository challengeParticipantRepository;
 
     @Transactional
-    public void createCommentReply(Long commentId, Long memberId, CreateCommentReplyRequest request) {
+    public void createCommentReply(Long challengeId, Long commentId, Long memberId, CreateCommentReplyRequest request) {
         validateComment(commentId);
-        ChallengeParticipant commentAuthor = getCommentAuthorByCommentId(commentId);
-        ChallengeParticipant replyAuthor = getParticipantWithChallengeId(memberId, commentAuthor.getChallengeId());
+        ChallengeParticipant replyAuthor = getParticipantWithChallengeId(memberId, challengeId);
 
         challengeCommentReplyRepository.save(
                 ChallengeCommentReply.builder()
@@ -41,9 +40,9 @@ public class ChallengeCommentReplyService {
         challengeCommentRepository.updateReplyCount(commentId);
     }
 
-    public Page<CommentReplyResponse> getCommentReplies(Long memberId, Long commentId, Pageable pageable) {
+    public Page<CommentReplyResponse> getCommentReplies(Long memberId, Long challengeId, Long commentId, Pageable pageable) {
         validateComment(commentId);
-        validateReplyVisible(commentId, memberId);
+        validateMemberInSameChallenge(challengeId, memberId);
         return challengeCommentReplyRepository.findAllByCommentId(commentId, memberId, pageable);
     }
 
@@ -55,12 +54,13 @@ public class ChallengeCommentReplyService {
         }
     }
 
-    private ChallengeParticipant getCommentAuthorByCommentId(Long commentId) {
-        return challengeParticipantRepository.findAuthorByCommentId(commentId)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.COMMENT_ID, commentId)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
-                        .addContext(ErrorContextKeys.OPERATION, "findAuthorByCommentId"));
+    private void validateMemberInSameChallenge(Long challengeId, Long memberId) {
+        if (!challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId)) {
+            throw new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.OPERATION, "existsByChallengeIdAndMemberId");
+        }
     }
 
     private ChallengeParticipant getParticipantWithChallengeId(Long memberId, Long challengeId) {
@@ -70,14 +70,5 @@ public class ChallengeCommentReplyService {
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
                         .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
-    }
-
-    private void validateReplyVisible(Long commentId, Long memberId) {
-        if (!challengeCommentRepository.existsVisibleToMember(commentId, memberId)) {
-            throw new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
-                    .addContext(ErrorContextKeys.COMMENT_ID, commentId)
-                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
-                    .addContext(ErrorContextKeys.OPERATION, "existsVisibleToMember");
-        }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
@@ -78,7 +78,6 @@ public class ChallengeCommentReplyService {
                     .addContext(ErrorContextKeys.COMMENT_ID, commentId)
                     .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                     .addContext(ErrorContextKeys.OPERATION, "existsVisibleToMember");
-
         }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
@@ -38,6 +38,7 @@ public class ChallengeCommentReplyService {
                         .reply(request.reply())
                         .build()
         );
+        challengeCommentRepository.updateReplyCount(commentId);
     }
 
     public Page<CommentReplyResponse> getCommentReplies(Long memberId, Long commentId, Pageable pageable) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
@@ -1,0 +1,64 @@
+package me.bombom.api.v1.challenge.service;
+
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentReplyRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorContextKeys;
+import me.bombom.api.v1.common.exception.ErrorDetail;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeCommentReplyService {
+
+    private final ChallengeCommentReplyRepository challengeCommentReplyRepository;
+    private final ChallengeCommentRepository challengeCommentRepository;
+    private final ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Transactional
+    public void createCommentReply(Long commentId, Long memberId, CreateCommentReplyRequest request) {
+        validateComment(commentId);
+        ChallengeParticipant commentAuthor = getCommentAuthorByCommentId(commentId);
+        ChallengeParticipant replyAuthor = getParticipantWithChallengeId(memberId, commentAuthor.getChallengeId());
+
+        challengeCommentReplyRepository.save(
+                ChallengeCommentReply.builder()
+                        .commentId(commentId)
+                        .participantId(replyAuthor.getId())
+                        .reply(request.reply())
+                        .build()
+        );
+    }
+
+    private void validateComment(Long commentId) {
+        if (!challengeCommentRepository.existsById(commentId)) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.COMMENT_ID, commentId)
+                    .addContext(ErrorContextKeys.OPERATION, "existsById");
+        }
+    }
+
+    private ChallengeParticipant getCommentAuthorByCommentId(Long commentId) {
+        return challengeParticipantRepository.findAuthorByCommentId(commentId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.COMMENT_ID, commentId)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                        .addContext(ErrorContextKeys.OPERATION, "findAuthorByCommentId"));
+    }
+
+    private ChallengeParticipant getParticipantWithChallengeId(Long memberId, Long challengeId) {
+        return challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
+                        .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                        .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndMemberId"));
+    }
+}

--- a/backend/bom-bom-server/src/main/resources/db/migration/V21.0.0__create_challenge_comment_reply.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V21.0.0__create_challenge_comment_reply.sql
@@ -1,0 +1,11 @@
+CREATE TABLE challenge_comment_reply (
+    id             BIGINT       NOT NULL AUTO_INCREMENT,
+    participant_id BIGINT       NOT NULL,
+    comment_id     BIGINT       NOT NULL,
+    reply          VARCHAR(500) NOT NULL,
+    created_at     DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at     DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id)
+) ENGINE = InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_0900_ai_ci;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V21.0.1__add_reply_count_to_challenge_comment.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V21.0.1__add_reply_count_to_challenge_comment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge_comment
+    ADD COLUMN reply_count INT NOT NULL DEFAULT 0;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V21.0.2__alter_challenge_comment_like_collate.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V21.0.2__alter_challenge_comment_like_collate.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge_comment_like
+    COLLATE utf8mb4_unicode_ci;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerTest.java
@@ -1,0 +1,98 @@
+package me.bombom.api.v1.challenge.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Map;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class ChallengeCommentReplyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private OAuth2AuthenticationToken authToken;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository.deleteAllInBatch();
+
+        Member member = memberRepository.save(
+                TestFixture.createUniqueMember("replyUser", java.util.UUID.randomUUID().toString()));
+
+        Map<String, Object> attributes = Map.of(
+                "id", member.getId().toString(),
+                "email", member.getEmail(),
+                "name", member.getNickname()
+        );
+
+        CustomOAuth2User principal = new CustomOAuth2User(attributes, member, null, null);
+        authToken = new OAuth2AuthenticationToken(
+                principal,
+                principal.getAuthorities(),
+                "registrationId"
+        );
+    }
+
+    @Test
+    void commentId가_1_미만이면_400을_응답한다() throws Exception {
+        // given
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("감사합니다!");
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenges/comments/{commentId}/replies", 0L)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 답글_내용이_null이면_400을_응답한다() throws Exception {
+        // given
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest(null);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenges/comments/{commentId}/replies", 1L)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 답글_내용이_500자를_초과하면_400을_응답한다() throws Exception {
+        // given
+        String longReply = "a".repeat(501);
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest(longReply);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/challenges/comments/{commentId}/replies", 1L)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerTest.java
@@ -1,13 +1,25 @@
 package me.bombom.api.v1.challenge.controller;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Map;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeComment;
+import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentReplyRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.support.IntegrationTest;
@@ -33,22 +45,77 @@ class ChallengeCommentReplyControllerTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ChallengeCommentRepository challengeCommentRepository;
+
+    @Autowired
+    private ChallengeCommentReplyRepository challengeCommentReplyRepository;
+
     private OAuth2AuthenticationToken authToken;
+    private Member viewer;
+    private Challenge challenge;
+    private ChallengeComment challengeComment;
 
     @BeforeEach
     void setUp() {
+        challengeCommentReplyRepository.deleteAllInBatch();
+        challengeCommentRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
 
-        Member member = memberRepository.save(
+        viewer = memberRepository.save(
                 TestFixture.createUniqueMember("replyUser", java.util.UUID.randomUUID().toString()));
+        Member commentAuthor = memberRepository.save(
+                TestFixture.createUniqueMember("commentAuthor", java.util.UUID.randomUUID().toString()));
+
+        challenge = challengeRepository.save(
+                TestFixture.createChallenge(
+                        "comment-challenge",
+                        java.time.LocalDate.now().minusDays(1),
+                        java.time.LocalDate.now().plusDays(5),
+                        7));
+
+        ChallengeParticipant commentAuthorParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        commentAuthor.getId(),
+                        0));
+
+        ChallengeParticipant viewerParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        viewer.getId(),
+                        0));
+
+        challengeComment = challengeCommentRepository.save(
+                TestFixture.createChallengeComment(
+                        1L,
+                        commentAuthorParticipant.getId(),
+                        "article title",
+                        "quote",
+                        "comment"));
+
+        challengeCommentReplyRepository.save(
+                ChallengeCommentReply.builder()
+                        .commentId(challengeComment.getId())
+                        .participantId(viewerParticipant.getId())
+                        .reply("첫번째 답글")
+                        .build());
 
         Map<String, Object> attributes = Map.of(
-                "id", member.getId().toString(),
-                "email", member.getEmail(),
-                "name", member.getNickname()
+                "id", viewer.getId().toString(),
+                "email", viewer.getEmail(),
+                "name", viewer.getNickname()
         );
 
-        CustomOAuth2User principal = new CustomOAuth2User(attributes, member, null, null);
+        CustomOAuth2User principal = new CustomOAuth2User(attributes, viewer, null, null);
         authToken = new OAuth2AuthenticationToken(
                 principal,
                 principal.getAuthorities(),
@@ -93,6 +160,28 @@ class ChallengeCommentReplyControllerTest {
                         .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void 코멘트_답글_목록을_조회하면_200과_페이지정보를_반환한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/comments/{commentId}/replies", challengeComment.getId())
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                        .param("size", "10")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content", hasSize(1)))
+                .andExpect(jsonPath("$.content[0].reply", is("첫번째 답글")))
+                .andExpect(jsonPath("$.content[0].isMyReply", is(true)));
+    }
+
+    @Test
+    void 코멘트ID가_1미만이면_답글_조회시_400을_응답한다() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/comments/{commentId}/replies", 0L)
+                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                        .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerTest.java
@@ -129,7 +129,7 @@ class ChallengeCommentReplyControllerTest {
         CreateCommentReplyRequest request = new CreateCommentReplyRequest("감사합니다!");
 
         // when & then
-        mockMvc.perform(post("/api/v1/challenges/comments/{commentId}/replies", 0L)
+        mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), 0L)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -142,7 +142,7 @@ class ChallengeCommentReplyControllerTest {
         CreateCommentReplyRequest request = new CreateCommentReplyRequest(null);
 
         // when & then
-        mockMvc.perform(post("/api/v1/challenges/comments/{commentId}/replies", 1L)
+        mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
                         .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -156,7 +156,7 @@ class ChallengeCommentReplyControllerTest {
         CreateCommentReplyRequest request = new CreateCommentReplyRequest(longReply);
 
         // when & then
-        mockMvc.perform(post("/api/v1/challenges/comments/{commentId}/replies", 1L)
+        mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
                         .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
@@ -166,7 +166,7 @@ class ChallengeCommentReplyControllerTest {
     @Test
     void 코멘트_답글_목록을_조회하면_200과_페이지정보를_반환한다() throws Exception {
         // when & then
-        mockMvc.perform(get("/api/v1/challenges/comments/{commentId}/replies", challengeComment.getId())
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
                         .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
                         .param("size", "10")
                         .accept(MediaType.APPLICATION_JSON))
@@ -179,7 +179,7 @@ class ChallengeCommentReplyControllerTest {
     @Test
     void 코멘트ID가_1미만이면_답글_조회시_400을_응답한다() throws Exception {
         // when & then
-        mockMvc.perform(get("/api/v1/challenges/comments/{commentId}/replies", 0L)
+        mockMvc.perform(get("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), 0L)
                         .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
                         .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
@@ -1,0 +1,134 @@
+package me.bombom.api.v1.challenge.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeComment;
+import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentReplyRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+class ChallengeCommentReplyServiceTest {
+
+    @Autowired
+    private ChallengeCommentReplyService challengeCommentReplyService;
+
+    @Autowired
+    private ChallengeCommentReplyRepository challengeCommentReplyRepository;
+
+    @Autowired
+    private ChallengeCommentRepository challengeCommentRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Member commentAuthorMember;
+    private Member replyMember;
+    private Challenge challenge;
+    private ChallengeParticipant commentAuthorParticipant;
+    private ChallengeComment challengeComment;
+
+    @BeforeEach
+    void setUp() {
+        challengeCommentReplyRepository.deleteAllInBatch();
+        challengeCommentRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        commentAuthorMember = memberRepository.save(
+                TestFixture.createUniqueMember("commentAuthor", java.util.UUID.randomUUID().toString()));
+        replyMember = memberRepository.save(
+                TestFixture.createUniqueMember("replyAuthor", java.util.UUID.randomUUID().toString()));
+
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "reply-challenge",
+                LocalDate.now().minusDays(1),
+                LocalDate.now().plusDays(5),
+                7));
+
+        commentAuthorParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        commentAuthorMember.getId(),
+                        0));
+
+        challengeComment = challengeCommentRepository.save(
+                TestFixture.createChallengeComment(
+                        1L,
+                        commentAuthorParticipant.getId(),
+                        "article title",
+                        "quote",
+                        "comment"));
+    }
+
+    @Test
+    void 코멘트에_답글을_작성한다() {
+        // given
+        ChallengeParticipant replyParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        replyMember.getId(),
+                        0));
+
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("감사합니다!");
+
+        //when
+        challengeCommentReplyService.createCommentReply(challengeComment.getId(), replyMember.getId(), request);
+
+        // then
+        List<ChallengeCommentReply> replies = challengeCommentReplyRepository.findAll();
+        assertSoftly(softly -> {
+            softly.assertThat(replies).hasSize(1);
+            softly.assertThat(replies.get(0).getCommentId()).isEqualTo(challengeComment.getId());
+            softly.assertThat(replies.get(0).getParticipantId()).isEqualTo(replyParticipant.getId());
+            softly.assertThat(replies.get(0).getReply()).isEqualTo("감사합니다!");
+        });
+    }
+
+    @Test
+    void 존재하지_않는_코멘트에_답글을_작성하면_예외가_발생한다() {
+        // given
+        Long notExistCommentId = 999L;
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("reply");
+
+        // when & then
+        assertThatThrownBy(() -> challengeCommentReplyService.createCommentReply(notExistCommentId, replyMember.getId(), request))
+                .isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 챌린지_참여자가_아닌_회원은_답글을_작성할_수_없다() {
+        // given
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("reply");
+
+        // when & then
+        assertThatThrownBy(() -> challengeCommentReplyService.createCommentReply(
+                challengeComment.getId(),
+                replyMember.getId(),
+                request))
+                .isInstanceOf(CIllegalArgumentException.class);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
@@ -99,7 +99,12 @@ class ChallengeCommentReplyServiceTest {
         CreateCommentReplyRequest request = new CreateCommentReplyRequest("감사합니다!");
 
         //when
-        challengeCommentReplyService.createCommentReply(challengeComment.getId(), replyMember.getId(), request);
+        challengeCommentReplyService.createCommentReply(
+                challenge.getId(),
+                challengeComment.getId(),
+                replyMember.getId(),
+                request
+        );
 
         // then
         List<ChallengeCommentReply> replies = challengeCommentReplyRepository.findAll();
@@ -118,7 +123,12 @@ class ChallengeCommentReplyServiceTest {
         CreateCommentReplyRequest request = new CreateCommentReplyRequest("reply");
 
         // when & then
-        assertThatThrownBy(() -> challengeCommentReplyService.createCommentReply(notExistCommentId, replyMember.getId(), request))
+        assertThatThrownBy(
+                () -> challengeCommentReplyService.createCommentReply(
+                        challenge.getId(),
+                        notExistCommentId,
+                        replyMember.getId(),
+                        request))
                 .isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -129,6 +139,7 @@ class ChallengeCommentReplyServiceTest {
 
         // when & then
         assertThatThrownBy(() -> challengeCommentReplyService.createCommentReply(
+                challenge.getId(),
                 challengeComment.getId(),
                 replyMember.getId(),
                 request))
@@ -154,6 +165,7 @@ class ChallengeCommentReplyServiceTest {
         // when
         Page<CommentReplyResponse> page = challengeCommentReplyService.getCommentReplies(
                 replyMember.getId(),
+                challenge.getId(),
                 challengeComment.getId(),
                 PageRequest.of(0, 10));
 
@@ -174,6 +186,7 @@ class ChallengeCommentReplyServiceTest {
         // when & then
         assertThatThrownBy(() -> challengeCommentReplyService.getCommentReplies(
                 outsider.getId(),
+                challenge.getId(),
                 challengeComment.getId(),
                 PageRequest.of(0, 10)))
                 .isInstanceOf(CIllegalArgumentException.class);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
@@ -11,6 +11,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeComment;
 import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
+import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentReplyRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
@@ -22,6 +23,8 @@ import me.bombom.support.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 
 @IntegrationTest
 class ChallengeCommentReplyServiceTest {
@@ -129,6 +132,50 @@ class ChallengeCommentReplyServiceTest {
                 challengeComment.getId(),
                 replyMember.getId(),
                 request))
+                .isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 코멘트에_달린_답글을_조회한다() {
+        // given
+        ChallengeParticipant replyParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        replyMember.getId(),
+                        0));
+
+        challengeCommentReplyRepository.save(
+                ChallengeCommentReply.builder()
+                        .commentId(challengeComment.getId())
+                        .participantId(replyParticipant.getId())
+                        .reply("첫번째 답글")
+                        .build());
+
+        // when
+        Page<CommentReplyResponse> page = challengeCommentReplyService.getCommentReplies(
+                replyMember.getId(),
+                challengeComment.getId(),
+                PageRequest.of(0, 10));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(page.getTotalElements()).isEqualTo(1);
+            softly.assertThat(page.getContent().get(0).reply()).isEqualTo("첫번째 답글");
+            softly.assertThat(page.getContent().get(0).isMyReply()).isTrue();
+        });
+    }
+
+    @Test
+    void 챌린지_참여자가_아니면_답글을_조회할_수_없다() {
+        // given
+        Member outsider = memberRepository.save(
+                TestFixture.createUniqueMember("챌린지 참여 안한 사람", java.util.UUID.randomUUID().toString()));
+
+        // when & then
+        assertThatThrownBy(() -> challengeCommentReplyService.getCommentReplies(
+                outsider.getId(),
+                challengeComment.getId(),
+                PageRequest.of(0, 10)))
                 .isInstanceOf(CIllegalArgumentException.class);
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 코멘트에 대한 답글 작성 기능을 추가합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
좋은 의견에 대해 챌린지 참여자들끼리 활발한 의견 나눔을 도모하기 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

### UI 및 기능 
- 챌린지 코멘트에 답글을 작성할 수 있습니다.
- 챌린지 코멘트의 '답글 N개 더보기' 버튼을 누르면 해당 코멘트에 달린 답글들을 볼 수 있습니다.
(지금 프론트 담당자분이 너무 바쁘신 관계로 아직 봄봄 디자인은 안나왔습니다..
ref로 유튜브랑 인스타 형태를 따라가고자 해서 이거라도 올립니다)
<img width="277" height="233" alt="image" src="https://github.com/user-attachments/assets/b25087f4-d92b-498f-b20c-9eb9578411eb" />
<img width="265" height="133" alt="image" src="https://github.com/user-attachments/assets/632f5dee-cafe-4895-9f20-b8ce49286000" />

### 백엔드 구현사항
#### 1️⃣ 챌린지 코멘트 답글 작성 API
- 챌린지 코멘트 하나에 대해 답글을 작성합니다.
- 일단 답글 작성 길이 제한은 500자로 했습니다. (기준은 딱히 없었는데 아마 프론트와 UI 의논을 한 번 더 하고 정할 것 같습니다.)

#### 2️⃣ 특정 챌린지 코멘트에 대한 답글 목록 조회 API
- '답글 N개 더보기' 버튼을 누르면 해당 코멘트에 대한 답글이 목록으로 펼쳐질 예정입니다.
- UI는 페이지네이션 계획이 아직 없지만 추후에 도입하게 된다면 param 설정만으로 쉽게 할 수 있도록 백엔드는 선제적으로 페이징을 도입했습니다.
- 기존의 채팅이나 답글 flow 상, 가장 오래된 것이 위로 올라가고 아래로 갈수록 최신인 흐름이 자연스러운 것 같아서 `createdAt` `ASC`로 정렬하도록 했습니다.

#### 3️⃣ 챌린지 코멘트 목록 조회 시 응답에 답글 개수 추가
- '답글 N개 더보기' 버튼을 만들기 위해 코멘트 목록 조회 시 답글 개수를 응답에 포함합니다.
- 챌린지 코멘트에 `replyCount` 필드를 추가해서 답글 작성 시 `replyCount++` 하도록 만들고, 조회시에는 단순 필드 조회로 만들었습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 프론트와의 일정 조정 상 답글 수정/삭제는 2차 PR로 쪼개서 구현할 것 같습니다! 참고 부탁드립니다.

- 지금 `Reply`에 `participantId`와 `commentId`를 갖도록 구현했습니다.
- 이렇게 하다보니 지금 답글을 달려는 사람이 해당 코멘트가 작성된 챌린지에 참여하고 있는지를 검증하려면 쿼리가 꽤 복잡해집니다..
```sql
# ChallengeCommentRepository의 existsVisibleToMember() 참조

SELECT CASE WHEN COUNT(ccParticipant) > 0 THEN true ELSE false END
FROM ChallengeComment cc
JOIN ChallengeParticipant ccAuthor ON ccAuthor.id = cc.participantId
JOIN ChallengeParticipant ccParticipant
    ON ccParticipant.challengeId = ccAuthor.challengeId
    AND ccParticipant.memberId = :memberId
    WHERE cc.id = :commentId
```
- 혹시 쿼리가 더 간단해질 수 있을지, 개선할 방향이 있다면 추천 부탁드립니다!