### PR TITLE
[BOM-911] feat: 내 랭킹 조회 시 뱃지 조회 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeDetailResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeDetailResponse.java
@@ -13,7 +13,7 @@ public record ChallengeDetailResponse(
 
         ChallengeGrade grade,
 
-        Boolean isSuccess
+        Boolean isSurvived
 ) {
 
     public static ChallengeDetailResponse notJoined() {
@@ -26,7 +26,6 @@ public record ChallengeDetailResponse(
 
     public static ChallengeDetailResponse ended(int progress, boolean isSurvived) {
         ChallengeGrade grade = ChallengeGrade.calculate(progress, isSurvived);
-        boolean isSuccess = grade != ChallengeGrade.FAIL;
-        return new ChallengeDetailResponse(true, progress, grade, isSuccess);
+        return new ChallengeDetailResponse(true, progress, grade, isSurvived);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/MonthlyReadingRankFlat.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/MonthlyReadingRankFlat.java
@@ -4,6 +4,7 @@ public record MonthlyReadingRankFlat(
                 String nickname,
                 long rank,
                 int monthlyReadCount,
+                long nextRankDifference,
                 String rankingBadgeGrade,
                 Integer rankingBadgeYear,
                 Integer rankingBadgeMonth,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/MemberMonthlyReadingRankResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/MemberMonthlyReadingRankResponse.java
@@ -1,16 +1,33 @@
 package me.bombom.api.v1.reading.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import me.bombom.api.v1.badge.dto.response.BadgesResponse;
+import me.bombom.api.v1.reading.dto.MonthlyReadingRankFlat;
 
 public record MemberMonthlyReadingRankResponse(
+
+        @NotNull
+        String nickname,
 
         @Schema(required = true)
         long rank,
 
         @Schema(required = true)
-        long readCount,
+        int monthlyReadCount,
 
         @Schema(required = true)
-        long nextRankDifference
+        long nextRankDifference,
+
+        BadgesResponse badges
 ) {
+
+    public static MemberMonthlyReadingRankResponse from(MonthlyReadingRankFlat flat) {
+        return new MemberMonthlyReadingRankResponse(
+                flat.nickname(),
+                flat.rank(),
+                flat.monthlyReadCount(),
+                flat.nextRankDifference(),
+                BadgesResponse.from(flat));
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/MonthlyReadingRankResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/MonthlyReadingRankResponse.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.reading.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import me.bombom.api.v1.badge.dto.response.BadgesResponse;
 import me.bombom.api.v1.reading.dto.MonthlyReadingRankFlat;
 
@@ -26,5 +27,11 @@ public record MonthlyReadingRankResponse(
                 flat.monthlyReadCount(),
                 BadgesResponse.from(flat)
         );
+    }
+
+    public static List<MonthlyReadingRankResponse> from(List<MonthlyReadingRankFlat> flats) {
+        return flats.stream()
+                .map(MonthlyReadingRankResponse::from)
+                .toList();
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingSnapshotRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingSnapshotRepository.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import me.bombom.api.v1.reading.domain.MonthlyReadingSnapshot;
 import me.bombom.api.v1.reading.dto.MonthlyReadingRankFlat;
 import me.bombom.api.v1.reading.dto.RankerInfo;
-import me.bombom.api.v1.reading.dto.response.MemberMonthlyReadingRankResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -20,6 +19,7 @@ public interface MonthlyReadingSnapshotRepository extends JpaRepository<MonthlyR
 			m.nickname AS nickname,
 			mr.rank_order AS `rank`,
 			mr.current_count AS monthlyReadCount,
+			mr.next_rank_difference AS nextRankDifference,
 			rb.badge_grade AS rankingBadgeGrade,
 			rb.period_year AS rankingBadgeYear,
 			rb.period_month AS rankingBadgeMonth,
@@ -59,46 +59,70 @@ public interface MonthlyReadingSnapshotRepository extends JpaRepository<MonthlyR
 	""", nativeQuery = true)
 	List<RankerInfo> findTopRankers(@Param("maxRank") long maxRank);
 
-  @Modifying(clearAutomatically = true, flushAutomatically = true)
-  @Query(value = """
-    UPDATE monthly_reading_snapshot mrs
-    JOIN (
-        SELECT
-          r.member_id,
-          RANK() OVER (ORDER BY r.current_count DESC) AS calculated_rank,
-          COALESCE(ds.prev_distinct - r.current_count, 0) AS next_diff,
-          r.current_count AS current_count
-        FROM monthly_reading_realtime r
-        JOIN (
-          SELECT
-            t.current_count AS cnt,
-            LAG(t.current_count) OVER (ORDER BY t.current_count DESC) AS prev_distinct
-          FROM (SELECT DISTINCT current_count FROM monthly_reading_realtime) t
-        ) ds ON ds.cnt = r.current_count
-    ) ranks ON mrs.member_id = ranks.member_id
-    SET
-        mrs.current_count = ranks.current_count,
-        mrs.rank_order = ranks.calculated_rank,
-        mrs.next_rank_difference = ranks.next_diff
-  """, nativeQuery = true)
-  void updateMonthlyRanking();
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query(value = """
+		UPDATE monthly_reading_snapshot mrs
+		JOIN (
+			SELECT
+				r.member_id,
+				RANK() OVER (ORDER BY r.current_count DESC) AS calculated_rank,
+				COALESCE(ds.prev_distinct - r.current_count, 0) AS next_diff,
+				r.current_count AS current_count
+			FROM monthly_reading_realtime r
+			JOIN (
+				SELECT
+					t.current_count AS cnt,
+					LAG(t.current_count) OVER (ORDER BY t.current_count DESC) AS prev_distinct
+				FROM (SELECT DISTINCT current_count FROM monthly_reading_realtime) t
+			) ds ON ds.cnt = r.current_count
+		) ranks ON mrs.member_id = ranks.member_id
+		SET
+			mrs.current_count = ranks.current_count,
+			mrs.rank_order = ranks.calculated_rank,
+			mrs.next_rank_difference = ranks.next_diff
+	""", nativeQuery = true)
+	void updateMonthlyRanking();
 
-	@Query("""
-		SELECT new me.bombom.api.v1.reading.dto.response.MemberMonthlyReadingRankResponse(
-		  mr.rankOrder AS rank,
-		  mr.currentCount AS readCount,
-		  mr.nextRankDifference AS nextRankDifference
-		)
-		FROM MonthlyReadingSnapshot mr
-		WHERE mr.memberId = :memberId
-	""")
-	MemberMonthlyReadingRankResponse findMemberRankAndGap(@Param("memberId") Long memberId);
+	@Query(value = """
+		SELECT
+			m.nickname AS nickname,
+			mr.rank_order AS `rank`,
+			mr.current_count AS monthlyReadCount,
+			mr.next_rank_difference AS nextRankDifference,
+			rb.badge_grade AS rankingBadgeGrade,
+			rb.period_year AS rankingBadgeYear,
+			rb.period_month AS rankingBadgeMonth,
+			cb_latest.badge_grade AS challengeBadgeGrade,
+			cb_latest.challenge_name AS challengeBadgeName,
+			cb_latest.challenge_generation AS challengeBadgeGeneration
+		FROM monthly_reading_snapshot mr
+		JOIN member m ON mr.member_id = m.id
+		LEFT JOIN badge rb ON rb.member_id = mr.member_id
+			AND rb.badge_category = 'RANKING'
+			AND rb.period_year = :lastMonthYear
+			AND rb.period_month = :lastMonthValue
+		LEFT JOIN LATERAL (
+			SELECT cb.*
+			FROM badge cb
+			WHERE cb.member_id = mr.member_id
+				AND cb.badge_category = 'CHALLENGE'
+			ORDER BY cb.created_at DESC
+			LIMIT 1
+		) cb_latest ON true
+		WHERE mr.member_id = :memberId
+			AND mr.rank_order IS NOT NULL
+	""", nativeQuery = true)
+	MonthlyReadingRankFlat findMemberRanking(
+			@Param("memberId") Long memberId,
+			@Param("lastMonthYear") Integer lastMonthYear,
+			@Param("lastMonthValue") Integer lastMonthValue
+	);
 
 	MonthlyReadingSnapshot findTopByOrderByRankOrderDesc();
 
-  @Modifying(clearAutomatically = true, flushAutomatically = true)
-  @Query("UPDATE MonthlyReadingSnapshot mrs SET mrs.currentCount = 0")
-  void resetAllCurrentCount();
-         
+	@Modifying(clearAutomatically = true, flushAutomatically = true)
+	@Query("UPDATE MonthlyReadingSnapshot mrs SET mrs.currentCount = 0")
+	void resetAllCurrentCount();
+
 	void deleteByMemberId(Long memberId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -222,9 +222,7 @@ public class ReadingService {
 
         List<MonthlyReadingRankFlat> flatResults = monthlyReadingSnapshotRepository.findMonthlyRanking(limit, lastMonthYear, lastMonthValue);
 
-        List<MonthlyReadingRankResponse> monthlyRanking = flatResults.stream()
-                .map(MonthlyReadingRankResponse::from)
-                .toList();
+        List<MonthlyReadingRankResponse> monthlyRanking = MonthlyReadingRankResponse.from(flatResults);
 
         LocalDateTime rankingUpdatedAt = monthlyReadingSnapshotMetaService.getSnapshotAt();
         ZonedDateTime serverNow = ZonedDateTime.now(scheduleProps.zoneId());

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -1,6 +1,7 @@
 
 package me.bombom.api.v1.reading.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
@@ -61,6 +62,7 @@ public class ReadingService {
 
     private final MonthlyRankingScheduleProperties scheduleProps;
     private final BadgeService badgeService;
+    private final Clock clock;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void initializeReadingInformation(Long memberId) {
@@ -245,7 +247,7 @@ public class ReadingService {
     }
 
     public MemberMonthlyReadingRankResponse getMemberMonthlyReadingRank(Member member) {
-        LocalDate lastMonth = LocalDate.now().minusMonths(LAST_MONTH_OFFSET);
+        LocalDate lastMonth = LocalDate.now(clock).minusMonths(LAST_MONTH_OFFSET);
         int lastMonthYear = lastMonth.getYear();
         int lastMonthValue = lastMonth.getMonthValue();
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -84,7 +84,6 @@ public class ReadingService {
         MonthlyReadingRealtime monthlyReadingRealtime = MonthlyReadingRealtime.create(memberId);
         monthlyReadingRealtimeRepository.save(monthlyReadingRealtime);
 
-
         YearlyReading newYearlyReading = YearlyReading.create(memberId, LocalDate.now().getYear());
         yearlyReadingRepository.save(newYearlyReading);
     }
@@ -248,7 +247,19 @@ public class ReadingService {
     }
 
     public MemberMonthlyReadingRankResponse getMemberMonthlyReadingRank(Member member) {
-        return monthlyReadingSnapshotRepository.findMemberRankAndGap(member.getId());
+        LocalDate lastMonth = LocalDate.now().minusMonths(LAST_MONTH_OFFSET);
+        int lastMonthYear = lastMonth.getYear();
+        int lastMonthValue = lastMonth.getMonthValue();
+
+        MonthlyReadingRankFlat flat = monthlyReadingSnapshotRepository.findMemberRanking(member.getId(), lastMonthYear, lastMonthValue);
+
+        if (flat == null) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "MonthlyReadingSnapshot");
+        }
+
+        return MemberMonthlyReadingRankResponse.from(flat);
     }
 
     @Transactional
@@ -284,7 +295,7 @@ public class ReadingService {
             monthlyReadingSnapshotRepository.deleteByMemberId(memberId);
             monthlyReadingRealtimeRepository.deleteByMemberId(memberId);
             yearlyReadingRepository.deleteByMemberId(memberId);
-        } catch (Exception e){
+        } catch (Exception e) {
             log.error("회원 읽기 정보 삭제 실패. memberId = {}", memberId, e.getStackTrace());
         }
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -312,7 +312,7 @@ class ChallengeServiceTest {
             softly.assertThat(detail.isJoined()).isTrue();
             softly.assertThat(detail.progress()).isGreaterThan(0);
             softly.assertThat(detail.grade()).isNotNull();
-            softly.assertThat(detail.isSuccess()).isNotNull();
+            softly.assertThat(detail.isSurvived()).isNotNull();
         });
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -17,7 +17,6 @@ import me.bombom.api.v1.badge.repository.BadgeRepository;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.reading.domain.ContinueReading;
-import me.bombom.api.v1.reading.domain.MonthlyReadingRealtime;
 import me.bombom.api.v1.reading.domain.MonthlyReadingSnapshot;
 import me.bombom.api.v1.reading.domain.MonthlyReadingSnapshotMeta;
 import me.bombom.api.v1.reading.domain.TodayReading;
@@ -223,7 +222,7 @@ class ReadingServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(memberRank.rank()).isGreaterThan(0L);
-            softly.assertThat(memberRank.readCount()).isEqualTo(monthlyReadingSnapshot.getCurrentCount());
+            softly.assertThat(memberRank.monthlyReadCount()).isEqualTo(monthlyReadingSnapshot.getCurrentCount());
             softly.assertThat(memberRank.nextRankDifference())
                     .isEqualTo(member3Reading.getCurrentCount() - monthlyReadingSnapshot.getCurrentCount());
         });
@@ -468,6 +467,142 @@ class ReadingServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(result.data()).hasSize(1);
             softly.assertThat(result.data().get(0).badges()).isNull();
+        });
+    }
+
+    @Test
+    void 내_랭킹_조회_시_이전달_랭킹_뱃지가_표시된다() {
+        // given
+        monthlyReadingSnapshotRepository.deleteAllInBatch();
+
+        Member member1 = memberRepository.save(TestFixture.createUniqueMember("member1", "provider1"));
+
+        monthlyReadingSnapshotRepository.save(TestFixture.monthlyReadingSnapshotWithRank(member1, 30, 1, 0));
+
+        LocalDate lastMonth = LocalDate.now().minusMonths(1);
+        RankingBadge rankingBadge = RankingBadge.builder()
+                .memberId(member1.getId())
+                .grade(BadgeGrade.GOLD)
+                .periodYear(lastMonth.getYear())
+                .periodMonth(lastMonth.getMonthValue())
+                .build();
+        badgeRepository.save(rankingBadge);
+
+        // when
+        readingService.updateMonthlyRanking();
+        MemberMonthlyReadingRankResponse result = readingService.getMemberMonthlyReadingRank(member1);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.badges()).isNotNull();
+            softly.assertThat(result.badges().ranking()).isNotNull();
+            softly.assertThat(result.badges().ranking().grade()).isEqualTo(BadgeGrade.GOLD);
+            softly.assertThat(result.badges().ranking().year()).isEqualTo(lastMonth.getYear());
+            softly.assertThat(result.badges().ranking().month()).isEqualTo(lastMonth.getMonthValue());
+        });
+    }
+
+    @Test
+    void 내_랭킹_조회_시_가장_최근_챌린지_뱃지가_표시된다() {
+        // given
+        monthlyReadingSnapshotRepository.deleteAllInBatch();
+
+        Member member1 = memberRepository.save(TestFixture.createUniqueMember("member1", "provider1"));
+
+        monthlyReadingSnapshotRepository.save(TestFixture.monthlyReadingSnapshotWithRank(member1, 30, 1, 0));
+
+        // 오래된 챌린지 뱃지
+        ChallengeBadge oldBadge = ChallengeBadge.builder()
+                .memberId(member1.getId())
+                .grade(BadgeGrade.BRONZE)
+                .challengeId(1L)
+                .challengeName("오래된 챌린지")
+                .challengeGeneration(1)
+                .build();
+        badgeRepository.save(oldBadge);
+        badgeRepository.flush();
+
+        // 최근 챌린지 뱃지
+        ChallengeBadge recentBadge = ChallengeBadge.builder()
+                .memberId(member1.getId())
+                .grade(BadgeGrade.GOLD)
+                .challengeId(2L)
+                .challengeName("최근 챌린지")
+                .challengeGeneration(2)
+                .build();
+        badgeRepository.save(recentBadge);
+
+        // when
+        readingService.updateMonthlyRanking();
+        MemberMonthlyReadingRankResponse result = readingService.getMemberMonthlyReadingRank(member1);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.badges()).isNotNull();
+            softly.assertThat(result.badges().challenge()).isNotNull();
+            softly.assertThat(result.badges().challenge().grade()).isEqualTo(BadgeGrade.GOLD);
+            softly.assertThat(result.badges().challenge().name()).isEqualTo("최근 챌린지");
+            softly.assertThat(result.badges().challenge().generation()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void 내_랭킹_조회_시_랭킹_뱃지와_챌린지_뱃지가_모두_표시된다() {
+        // given
+        monthlyReadingSnapshotRepository.deleteAllInBatch();
+
+        Member member1 = memberRepository.save(TestFixture.createUniqueMember("member1", "provider1"));
+
+        monthlyReadingSnapshotRepository.save(TestFixture.monthlyReadingSnapshotWithRank(member1, 30, 1, 0));
+
+        LocalDate lastMonth = LocalDate.now().minusMonths(1);
+        RankingBadge rankingBadge = RankingBadge.builder()
+                .memberId(member1.getId())
+                .grade(BadgeGrade.GOLD)
+                .periodYear(lastMonth.getYear())
+                .periodMonth(lastMonth.getMonthValue())
+                .build();
+        badgeRepository.save(rankingBadge);
+
+        ChallengeBadge challengeBadge = ChallengeBadge.builder()
+                .memberId(member1.getId())
+                .grade(BadgeGrade.SILVER)
+                .challengeId(1L)
+                .challengeName("테스트 챌린지")
+                .challengeGeneration(1)
+                .build();
+        badgeRepository.save(challengeBadge);
+
+        // when
+        readingService.updateMonthlyRanking();
+        MemberMonthlyReadingRankResponse result = readingService.getMemberMonthlyReadingRank(member1);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.badges()).isNotNull();
+            softly.assertThat(result.badges().ranking()).isNotNull();
+            softly.assertThat(result.badges().challenge()).isNotNull();
+            softly.assertThat(result.badges().ranking().grade()).isEqualTo(BadgeGrade.GOLD);
+            softly.assertThat(result.badges().challenge().grade()).isEqualTo(BadgeGrade.SILVER);
+        });
+    }
+
+    @Test
+    void 내_랭킹_조회_시_뱃지가_없으면_null로_표시된다() {
+        // given
+        monthlyReadingSnapshotRepository.deleteAllInBatch();
+
+        Member member1 = memberRepository.save(TestFixture.createUniqueMember("member1", "provider1"));
+
+        monthlyReadingSnapshotRepository.save(TestFixture.monthlyReadingSnapshotWithRank(member1, 30, 1, 0));
+
+        // when
+        readingService.updateMonthlyRanking();
+        MemberMonthlyReadingRankResponse result = readingService.getMemberMonthlyReadingRank(member1);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.badges()).isNull();
         });
     }
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
내 랭킹 조회 시에도 뱃지 및 닉네임을 조회 할 수 있게 추가
### 변경 전 UI
<img width="505" height="198" alt="image" src="https://github.com/user-attachments/assets/e5c6dee1-6bfa-4a94-b0e0-568b21331a83" />

### 변경 후 UI
<img width="482" height="189" alt="image" src="https://github.com/user-attachments/assets/d1250ac0-6004-4e34-a76e-3cbf434a6217" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
전체 랭킹과의 일관성 및 나의 뱃지도 간편히 확인하기 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
전체 랭킹 조회 시의 쿼리와 동일한 방식으로 내 랭킹 조회하도록 하였습니다.
[전체 조회 방식 PR](https://github.com/woowacourse-teams/2025-bom-bom/pull/636)

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 전체 랭킹과 내 랭킹 조회 로직이 비슷하여 QueryDSL을 고려하였으나 Native Query 사용이 불가능 하여 쿼리를 별도로 분리하는 식으로 구현했는데, 더 좋은 방법 있으면 추천 바랍니다.
- 코드 들여쓰기가 잘못되었던 부분이 있어서 변경 범위가 좀 더 나오는데 `MonthlyReadingSnapshotRepository`에서는 `findMemberRanking` 쿼리만 추가되었습니다.
