### PR TITLE
[BOM-916] feat: 챌린지 수료 시, 챌린지 기간이 짧으면 뱃지 주지 않도록 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeRepository.java
@@ -21,6 +21,10 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
         FROM Challenge c
         WHERE c.endDate < :date
           AND c.isBadgeIssued = false
+          AND c.totalDays >= :minTotalDays
     """)
-    List<Challenge> findEndedChallengesPendingBadge(@Param("date") LocalDate date);
+    List<Challenge> findEndedChallengesPendingBadge(
+            @Param("date") LocalDate date,
+            @Param("minTotalDays") int minTotalDays
+    );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.badge.service.BadgeService;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeGrade;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
@@ -37,7 +38,6 @@ import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.badge.service.BadgeService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -49,6 +49,7 @@ public class ChallengeService {
 
     // TODO: 이후에 수료 처리 등 구현 시 관리 방법 고려
     private static final double SUCCESS_REQUIRED_RATIO = 0.8;
+    private static final int MIN_CHALLENGE_TOTAL_DAYS_FOR_BADGE = 15;
 
     private final ChallengeRepository challengeRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
@@ -163,7 +164,7 @@ public class ChallengeService {
     }
 
     public List<Challenge> getEndedChallengesPendingBadge(LocalDate date) {
-        return challengeRepository.findEndedChallengesPendingBadge(date);
+        return challengeRepository.findEndedChallengesPendingBadge(date, MIN_CHALLENGE_TOTAL_DAYS_FOR_BADGE);
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 수료 시, 챌린지 기간이 짧으면 뱃지 주지 않도록 구현했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지와 챌린지 사이 기간 동안 유저 동기 부여를 위한 미니 챌린지를 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
간단하게 챌린지 totalDays(주말 제외 챌린지 일 수)가 15일 아래면 뱃지 부여 스케줄러에 들어가지 않도록 했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
