### PR TITLE
[BOM - 923] feat: 아웃박스 패턴 개선

### DIFF
--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotification.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotification.java
@@ -21,6 +21,7 @@ import news.bombom.notification.common.BaseEntity;
 public class ArticleArrivalNotification extends BaseEntity {
 
     private static final int MAX_RETRY_ATTEMPTS = 6;
+    private static final int SHORT_RETRY_ATTEMPTS = 3;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -98,7 +99,7 @@ public class ArticleArrivalNotification extends BaseEntity {
     private LocalDateTime calculateNextRetryTime(int attempts) {
         long delaySeconds;
 
-        if (attempts <= 3) {
+        if (attempts <= SHORT_RETRY_ATTEMPTS) {
             delaySeconds = 30L * (long) Math.pow(2, attempts - 1);
         } else {
             switch (attempts) {
@@ -108,7 +109,7 @@ public class ArticleArrivalNotification extends BaseEntity {
                 case 5:
                     delaySeconds = 3600L;
                     break;
-                case 6:
+                case MAX_RETRY_ATTEMPTS:
                     delaySeconds = 10800L;
                     break;
                 default:

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotification.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotification.java
@@ -20,7 +20,7 @@ import news.bombom.notification.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArticleArrivalNotification extends BaseEntity {
 
-    private static final int MAX_RETRY_ATTEMPTS = 3;
+    private static final int MAX_RETRY_ATTEMPTS = 6;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -91,25 +91,31 @@ public class ArticleArrivalNotification extends BaseEntity {
         this.nextRetryAt = calculateNextRetryTime(this.attempts);
     }
 
-    public void resetForRetry() {
-        this.status = NotificationStatus.PENDING;
-        this.nextRetryAt = null;
-        this.lastError = null;
-    }
-
-    public void markAsRead() {
-        this.isRead = true;
-    }
-
     public boolean shouldRetry() {
         return this.attempts < MAX_RETRY_ATTEMPTS;
     }
 
     private LocalDateTime calculateNextRetryTime(int attempts) {
-        long delaySeconds = 30L * (long) Math.pow(2, attempts - 1); // 30s, 60s, 120s...
-        if (delaySeconds > 1800) { // Max 30 minutes
-            delaySeconds = 1800;
+        long delaySeconds;
+
+        if (attempts <= 3) {
+            delaySeconds = 30L * (long) Math.pow(2, attempts - 1);
+        } else {
+            switch (attempts) {
+                case 4:
+                    delaySeconds = 1800L;
+                    break;
+                case 5:
+                    delaySeconds = 3600L;
+                    break;
+                case 6:
+                    delaySeconds = 10800L;
+                    break;
+                default:
+                    delaySeconds = 10800L;
+            }
         }
+
         return LocalDateTime.now().plusSeconds(delaySeconds);
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotification.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotification.java
@@ -93,7 +93,7 @@ public class ArticleArrivalNotification extends BaseEntity {
     }
 
     public boolean shouldRetry() {
-        return this.attempts < MAX_RETRY_ATTEMPTS;
+        return this.attempts <= MAX_RETRY_ATTEMPTS;
     }
 
     private LocalDateTime calculateNextRetryTime(int attempts) {

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotificationFailed.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotificationFailed.java
@@ -10,17 +10,20 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombom.notification.common.BaseEntity;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class ArticleArrivalNotificationFailed {
+public class ArticleArrivalNotificationFailed extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long originalNotificationId; // 추적용
+    @Column(nullable = false)
+    private Long originalNotificationId;
 
     @Column(nullable = false)
     private Long memberId;
@@ -42,9 +45,15 @@ public class ArticleArrivalNotificationFailed {
     private LocalDateTime failedAt;
 
     @Builder
-    public ArticleArrivalNotificationFailed(Long originalNotificationId, Long memberId, Long articleId,
-                                            String newsletterName, String articleTitle, int finalAttempts,
-                                            String lastError) {
+    public ArticleArrivalNotificationFailed(
+            @NonNull Long originalNotificationId,
+            @NonNull Long memberId,
+            @NonNull Long articleId,
+            @NonNull String newsletterName,
+            @NonNull String articleTitle,
+            int finalAttempts,
+            String lastError
+    ) {
         this.originalNotificationId = originalNotificationId;
         this.memberId = memberId;
         this.articleId = articleId;

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotificationFailed.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/ArticleArrivalNotificationFailed.java
@@ -1,0 +1,69 @@
+package news.bombom.notification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArticleArrivalNotificationFailed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long originalNotificationId; // 추적용
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Long articleId;
+
+    @Column(nullable = false)
+    private String newsletterName;
+
+    @Column(nullable = false)
+    private String articleTitle;
+
+    private int finalAttempts;
+
+    @Column(length = 1024)
+    private String lastError;
+
+    private LocalDateTime failedAt;
+
+    @Builder
+    public ArticleArrivalNotificationFailed(Long originalNotificationId, Long memberId, Long articleId,
+                                            String newsletterName, String articleTitle, int finalAttempts,
+                                            String lastError) {
+        this.originalNotificationId = originalNotificationId;
+        this.memberId = memberId;
+        this.articleId = articleId;
+        this.newsletterName = newsletterName;
+        this.articleTitle = articleTitle;
+        this.finalAttempts = finalAttempts;
+        this.lastError = lastError;
+        this.failedAt = LocalDateTime.now();
+    }
+
+    public static ArticleArrivalNotificationFailed from(ArticleArrivalNotification notification) {
+        return ArticleArrivalNotificationFailed.builder()
+                .originalNotificationId(notification.getId())
+                .memberId(notification.getMemberId())
+                .articleId(notification.getArticleId())
+                .newsletterName(notification.getNewsletterName())
+                .articleTitle(notification.getArticleTitle())
+                .finalAttempts(notification.getAttempts())
+                .lastError(notification.getLastError())
+                .build();
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/repository/ArticleArrivalNotificationFailedRepository.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/repository/ArticleArrivalNotificationFailedRepository.java
@@ -1,0 +1,7 @@
+package news.bombom.notification.repository;
+
+import news.bombom.notification.domain.ArticleArrivalNotificationFailed;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleArrivalNotificationFailedRepository extends JpaRepository<ArticleArrivalNotificationFailed, Long> {
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/scheduler/NotificationScheduler.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/scheduler/NotificationScheduler.java
@@ -8,6 +8,7 @@ import news.bombom.notification.domain.ArticleArrivalNotification;
 import news.bombom.notification.domain.NotificationStatus;
 import news.bombom.notification.repository.ArticleArrivalNotificationRepository;
 import news.bombom.notification.service.NotificationProcessingService;
+import news.bombom.notification.service.NotificationStatusService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,7 @@ public class NotificationScheduler {
 
     private final ArticleArrivalNotificationRepository notificationRepository;
     private final NotificationProcessingService notificationProcessingService;
+    private final NotificationStatusService notificationStatusService;
 
     @Scheduled(fixedDelay = 30000)
     public void processPendingNotifications() {
@@ -34,6 +36,7 @@ public class NotificationScheduler {
                 if (!notification.shouldRetry()) {
                     log.warn("최대 재시도 횟수 초과: notificationId={}, attempts={}",
                             notification.getId(), notification.getAttempts());
+                    notificationStatusService.moveToFailedTableIfExceeded(notification);
                     continue;
                 }
 

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationStatusService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationStatusService.java
@@ -20,7 +20,6 @@ public class NotificationStatusService {
     public void updateStatus(ArticleArrivalNotification notification, NotificationResultResponse result) {
         if (result.successCount() > 0) {
             notification.markSent();
-            notificationRepository.save(notification);
             log.info("알림 발송 완료: notificationId={}, 성공={}, 실패={}, 스킵={}",
                     notification.getId(), result.successCount(), result.failCount(), result.skippedCount());
             return;
@@ -28,14 +27,12 @@ public class NotificationStatusService {
         if (result.skippedCount() == result.totalDevices()) {
             // 모든 기기가 알림 설정이 꺼져있으면 SENT로 처리 (정상적인 상황)
             notification.markSent();
-            notificationRepository.save(notification);
             log.info("모든 기기에서 알림 설정이 꺼져있음: notificationId={}, 스킵={}",
                     notification.getId(), result.skippedCount());
             return;
         }
         // 모든 기기에서 실패하면 FAILED로 처리
         notification.markFailed(result.errorMessages());
-        notificationRepository.save(notification);
         log.error("모든 기기에서 알림 발송 실패: notificationId={}", notification.getId());
     }
 

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationStatusService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationStatusService.java
@@ -38,9 +38,7 @@ public class NotificationStatusService {
         notification.markFailed(result.errorMessages());
         log.error("모든 기기에서 알림 발송 실패: notificationId={}", notification.getId());
 
-        if (!notification.shouldRetry()) {
-            moveToFailedTable(notification);
-        }
+        moveToFailedTableIfExceeded(notification);
     }
 
     @Transactional
@@ -48,10 +46,7 @@ public class NotificationStatusService {
         log.warn("FCM 토큰이 없습니다: memberId={}", notification.getMemberId());
         notification.markFailed(reason);
         notificationRepository.save(notification);
-        
-        if (!notification.shouldRetry()) {
-            moveToFailedTable(notification);
-        }
+        moveToFailedTableIfExceeded(notification);
     }
 
     @Transactional

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationStatusService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationStatusService.java
@@ -3,7 +3,9 @@ package news.bombom.notification.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombom.notification.domain.ArticleArrivalNotification;
+import news.bombom.notification.domain.ArticleArrivalNotificationFailed;
 import news.bombom.notification.dto.response.NotificationResultResponse;
+import news.bombom.notification.repository.ArticleArrivalNotificationFailedRepository;
 import news.bombom.notification.repository.ArticleArrivalNotificationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationStatusService {
 
     private final ArticleArrivalNotificationRepository notificationRepository;
+    private final ArticleArrivalNotificationFailedRepository articleArrivalNotificationFailedRepository;
 
     @Transactional
     public void updateStatus(ArticleArrivalNotification notification, NotificationResultResponse result) {
@@ -34,6 +37,10 @@ public class NotificationStatusService {
         // 모든 기기에서 실패하면 FAILED로 처리
         notification.markFailed(result.errorMessages());
         log.error("모든 기기에서 알림 발송 실패: notificationId={}", notification.getId());
+
+        if (!notification.shouldRetry()) {
+            moveToFailedTable(notification);
+        }
     }
 
     @Transactional
@@ -41,5 +48,23 @@ public class NotificationStatusService {
         log.warn("FCM 토큰이 없습니다: memberId={}", notification.getMemberId());
         notification.markFailed(reason);
         notificationRepository.save(notification);
+        
+        if (!notification.shouldRetry()) {
+            moveToFailedTable(notification);
+        }
+    }
+
+    @Transactional
+    public void moveToFailedTableIfExceeded(ArticleArrivalNotification notification) {
+        if (!notification.shouldRetry()) {
+            moveToFailedTable(notification);
+        }
+    }
+
+    private void moveToFailedTable(ArticleArrivalNotification notification) {
+        ArticleArrivalNotificationFailed failed = ArticleArrivalNotificationFailed.from(notification);
+        articleArrivalNotificationFailedRepository.save(failed);
+        notificationRepository.delete(notification);
+        log.warn("최대 재시도 횟수 초과로 인한 데이터 격리: notificationId={}", notification.getId());
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 알림 재시도 로직 개선: 3회 → 6회, 2단계 지수 백오프 적용
- 실패 알림 자동 격리: 최대 재시도 초과 시 Failed 테이블로 이동

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

### 문제점
1. 서버 장애 대응 부족
   - 기존 로직은 최대 3회 재시도 후 약 3.5분 만에 포기
   - 서버 일시 장애 시 복구 전에 알림이 실패 처리되어 사용자에게 전달되지 않음
   - 최대 재시도 간격이 2분으로 짧아 서버 복구 시간을 고려하지 못함

2. 실패 알림 관리 부재
   - 최대 재시도 횟수 초과 시 알림이 그대로 남아있어 데이터 정리 필요
   - 실패 원인 분석 및 모니터링이 어려움
   - 실패한 알림과 재시도 중인 알림이 구분되지 않음

3. 재시도 전략의 한계
   - 모든 재시도가 짧은 간격(최대 30분)으로만 수행
   - 서버 장애가 장시간 지속될 경우 대응 불가

### 해결 목표
- 서버 일시 장애 상황에서도 복구 후 알림이 정상 전달되도록 보장
- 실패한 알림을 체계적으로 관리하고 모니터링 가능하도록 개선
- 재시도 전략을 단계적으로 적용하여 리소스 효율성과 성공률 균형 유지

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
1. 2단계 지수 백오프 구현

**재시도 타임라인:**
- 1회 실패 → 30초 후 재시도
- 2회 실패 → 60초 후 재시도
- 3회 실패 → 120초(2분) 후 재시도
- 4회 실패 → 30분 후 재시도
- 5회 실패 → 1시간 후 재시도
- 6회 실패 → 3시간 후 재시도
- 7회 실패 → Failed 테이블로 이동

2. 실패 알림 자동 격리 로직
테이블 이동 로직이 적용된 위치
`NotificationStatusService.updateStatus()`: 알림 발송 실패 후 재시도 불가 시 이동
`NotificationStatusService.markAsFailed()`: FCM 토큰 없음으로 실패 시 재시도 불가 시 이동
`NotificationScheduler`: 스케줄러에서 재시도 불가 알림 발견 시 이동

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 로직상 놓친부분이 있는 리뷰해주시면 감사합니다.