### PR TITLE
[BOM-918] fix: 회원 정합성 문제 해결

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/WebConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/WebConfig.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.common.config;
 
 import jakarta.servlet.DispatcherType;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import me.bombom.api.log.MDCLoggingFilter;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -12,7 +13,10 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
     @Bean
     public FilterRegistrationBean<MDCLoggingFilter> mdcLoggingFilterRegistration() {
@@ -26,6 +30,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginMemberArgumentResolver());
+        resolvers.add(loginMemberArgumentResolver);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -1,21 +1,28 @@
 package me.bombom.api.v1.common.resolver;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -46,7 +53,9 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             if (member == null) {
                 throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
             }
-            return member;
+
+            return memberRepository.findById(member.getId())
+                    .orElseThrow(() -> new UnauthorizedException(ErrorDetail.UNAUTHORIZED));
         }
         throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN);
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -9,21 +9,23 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
-import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
-import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
-import java.time.LocalDate;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
 import me.bombom.api.v1.common.config.WebConfig;
+import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +40,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
-@Import(WebConfig.class)
+@Import({ WebConfig.class, LoginMemberArgumentResolver.class })
 @WebMvcTest(ChallengeProgressController.class)
 class ChallengeProgressControllerUnitTest {
 
@@ -50,6 +52,9 @@ class ChallengeProgressControllerUnitTest {
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
 
     private Authentication authentication;
 
@@ -65,17 +70,17 @@ class ChallengeProgressControllerUnitTest {
                 .roleId(1L)
                 .build();
 
+        given(memberRepository.findById(member.getId())).willReturn(java.util.Optional.of(member));
+
         Map<String, Object> attributes = Map.of(
                 "id", member.getId().toString(),
                 "email", member.getEmail(),
                 "name", member.getNickname());
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(attributes, member, null, null);
-
         authentication = new OAuth2AuthenticationToken(
                 customOAuth2User,
                 List.of(new SimpleGrantedAuthority("ROLE_USER")),
-                "google"
-        );
+                "google");
     }
 
     @Test
@@ -121,7 +126,7 @@ class ChallengeProgressControllerUnitTest {
         // given
         Long challengeId = 1L;
         Long teamId = 10L;
-        
+
         Challenge challenge = Challenge.builder()
                 .id(challengeId)
                 .name("Test Challenge")
@@ -130,10 +135,10 @@ class ChallengeProgressControllerUnitTest {
                 .endDate(LocalDate.now().plusDays(5))
                 .totalDays(10)
                 .build();
-        
+
         TeamChallengeProgressFlat progressFlat = new TeamChallengeProgressFlat(
                 1L, "tester", true, 5, 10, 77, LocalDate.now(), ChallengeDailyStatus.COMPLETE);
-        
+
         TeamChallengeProgressResponse response = TeamChallengeProgressResponse.of(
                 challenge,
                 List.of(progressFlat)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -2,6 +2,8 @@ package me.bombom.api.v1.common.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -10,8 +12,11 @@ import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -22,13 +27,21 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 
 class LoginMemberArgumentResolverTest {
 
-    private final LoginMemberArgumentResolver resolver = new LoginMemberArgumentResolver();
+    private MemberRepository memberRepository;
+    private LoginMemberArgumentResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = Mockito.mock(MemberRepository.class);
+        resolver = new LoginMemberArgumentResolver(memberRepository);
+    }
 
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
     }
 
+    //테스트를 위한 가짜 컨트롤러
     static class StubController {
         public void endpointNullableTrue(@LoginMember(anonymous = true) Member member) {}
         public void endpointNullableFalse(@LoginMember(anonymous = false) Member member) {}
@@ -92,9 +105,10 @@ class LoginMemberArgumentResolverTest {
     }
 
     @Test
-    void 정상_로그인_이면_Member_반환() throws Exception {
-        // Member는 복잡한 엔티티일 수 있으므로 목 객체로 대체
+    void 정상_로그인_이고_DB에_회원이_존재하면_Member_반환() throws Exception {
+        // given
         Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(1L);
 
         CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
         OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
@@ -104,8 +118,38 @@ class LoginMemberArgumentResolverTest {
         );
         SecurityContextHolder.getContext().setAuthentication(auth);
 
+        given(memberRepository.findById(1L)).willReturn(java.util.Optional.of(member));
+
+        // when
         Object result = resolver.resolveArgument(paramNullableTrue(), null, null, null);
-        assertThat(result).isInstanceOf(Member.class);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result).isInstanceOf(Member.class);
+            softly.assertThat(result).isEqualTo(member);
+        });
+    }
+
+    @Test
+    void 정상_로그인이지만_DB에_회원이_없으면_UNAUTHORIZED() throws Exception {
+        // given
+        Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(0L);
+
+        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
+                user,
+                user.getAuthorities(),
+                "registrationId"
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        given(memberRepository.findById(0L)).willReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> resolver.resolveArgument(paramNullableTrue(), null, null, null))
+                .isInstanceOfSatisfying(UnauthorizedException.class,
+                        e -> assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED));
     }
 
     //ArgumentResolver에게 파라미터 넘기기
@@ -119,5 +163,3 @@ class LoginMemberArgumentResolverTest {
         return new MethodParameter(m, 0);
     }
 }
-
-

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
@@ -1,8 +1,8 @@
 package me.bombom.api.v1.subscribe.controller;
 
-import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,10 +11,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.enums.Gender;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.subscribe.dto.UnsubscribeResponse;
 import me.bombom.api.v1.subscribe.service.SubscribeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,12 +39,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @AutoConfigureMockMvc
 @WebMvcTest(controllers = SubscribeController.class)
-@Import({SubscribeController.class, SubscribeControllerTest.TestConfig.class})
+@Import({ SubscribeController.class, SubscribeControllerTest.TestConfig.class })
 class SubscribeControllerTest {
 
     @Configuration
     @EnableWebSecurity
     static class TestConfig implements WebMvcConfigurer {
+
+        @Autowired
+        private MemberRepository memberRepository;
 
         @Bean
         public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -50,16 +55,15 @@ class SubscribeControllerTest {
                     .csrf(AbstractHttpConfigurer::disable)
                     .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
                     .exceptionHandling(ex -> ex
-                            .authenticationEntryPoint((request, response, authException) ->
-                                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
-                            )
-                    )
+                            .authenticationEntryPoint((request, response,
+                                                       authException) -> response.sendError(
+                                    HttpServletResponse.SC_UNAUTHORIZED)))
                     .build();
         }
 
         @Override
         public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-            resolvers.add(new LoginMemberArgumentResolver());
+            resolvers.add(new LoginMemberArgumentResolver(memberRepository));
         }
     }
 
@@ -68,6 +72,9 @@ class SubscribeControllerTest {
 
     @MockitoBean
     SubscribeService subscribeService;
+
+    @MockitoBean
+    MemberRepository memberRepository;
 
     private OAuth2AuthenticationToken authToken;
 
@@ -82,6 +89,8 @@ class SubscribeControllerTest {
                 .gender(Gender.FEMALE)
                 .roleId(1L)
                 .build();
+
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
 
         Map<String, Object> attrs = Map.of(
                 "id", "1",


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
`@LoginMember` 애노테이션을 사용하는 API에서 발생하는 회원 정합성 문제를 해결했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

<img width="2870" height="1576" alt="image" src="https://github.com/user-attachments/assets/e559f8c8-4ce5-450f-aa34-a5bba4604e90" />

위 이미지를 참고하시면, 닉네임은 변경했는데 수료증에서는 이전의 닉네임이 조회되는 문제가 있었습니다.

### 문제된 기존 동작 방식
1. 사용자가 로그인하면 회원 정보를 담은 Authentication 객체가 생성되고, 이 객체는 직렬화되어 DB의 SPRING_SESSION_ATTRIBUTES 테이블에 저장됩니다. (세션 저장)
2. 이후 @LoginMember를 사용하여 회원 정보를 요청하면, **DB에서 최신 정보를 조회하는 것이 아니라 세션에 저장해둔(로그인 시점의) 오래된 객체를 역직렬화하여 그대로 반환**하고 있었습니다.

**=> 즉, 로그인 이후에 발생한 닉네임 변경 등이 세션에 반영되지 않아, @LoginMember를 사용하는 모든 API에서 과거 정보를 참조하는 정합성 문제가 발생했습니다.**

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

`LoginMemberArgumentResolver`에서 Member를 넘길 때, `memberRepository.findById(id)`로 한번 조회 후 넘기도록 했습니다.
`@LoginMember`를 사용하는 API를 사용할 때마다 DB 조회가 한번 늘어나지만, id를 통한 조회라서 큰 부담이 없을거라 생각됩니다. 
또한, 이렇게 하지 않으면, 유저 정보를 사용하는 기능을 개발할 때마다 정합성을 맞추기 위해 신경 써야하는데 그것은 실수할 여지가 굉장히 크다고 생각되어 이런 방식으로 구현하였습니다.


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
