### PR TITLE
[BOM-918] fix: 회원 정합성 문제 해결

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressController.java
@@ -44,9 +44,9 @@ public class ChallengeProgressController implements ChallengeProgressControllerA
     @Override
     @GetMapping("/{id}/certification")
     public CertificationInfoResponse getCertificationInfo(
-        @LoginMember Member member,
-        @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id
+            @LoginMember Long memberId,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id
     ) {
-        return challengeProgressService.getCertificationInfo(id, member);
+        return challengeProgressService.getCertificationInfo(id, memberId);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerApi.java
@@ -48,9 +48,9 @@ public interface ChallengeProgressControllerApi {
             @ApiResponse(responseCode = "200", description = "수료증 정보 조회 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청, 챌린지/참가자를 찾을 수 없음, 또는 진행 중인 챌린지, 탈락한 참가자", content = @Content),
             @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content)
-        })
+    })
     CertificationInfoResponse getCertificationInfo(
-            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(hidden = true) @LoginMember Long memberId,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id
     );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -25,6 +25,7 @@ import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +42,7 @@ public class ChallengeProgressService {
     private final ChallengeParticipantRepository challengeParticipantRepository;
     private final ChallengeDailyResultRepository challengeDailyResultRepository;
     private final ChallengeTeamRepository challengeTeamRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public void proceedDailySurvivalCheck(Challenge challenge, LocalDate yesterday) {
@@ -78,15 +80,21 @@ public class ChallengeProgressService {
         return TeamChallengeProgressResponse.of(challenge, progressList);
     }
 
-    public CertificationInfoResponse getCertificationInfo(Long challengeId, Member member) {
+    public CertificationInfoResponse getCertificationInfo(Long challengeId, Long memberId) {
         Challenge challenge = getChallenge(challengeId);
         validateChallengeEnded(challenge);
 
-        ChallengeParticipant challengeParticipant = getChallengeParticipant(challengeId, member);
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new UnauthorizedException(ErrorDetail.INVALID_TOKEN)
+                        .addContext(ErrorContextKeys.OPERATION, "getCertificationInfo")
+                        .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                        .addContext(ErrorContextKeys.DETAIL, "유효하지 않은 인증 정보입니다."));
+
+        ChallengeParticipant challengeParticipant = getChallengeParticipant(challengeId, memberId);
         if (!challengeParticipant.isSurvived()) {
             throw new CIllegalArgumentException(ErrorDetail.PRECONDITION_FAILED)
                     .addContext(ErrorContextKeys.OPERATION, "getCertificationInfo")
-                    .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                     .addContext(ErrorContextKeys.DETAIL, "탈락한 참가자는 수료증을 발급받을 수 없습니다.");
         }
 
@@ -123,9 +131,8 @@ public class ChallengeProgressService {
                         .addContext(ErrorContextKeys.OPERATION, "getChallenge"));
     }
 
-    private ChallengeParticipant getChallengeParticipant(Long challengeId, Member member) {
-        return challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId,
-                member.getId())
+    private ChallengeParticipant getChallengeParticipant(Long challengeId, Long memberId) {
+        return challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
                         .addContext(ErrorContextKeys.OPERATION, "getChallengeParticipant"));

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/WebConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/WebConfig.java
@@ -2,7 +2,6 @@ package me.bombom.api.v1.common.config;
 
 import jakarta.servlet.DispatcherType;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import me.bombom.api.log.MDCLoggingFilter;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -13,10 +12,7 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
-
-    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
     @Bean
     public FilterRegistrationBean<MDCLoggingFilter> mdcLoggingFilterRegistration() {
@@ -30,6 +26,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(loginMemberArgumentResolver);
+        resolvers.add(new LoginMemberArgumentResolver());
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/WebConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/WebConfig.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.common.config;
 
 import jakarta.servlet.DispatcherType;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import me.bombom.api.log.MDCLoggingFilter;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -12,7 +13,10 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
 
     @Bean
     public FilterRegistrationBean<MDCLoggingFilter> mdcLoggingFilterRegistration() {
@@ -26,6 +30,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginMemberArgumentResolver());
+        resolvers.add(loginMemberArgumentResolver);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -22,8 +22,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(LoginMember.class)
-                && (parameter.getParameterType().equals(Member.class)
-                || parameter.getParameterType().equals(Long.class));
+                && (parameter.getParameterType().equals(Member.class) || parameter.getParameterType().equals(Long.class));
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -20,7 +20,8 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(LoginMember.class)
-                && parameter.getParameterType().equals(Member.class);
+                && (parameter.getParameterType().equals(Member.class)
+                || parameter.getParameterType().equals(Long.class));
     }
 
     @Override
@@ -45,6 +46,9 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             Member member = ((CustomOAuth2User) principal).getMember();
             if (member == null) {
                 throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
+            }
+            if (parameter.getParameterType().equals(Long.class)) {
+                return member.getId();
             }
             return member;
         }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -1,21 +1,28 @@
 package me.bombom.api.v1.common.resolver;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberRepository memberRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -46,7 +53,9 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             if (member == null) {
                 throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
             }
-            return member;
+
+            return memberRepository.findById(member.getId())
+                    .orElseThrow(() -> new UnauthorizedException(ErrorDetail.UNAUTHORIZED));
         }
         throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN);
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -1,12 +1,10 @@
 package me.bombom.api.v1.common.resolver;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -19,10 +17,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private final MemberRepository memberRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -1,28 +1,21 @@
 package me.bombom.api.v1.common.resolver;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Slf4j
-@Component
-@RequiredArgsConstructor
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private final MemberRepository memberRepository;
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -53,9 +46,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             if (member == null) {
                 throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
             }
-
-            return memberRepository.findById(member.getId())
-                    .orElseThrow(() -> new UnauthorizedException(ErrorDetail.UNAUTHORIZED));
+            return member;
         }
         throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN);
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -9,21 +9,23 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
-import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
-import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
-import java.time.LocalDate;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
 import me.bombom.api.v1.common.config.WebConfig;
+import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -38,7 +40,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
-@Import(WebConfig.class)
+@Import({ WebConfig.class, LoginMemberArgumentResolver.class })
 @WebMvcTest(ChallengeProgressController.class)
 class ChallengeProgressControllerUnitTest {
 
@@ -50,6 +52,9 @@ class ChallengeProgressControllerUnitTest {
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
+
+    @MockitoBean
+    private MemberRepository memberRepository;
 
     private Authentication authentication;
 
@@ -65,17 +70,17 @@ class ChallengeProgressControllerUnitTest {
                 .roleId(1L)
                 .build();
 
+        given(memberRepository.findById(member.getId())).willReturn(java.util.Optional.of(member));
+
         Map<String, Object> attributes = Map.of(
                 "id", member.getId().toString(),
                 "email", member.getEmail(),
                 "name", member.getNickname());
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(attributes, member, null, null);
-
         authentication = new OAuth2AuthenticationToken(
                 customOAuth2User,
                 List.of(new SimpleGrantedAuthority("ROLE_USER")),
-                "google"
-        );
+                "google");
     }
 
     @Test
@@ -121,7 +126,7 @@ class ChallengeProgressControllerUnitTest {
         // given
         Long challengeId = 1L;
         Long teamId = 10L;
-        
+
         Challenge challenge = Challenge.builder()
                 .id(challengeId)
                 .name("Test Challenge")
@@ -130,10 +135,10 @@ class ChallengeProgressControllerUnitTest {
                 .endDate(LocalDate.now().plusDays(5))
                 .totalDays(10)
                 .build();
-        
+
         TeamChallengeProgressFlat progressFlat = new TeamChallengeProgressFlat(
                 1L, "tester", true, 5, 10, 77, LocalDate.now(), ChallengeDailyStatus.COMPLETE);
-        
+
         TeamChallengeProgressResponse response = TeamChallengeProgressResponse.of(
                 challenge,
                 List.of(progressFlat)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -9,23 +9,21 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
-import me.bombom.api.v1.challenge.domain.Challenge;
-import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
+import java.time.LocalDate;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
 import me.bombom.api.v1.common.config.WebConfig;
-import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.member.repository.MemberRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,7 +38,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
-@Import({ WebConfig.class, LoginMemberArgumentResolver.class })
+@Import(WebConfig.class)
 @WebMvcTest(ChallengeProgressController.class)
 class ChallengeProgressControllerUnitTest {
 
@@ -52,9 +50,6 @@ class ChallengeProgressControllerUnitTest {
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMetamodelMappingContext;
-
-    @MockitoBean
-    private MemberRepository memberRepository;
 
     private Authentication authentication;
 
@@ -70,17 +65,17 @@ class ChallengeProgressControllerUnitTest {
                 .roleId(1L)
                 .build();
 
-        given(memberRepository.findById(member.getId())).willReturn(java.util.Optional.of(member));
-
         Map<String, Object> attributes = Map.of(
                 "id", member.getId().toString(),
                 "email", member.getEmail(),
                 "name", member.getNickname());
         CustomOAuth2User customOAuth2User = new CustomOAuth2User(attributes, member, null, null);
+
         authentication = new OAuth2AuthenticationToken(
                 customOAuth2User,
                 List.of(new SimpleGrantedAuthority("ROLE_USER")),
-                "google");
+                "google"
+        );
     }
 
     @Test
@@ -126,7 +121,7 @@ class ChallengeProgressControllerUnitTest {
         // given
         Long challengeId = 1L;
         Long teamId = 10L;
-
+        
         Challenge challenge = Challenge.builder()
                 .id(challengeId)
                 .name("Test Challenge")
@@ -135,10 +130,10 @@ class ChallengeProgressControllerUnitTest {
                 .endDate(LocalDate.now().plusDays(5))
                 .totalDays(10)
                 .build();
-
+        
         TeamChallengeProgressFlat progressFlat = new TeamChallengeProgressFlat(
                 1L, "tester", true, 5, 10, 77, LocalDate.now(), ChallengeDailyStatus.COMPLETE);
-
+        
         TeamChallengeProgressResponse response = TeamChallengeProgressResponse.of(
                 challenge,
                 List.of(progressFlat)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -9,15 +9,17 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
-import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
-import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
-import java.time.LocalDate;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeGrade;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
+import me.bombom.api.v1.challenge.dto.response.CertificationInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
@@ -121,7 +123,7 @@ class ChallengeProgressControllerUnitTest {
         // given
         Long challengeId = 1L;
         Long teamId = 10L;
-        
+
         Challenge challenge = Challenge.builder()
                 .id(challengeId)
                 .name("Test Challenge")
@@ -130,10 +132,10 @@ class ChallengeProgressControllerUnitTest {
                 .endDate(LocalDate.now().plusDays(5))
                 .totalDays(10)
                 .build();
-        
+
         TeamChallengeProgressFlat progressFlat = new TeamChallengeProgressFlat(
                 1L, "tester", true, 5, 10, 77, LocalDate.now(), ChallengeDailyStatus.COMPLETE);
-        
+
         TeamChallengeProgressResponse response = TeamChallengeProgressResponse.of(
                 challenge,
                 List.of(progressFlat)
@@ -176,6 +178,33 @@ class ChallengeProgressControllerUnitTest {
         mockMvc.perform(get("/api/v1/challenges/{id}/progress/teams/{teamId}", challengeId, invalidTeamId)
                         .with(authentication(authentication)))
                 .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    void 수료증_정보_조회_성공() throws Exception {
+        // given
+        Long challengeId = 1L;
+        CertificationInfoResponse response = new CertificationInfoResponse(
+                "tester",
+                "Test Challenge",
+                1,
+                LocalDate.now().minusDays(10),
+                LocalDate.now().minusDays(1),
+                ChallengeGrade.GOLD,
+                100
+        );
+
+        given(challengeProgressService.getCertificationInfo(eq(challengeId), eq(1L)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/certification", challengeId)
+                        .with(authentication(authentication)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.nickname").value("tester"))
+                .andExpect(jsonPath("$.challengeName").value("Test Challenge"))
+                .andExpect(jsonPath("$.medal").value("GOLD"))
                 .andDo(print());
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -425,10 +425,10 @@ class ChallengeProgressServiceTest {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         Challenge completedChallenge = challengeRepository.save(
                 TestFixture.createChallenge(
-                    "Completed Challenge",
-                    yesterday.minusDays(10),
-                    yesterday,
-                    10
+                        "Completed Challenge",
+                        yesterday.minusDays(10),
+                        yesterday,
+                        10
                 )
         );
 
@@ -442,7 +442,8 @@ class ChallengeProgressServiceTest {
         );
 
         // when
-        CertificationInfoResponse response = challengeProgressService.getCertificationInfo(completedChallenge.getId(), member);
+        CertificationInfoResponse response = challengeProgressService.getCertificationInfo(completedChallenge.getId(),
+                member.getId());
 
         // then
         assertSoftly(softly -> {
@@ -459,7 +460,7 @@ class ChallengeProgressServiceTest {
     @Test
     void 진행_중인_챌린지의_수료증_조회시_예외_발생() {
         // when & then
-        assertThatThrownBy(() -> challengeProgressService.getCertificationInfo(challenge.getId(), member))
+        assertThatThrownBy(() -> challengeProgressService.getCertificationInfo(challenge.getId(), member.getId()))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .satisfies(e -> {
                     CIllegalArgumentException exception = (CIllegalArgumentException) e;
@@ -473,7 +474,7 @@ class ChallengeProgressServiceTest {
         Long nonExistentChallengeId = 0L;
 
         // when & then
-        assertThatThrownBy(() -> challengeProgressService.getCertificationInfo(nonExistentChallengeId, member))
+        assertThatThrownBy(() -> challengeProgressService.getCertificationInfo(nonExistentChallengeId, member.getId()))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .satisfies(e -> {
                     CIllegalArgumentException exception = (CIllegalArgumentException) e;
@@ -488,10 +489,10 @@ class ChallengeProgressServiceTest {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         Challenge completedChallenge = challengeRepository.save(
                 TestFixture.createChallenge(
-                    "Other Challenge",
-                    yesterday.minusDays(10),
-                    yesterday,
-                    10
+                        "Other Challenge",
+                        yesterday.minusDays(10),
+                        yesterday,
+                        10
                 )
         );
 
@@ -503,7 +504,7 @@ class ChallengeProgressServiceTest {
         );
 
         // when & then
-        assertThatThrownBy(() -> challengeProgressService.getCertificationInfo(completedChallenge.getId(), otherMember))
+        assertThatThrownBy(() -> challengeProgressService.getCertificationInfo(completedChallenge.getId(), otherMember.getId()))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .satisfies(e -> {
                     CIllegalArgumentException exception = (CIllegalArgumentException) e;
@@ -519,10 +520,10 @@ class ChallengeProgressServiceTest {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         Challenge completedChallenge = challengeRepository.save(
                 TestFixture.createChallenge(
-                    "Failed Challenge",
-                    yesterday.minusDays(10),
-                    yesterday,
-                    10
+                        "Failed Challenge",
+                        yesterday.minusDays(10),
+                        yesterday,
+                        10
                 )
         );
 
@@ -536,12 +537,12 @@ class ChallengeProgressServiceTest {
         );
 
         // when & then
-        assertThatThrownBy(() -> challengeProgressService.getCertificationInfo(completedChallenge.getId(), member))
+        assertThatThrownBy(() -> challengeProgressService.getCertificationInfo(completedChallenge.getId(), member.getId()))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .satisfies(e -> {
                     CIllegalArgumentException exception = (CIllegalArgumentException) e;
                     assertThat(exception.getErrorDetail()).isEqualTo(ErrorDetail.PRECONDITION_FAILED);
-        });
+                });
     }
 
     @Test
@@ -550,10 +551,10 @@ class ChallengeProgressServiceTest {
         LocalDate yesterday = LocalDate.now().minusDays(1);
         Challenge completedChallenge = challengeRepository.save(
                 TestFixture.createChallenge(
-                    "Grade Challenge",
-                    yesterday.minusDays(10),
-                    yesterday,
-                    10
+                        "Grade Challenge",
+                        yesterday.minusDays(10),
+                        yesterday,
+                        10
                 )
         );
 
@@ -568,7 +569,8 @@ class ChallengeProgressServiceTest {
         );
 
         // when
-        CertificationInfoResponse response = challengeProgressService.getCertificationInfo(completedChallenge.getId(), member);
+        CertificationInfoResponse response = challengeProgressService.getCertificationInfo(completedChallenge.getId(),
+                member.getId());
 
         // then
         assertSoftly(softly -> {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -2,6 +2,8 @@ package me.bombom.api.v1.common.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -30,13 +32,28 @@ class LoginMemberArgumentResolverTest {
     }
 
     static class StubController {
-        public void endpointNullableTrue(@LoginMember(anonymous = true) Member member) {}
-        public void endpointNullableFalse(@LoginMember(anonymous = false) Member member) {}
+        public void endpointNullableTrue(@LoginMember(anonymous = true) Member member) {
+        }
+
+        public void endpointNullableFalse(@LoginMember(anonymous = false) Member member) {
+        }
+
+        public void endpointLong(@LoginMember Long memberId) {
+        }
+
+        public void endpointLongAnonymousTrue(@LoginMember(anonymous = true) Long memberId) {
+        }
+    }
+
+    @Test
+    void supportsParameter는_Member와_Long타입을_지원한다() throws Exception {
+        assertThat(resolver.supportsParameter(paramNullableTrue())).isTrue();
+        assertThat(resolver.supportsParameter(paramLongAnonymousFalse())).isTrue();
     }
 
     @Test
     void 익명_요청_anonymous_true이면_null_반환() throws Exception {
-        //익명 토큰 = 로그인하지 않은 유저
+        // 익명 토큰 = 로그인하지 않은 유저
         Authentication anonymous = new AnonymousAuthenticationToken(
                 "key",
                 "anonymousUser",
@@ -58,6 +75,33 @@ class LoginMemberArgumentResolverTest {
         SecurityContextHolder.getContext().setAuthentication(anonymous);
 
         assertThatThrownBy(() -> resolver.resolveArgument(paramNullableFalse(), null, null, null))
+                .isInstanceOfSatisfying(UnauthorizedException.class, e ->
+                        assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED)
+                );
+    }
+
+    @Test
+    void Long타입_익명_요청_anonymous_true이면_null_반환() throws Exception {
+        Authentication anonymous = new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
+        );
+        SecurityContextHolder.getContext().setAuthentication(anonymous);
+
+        Object result = resolver.resolveArgument(paramLongAnonymousTrue(), null, null, null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void Long타입_익명_요청_anonymous_false이면_UNAUTHORIZED() {
+        Authentication anonymous = new AnonymousAuthenticationToken(
+                "key",
+                "anonymousUser",
+                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+        SecurityContextHolder.getContext().setAuthentication(anonymous);
+
+        assertThatThrownBy(() -> resolver.resolveArgument(paramLongAnonymousFalse(), null, null, null))
                 .isInstanceOfSatisfying(UnauthorizedException.class, e ->
                         assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED)
                 );
@@ -94,7 +138,7 @@ class LoginMemberArgumentResolverTest {
     @Test
     void 정상_로그인_이면_Member_반환() throws Exception {
         // Member는 복잡한 엔티티일 수 있으므로 목 객체로 대체
-        Member member = org.mockito.Mockito.mock(Member.class);
+        Member member = mock(Member.class);
 
         CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
         OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
@@ -108,7 +152,25 @@ class LoginMemberArgumentResolverTest {
         assertThat(result).isInstanceOf(Member.class);
     }
 
-    //ArgumentResolver에게 파라미터 넘기기
+    @Test
+    void Long타입_요청이면_memberId_반환() throws Exception {
+        Member member = mock(Member.class);
+        Long memberId = 1L;
+        when(member.getId()).thenReturn(memberId);
+
+        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
+                user,
+                user.getAuthorities(),
+                "registrationId"
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Object result = resolver.resolveArgument(paramLongAnonymousFalse(), null, null, null);
+        assertThat(result).isEqualTo(memberId);
+    }
+
+    // ArgumentResolver에게 파라미터 넘기기
     private MethodParameter paramNullableTrue() throws Exception {
         Method m = StubController.class.getMethod("endpointNullableTrue", Member.class);
         return new MethodParameter(m, 0);
@@ -118,6 +180,14 @@ class LoginMemberArgumentResolverTest {
         Method m = StubController.class.getMethod("endpointNullableFalse", Member.class);
         return new MethodParameter(m, 0);
     }
+
+    private MethodParameter paramLongAnonymousFalse() throws Exception {
+        Method m = StubController.class.getMethod("endpointLong", Long.class);
+        return new MethodParameter(m, 0);
+    }
+
+    private MethodParameter paramLongAnonymousTrue() throws Exception {
+        Method m = StubController.class.getMethod("endpointLongAnonymousTrue", Long.class);
+        return new MethodParameter(m, 0);
+    }
 }
-
-

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -2,8 +2,6 @@ package me.bombom.api.v1.common.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-import static org.mockito.BDDMockito.given;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -12,11 +10,8 @@ import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -27,21 +22,13 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 
 class LoginMemberArgumentResolverTest {
 
-    private MemberRepository memberRepository;
-    private LoginMemberArgumentResolver resolver;
-
-    @BeforeEach
-    void setUp() {
-        memberRepository = Mockito.mock(MemberRepository.class);
-        resolver = new LoginMemberArgumentResolver(memberRepository);
-    }
+    private final LoginMemberArgumentResolver resolver = new LoginMemberArgumentResolver();
 
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
     }
 
-    //테스트를 위한 가짜 컨트롤러
     static class StubController {
         public void endpointNullableTrue(@LoginMember(anonymous = true) Member member) {}
         public void endpointNullableFalse(@LoginMember(anonymous = false) Member member) {}
@@ -105,10 +92,9 @@ class LoginMemberArgumentResolverTest {
     }
 
     @Test
-    void 정상_로그인_이고_DB에_회원이_존재하면_Member_반환() throws Exception {
-        // given
+    void 정상_로그인_이면_Member_반환() throws Exception {
+        // Member는 복잡한 엔티티일 수 있으므로 목 객체로 대체
         Member member = org.mockito.Mockito.mock(Member.class);
-        given(member.getId()).willReturn(1L);
 
         CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
         OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
@@ -118,38 +104,8 @@ class LoginMemberArgumentResolverTest {
         );
         SecurityContextHolder.getContext().setAuthentication(auth);
 
-        given(memberRepository.findById(1L)).willReturn(java.util.Optional.of(member));
-
-        // when
         Object result = resolver.resolveArgument(paramNullableTrue(), null, null, null);
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(result).isInstanceOf(Member.class);
-            softly.assertThat(result).isEqualTo(member);
-        });
-    }
-
-    @Test
-    void 정상_로그인이지만_DB에_회원이_없으면_UNAUTHORIZED() throws Exception {
-        // given
-        Member member = org.mockito.Mockito.mock(Member.class);
-        given(member.getId()).willReturn(0L);
-
-        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
-        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
-                user,
-                user.getAuthorities(),
-                "registrationId"
-        );
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        given(memberRepository.findById(0L)).willReturn(java.util.Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> resolver.resolveArgument(paramNullableTrue(), null, null, null))
-                .isInstanceOfSatisfying(UnauthorizedException.class,
-                        e -> assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED));
+        assertThat(result).isInstanceOf(Member.class);
     }
 
     //ArgumentResolver에게 파라미터 넘기기
@@ -163,3 +119,5 @@ class LoginMemberArgumentResolverTest {
         return new MethodParameter(m, 0);
     }
 }
+
+

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -2,6 +2,8 @@ package me.bombom.api.v1.common.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
 import java.lang.reflect.Method;
 import java.util.List;
@@ -10,8 +12,11 @@ import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -22,13 +27,21 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 
 class LoginMemberArgumentResolverTest {
 
-    private final LoginMemberArgumentResolver resolver = new LoginMemberArgumentResolver();
+    private MemberRepository memberRepository;
+    private LoginMemberArgumentResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        memberRepository = Mockito.mock(MemberRepository.class);
+        resolver = new LoginMemberArgumentResolver(memberRepository);
+    }
 
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
     }
 
+    //테스트를 위한 가짜 컨트롤러
     static class StubController {
         public void endpointNullableTrue(@LoginMember(anonymous = true) Member member) {}
         public void endpointNullableFalse(@LoginMember(anonymous = false) Member member) {}
@@ -92,9 +105,10 @@ class LoginMemberArgumentResolverTest {
     }
 
     @Test
-    void 정상_로그인_이면_Member_반환() throws Exception {
-        // Member는 복잡한 엔티티일 수 있으므로 목 객체로 대체
+    void 정상_로그인_이고_DB에_회원이_존재하면_Member_반환() throws Exception {
+        // given
         Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(1L);
 
         CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
         OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
@@ -104,8 +118,38 @@ class LoginMemberArgumentResolverTest {
         );
         SecurityContextHolder.getContext().setAuthentication(auth);
 
+        given(memberRepository.findById(1L)).willReturn(java.util.Optional.of(member));
+
+        // when
         Object result = resolver.resolveArgument(paramNullableTrue(), null, null, null);
-        assertThat(result).isInstanceOf(Member.class);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result).isInstanceOf(Member.class);
+            softly.assertThat(result).isEqualTo(member);
+        });
+    }
+
+    @Test
+    void 정상_로그인이지만_DB에_회원이_없으면_UNAUTHORIZED() throws Exception {
+        // given
+        Member member = org.mockito.Mockito.mock(Member.class);
+        given(member.getId()).willReturn(0L);
+
+        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
+                user,
+                user.getAuthorities(),
+                "registrationId"
+        );
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        given(memberRepository.findById(0L)).willReturn(java.util.Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> resolver.resolveArgument(paramNullableTrue(), null, null, null))
+                .isInstanceOfSatisfying(UnauthorizedException.class,
+                        e -> assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED));
     }
 
     //ArgumentResolver에게 파라미터 넘기기
@@ -119,5 +163,3 @@ class LoginMemberArgumentResolverTest {
         return new MethodParameter(m, 0);
     }
 }
-
-

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -2,8 +2,10 @@ package me.bombom.api.v1.common.resolver;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
@@ -11,11 +13,10 @@ import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.member.repository.MemberRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.TestingAuthenticationToken;
@@ -26,13 +27,11 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 
 class LoginMemberArgumentResolverTest {
 
-    private MemberRepository memberRepository;
     private LoginMemberArgumentResolver resolver;
 
     @BeforeEach
     void setUp() {
-        memberRepository = Mockito.mock(MemberRepository.class);
-        resolver = new LoginMemberArgumentResolver(memberRepository);
+        resolver = new LoginMemberArgumentResolver();
     }
 
     @AfterEach
@@ -40,12 +39,11 @@ class LoginMemberArgumentResolverTest {
         SecurityContextHolder.clearContext();
     }
 
-    //테스트를 위한 가짜 컨트롤러
     static class StubController {
-        public void endpointNullableTrue(@LoginMember(anonymous = true) Member member) {
+        public void endpointMember(@LoginMember Member member) {
         }
 
-        public void endpointNullableFalse(@LoginMember(anonymous = false) Member member) {
+        public void endpointMemberAnonymousTrue(@LoginMember(anonymous = true) Member member) {
         }
 
         public void endpointLong(@LoginMember Long memberId) {
@@ -56,178 +54,115 @@ class LoginMemberArgumentResolverTest {
     }
 
     @Test
-    void supportsParameter는_Member와_Long타입을_지원한다() throws Exception {
-        assertThat(resolver.supportsParameter(paramNullableTrue())).isTrue();
-        assertThat(resolver.supportsParameter(paramLongAnonymousFalse())).isTrue();
-    }
-
-    @Test
-    void 익명_요청_anonymous_true이면_null_반환() throws Exception {
-        // 익명 토큰 = 로그인하지 않은 유저
-        Authentication anonymous = new AnonymousAuthenticationToken(
-                "key",
-                "anonymousUser",
-                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
-        );
-        SecurityContextHolder.getContext().setAuthentication(anonymous);
-
-        Object result = resolver.resolveArgument(paramNullableTrue(), null, null, null);
-        assertThat(result).isNull();
-    }
-
-    @Test
-    void 익명_요청_anonymous_false이면_UNAUTHORIZED() {
-        Authentication anonymous = new AnonymousAuthenticationToken(
-                "key",
-                "anonymousUser",
-                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
-        );
-        SecurityContextHolder.getContext().setAuthentication(anonymous);
-
-        assertThatThrownBy(() -> resolver.resolveArgument(paramNullableFalse(), null, null, null))
-                .isInstanceOfSatisfying(UnauthorizedException.class, e ->
-                        assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED)
-                );
-    }
-
-    @Test
-    void Long타입_익명_요청_anonymous_true이면_null_반환() throws Exception {
-        Authentication anonymous = new AnonymousAuthenticationToken(
-                "key",
-                "anonymousUser",
-                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS"))
-        );
-        SecurityContextHolder.getContext().setAuthentication(anonymous);
-
-        Object result = resolver.resolveArgument(paramLongAnonymousTrue(), null, null, null);
-        assertThat(result).isNull();
-    }
-
-    @Test
-    void Long타입_익명_요청_anonymous_false이면_UNAUTHORIZED() {
-        Authentication anonymous = new AnonymousAuthenticationToken(
-                "key",
-                "anonymousUser",
-                List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
-        SecurityContextHolder.getContext().setAuthentication(anonymous);
-
-        assertThatThrownBy(() -> resolver.resolveArgument(paramLongAnonymousFalse(), null, null, null))
-                .isInstanceOfSatisfying(UnauthorizedException.class, e ->
-                        assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED)
-                );
-    }
-
-    @Test
-    void principal_타입_불일치면_INVALID_TOKEN() {
-        TestingAuthenticationToken auth = new TestingAuthenticationToken("notCustomUser", null);
-        auth.setAuthenticated(true);
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        assertThatThrownBy(() -> resolver.resolveArgument(paramNullableTrue(), null, null, null))
-                .isInstanceOfSatisfying(UnauthorizedException.class, e ->
-                        assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.INVALID_TOKEN)
-                );
-    }
-
-    @Test
-    void principal은_CustomOAuth2User지만_member_null이면_UNAUTHORIZED() {
-        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), null, null, null);
-        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
-                user,
-                user.getAuthorities(),
-                "registrationId"
-        );
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        assertThatThrownBy(() -> resolver.resolveArgument(paramNullableTrue(), null, null, null))
-                .isInstanceOfSatisfying(UnauthorizedException.class, e ->
-                        assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED)
-                );
-    }
-
-    @Test
-    void 정상_로그인_이면_Member_반환() throws Exception {
-        // Member는 복잡한 엔티티일 수 있으므로 목 객체로 대체
-        Member member = mock(Member.class);
-
-        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
-        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
-                user,
-                user.getAuthorities(),
-                "registrationId"
-        );
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        given(memberRepository.findById(1L)).willReturn(java.util.Optional.of(member));
-
-        // when
-        Object result = resolver.resolveArgument(paramNullableTrue(), null, null, null);
-
-        // then
+    @DisplayName("Member 타입과 Long 타입을 모두 지원한다")
+    void supportsParameter() throws Exception {
         assertSoftly(softly -> {
-            softly.assertThat(result).isInstanceOf(Member.class);
-            softly.assertThat(result).isEqualTo(member);
+            softly.assertThat(resolver.supportsParameter(paramMember())).isTrue();
+            softly.assertThat(resolver.supportsParameter(paramLong())).isTrue();
         });
     }
 
     @Test
-    void 정상_로그인이지만_DB에_회원이_없으면_UNAUTHORIZED() throws Exception {
-        // given
-        Member member = org.mockito.Mockito.mock(Member.class);
-        given(member.getId()).willReturn(0L);
+    @DisplayName("로그인하지 않은 유저가 익명 허용 엔드포인트에 접근하면 null을 반환한다")
+    void anonymousTrue_WhenNotLoggedIn_ReturnsNull() throws Exception {
+        setAnonymousAuthentication();
 
-        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
-        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
-                user,
-                user.getAuthorities(),
-                "registrationId"
-        );
-        SecurityContextHolder.getContext().setAuthentication(auth);
-
-        given(memberRepository.findById(0L)).willReturn(java.util.Optional.empty());
-
-        // when & then
-        assertThatThrownBy(() -> resolver.resolveArgument(paramNullableTrue(), null, null, null))
-                .isInstanceOfSatisfying(UnauthorizedException.class,
-                        e -> assertThat(e.getErrorDetail()).isEqualTo(ErrorDetail.UNAUTHORIZED));
+        Object result = resolver.resolveArgument(paramMemberAnonymousTrue(), null, null, null);
+        assertThat(result).isNull();
     }
 
     @Test
-    void Long타입_요청이면_memberId_반환() throws Exception {
-        Member member = mock(Member.class);
-        Long memberId = 1L;
-        when(member.getId()).thenReturn(memberId);
+    @DisplayName("로그인하지 않은 유저가 익명 비허용 엔드포인트에 접근하면 UNAUTHORIZED 예외를 던진다")
+    void anonymousFalse_WhenNotLoggedIn_ThrowsException() throws Exception {
+        setAnonymousAuthentication();
 
-        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
-        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
-                user,
-                user.getAuthorities(),
-                "registrationId"
-        );
+        assertThatThrownBy(() -> resolver.resolveArgument(paramMember(), null, null, null))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("정상 로그인 유저에 대해 Member 객체를 반환한다")
+    void resolveMember_WhenLoggedIn() throws Exception {
+        Member member = mock(Member.class);
+        setLoggedInAuthentication(member);
+
+        Object result = resolver.resolveArgument(paramMember(), null, null, null);
+
+        assertThat(result).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("정상 로그인 유저에 대해 Long memberId를 반환한다")
+    void resolveLong_WhenLoggedIn() throws Exception {
+        Member member = mock(Member.class);
+        given(member.getId()).willReturn(1L);
+        setLoggedInAuthentication(member);
+
+        Object result = resolver.resolveArgument(paramLong(), null, null, null);
+
+        assertThat(result).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("OAuth2 유저 정보가 비정상(Member null)이면 UNAUTHORIZED 예외를 던진다")
+    void resolve_WhenMemberIsNullInPrincipal_ThrowsException() throws Exception {
+        setLoggedInAuthentication(null);
+
+        assertThatThrownBy(() -> resolver.resolveArgument(paramMember(), null, null, null))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("비정상적인 Principal 타입이면 INVALID_TOKEN 예외를 던진다")
+    void resolve_WhenInvalidPrincipal_ThrowsException() throws Exception {
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("notCustomUser", null);
+        auth.setAuthenticated(true);
         SecurityContextHolder.getContext().setAuthentication(auth);
 
-        Object result = resolver.resolveArgument(paramLongAnonymousFalse(), null, null, null);
-        assertThat(result).isEqualTo(memberId);
+        assertThatThrownBy(() -> resolver.resolveArgument(paramMember(), null, null, null))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_TOKEN);
     }
 
-    // ArgumentResolver에게 파라미터 넘기기
-    private MethodParameter paramNullableTrue() throws Exception {
-        Method m = StubController.class.getMethod("endpointNullableTrue", Member.class);
-        return new MethodParameter(m, 0);
+    private void setAnonymousAuthentication() {
+        Authentication anonymous = new AnonymousAuthenticationToken(
+                "key", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
+        SecurityContextHolder.getContext().setAuthentication(anonymous);
     }
 
-    private MethodParameter paramNullableFalse() throws Exception {
-        Method m = StubController.class.getMethod("endpointNullableFalse", Member.class);
-        return new MethodParameter(m, 0);
+    private void setLoggedInAuthentication(Member member) {
+        CustomOAuth2User user = new CustomOAuth2User(Map.of("name", "tester"), member, null, null);
+        OAuth2AuthenticationToken auth = new OAuth2AuthenticationToken(
+                user, user.getAuthorities(), "registrationId");
+        SecurityContextHolder.getContext().setAuthentication(auth);
     }
 
-    private MethodParameter paramLongAnonymousFalse() throws Exception {
-        Method m = StubController.class.getMethod("endpointLong", Long.class);
-        return new MethodParameter(m, 0);
+    private MethodParameter paramMember() {
+        try {
+            Method m = StubController.class.getMethod("endpointMember", Member.class);
+            return new MethodParameter(m, 0);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
     }
 
-    private MethodParameter paramLongAnonymousTrue() throws Exception {
-        Method m = StubController.class.getMethod("endpointLongAnonymousTrue", Long.class);
-        return new MethodParameter(m, 0);
+    private MethodParameter paramMemberAnonymousTrue() {
+        try {
+            Method m = StubController.class.getMethod("endpointMemberAnonymousTrue", Member.class);
+            return new MethodParameter(m, 0);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MethodParameter paramLong() {
+        try {
+            Method m = StubController.class.getMethod("endpointLong", Long.class);
+            return new MethodParameter(m, 0);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
@@ -1,8 +1,8 @@
 package me.bombom.api.v1.subscribe.controller;
 
+import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,12 +11,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.enums.Gender;
-import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.subscribe.dto.UnsubscribeResponse;
 import me.bombom.api.v1.subscribe.service.SubscribeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,15 +37,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @AutoConfigureMockMvc
 @WebMvcTest(controllers = SubscribeController.class)
-@Import({ SubscribeController.class, SubscribeControllerTest.TestConfig.class })
+@Import({SubscribeController.class, SubscribeControllerTest.TestConfig.class})
 class SubscribeControllerTest {
 
     @Configuration
     @EnableWebSecurity
     static class TestConfig implements WebMvcConfigurer {
-
-        @Autowired
-        private MemberRepository memberRepository;
 
         @Bean
         public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -55,15 +50,16 @@ class SubscribeControllerTest {
                     .csrf(AbstractHttpConfigurer::disable)
                     .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
                     .exceptionHandling(ex -> ex
-                            .authenticationEntryPoint((request, response,
-                                                       authException) -> response.sendError(
-                                    HttpServletResponse.SC_UNAUTHORIZED)))
+                            .authenticationEntryPoint((request, response, authException) ->
+                                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
+                            )
+                    )
                     .build();
         }
 
         @Override
         public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-            resolvers.add(new LoginMemberArgumentResolver(memberRepository));
+            resolvers.add(new LoginMemberArgumentResolver());
         }
     }
 
@@ -72,9 +68,6 @@ class SubscribeControllerTest {
 
     @MockitoBean
     SubscribeService subscribeService;
-
-    @MockitoBean
-    MemberRepository memberRepository;
 
     private OAuth2AuthenticationToken authToken;
 
@@ -89,8 +82,6 @@ class SubscribeControllerTest {
                 .gender(Gender.FEMALE)
                 .roleId(1L)
                 .build();
-
-        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
 
         Map<String, Object> attrs = Map.of(
                 "id", "1",

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
@@ -1,6 +1,5 @@
 package me.bombom.api.v1.subscribe.controller;
 
-import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -47,9 +46,6 @@ class SubscribeControllerTest {
     @EnableWebSecurity
     static class TestConfig implements WebMvcConfigurer {
 
-        @Autowired
-        private MemberRepository memberRepository;
-
         @Bean
         public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
             return http
@@ -64,7 +60,7 @@ class SubscribeControllerTest {
 
         @Override
         public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-            resolvers.add(new LoginMemberArgumentResolver(memberRepository));
+            resolvers.add(new LoginMemberArgumentResolver());
         }
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
@@ -1,8 +1,8 @@
 package me.bombom.api.v1.subscribe.controller;
 
-import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -11,10 +11,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.enums.Gender;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.subscribe.dto.UnsubscribeResponse;
 import me.bombom.api.v1.subscribe.service.SubscribeService;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,12 +39,15 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @AutoConfigureMockMvc
 @WebMvcTest(controllers = SubscribeController.class)
-@Import({SubscribeController.class, SubscribeControllerTest.TestConfig.class})
+@Import({ SubscribeController.class, SubscribeControllerTest.TestConfig.class })
 class SubscribeControllerTest {
 
     @Configuration
     @EnableWebSecurity
     static class TestConfig implements WebMvcConfigurer {
+
+        @Autowired
+        private MemberRepository memberRepository;
 
         @Bean
         public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -50,16 +55,15 @@ class SubscribeControllerTest {
                     .csrf(AbstractHttpConfigurer::disable)
                     .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
                     .exceptionHandling(ex -> ex
-                            .authenticationEntryPoint((request, response, authException) ->
-                                    response.sendError(HttpServletResponse.SC_UNAUTHORIZED)
-                            )
-                    )
+                            .authenticationEntryPoint((request, response,
+                                                       authException) -> response.sendError(
+                                    HttpServletResponse.SC_UNAUTHORIZED)))
                     .build();
         }
 
         @Override
         public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-            resolvers.add(new LoginMemberArgumentResolver());
+            resolvers.add(new LoginMemberArgumentResolver(memberRepository));
         }
     }
 
@@ -68,6 +72,9 @@ class SubscribeControllerTest {
 
     @MockitoBean
     SubscribeService subscribeService;
+
+    @MockitoBean
+    MemberRepository memberRepository;
 
     private OAuth2AuthenticationToken authToken;
 
@@ -82,6 +89,8 @@ class SubscribeControllerTest {
                 .gender(Gender.FEMALE)
                 .roleId(1L)
                 .build();
+
+        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
 
         Map<String, Object> attrs = Map.of(
                 "id", "1",


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
`@LoginMember` 리졸버의 의존성 구조를 개선하고, 수료증 조회 시 회원 데이터의 최신 정합성을 보장하도록 리팩토링을 진행했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 순환 참조 해결: `LoginMemberArgumentResolver`가 `MemberRepository`를 직접 참조하며 발생하던 아키텍처상의 순환 참조 위험을 제거했습니다.
- 데이터 정합성 확보: 수료증 발급과 같이 최신 유저 정보(닉네임 등)가 중요한 로직에서, 이전 세션 정보에 의존하지 않고 DB의 최신 상태를 직접 반영할 필요가 있었습니다.
- 유연한 타입 지원: 컨트롤러 레이어에서 상황에 따라 엔티티(`Member`) 또는 ID(`Long`)를 선택적으로 주입받을 수 있도록 하이브리드 지원이 필요했습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 리졸버 레이어 의존성 제거: `ArgumentResolver`에서 리포지토리 의존성을 완전히 제거했습니다. 대신 토큰/세션에서 추출된 정보를 기반으로 
`Member` 또는 `Long` 타입을 컨트롤러에 넘겨주도록 개선했습니다.
- 서비스 레이어 '정합성' 리팩토링: `ChallengeProgressService.getCertificationInfo`가 `memberId`를 직접 받아 서비스 내부에서 
`Member` 엔티티를 다시 Fetch 하도록 수정했습니다. 이를 통해 닉네임 변경 등 최신 상태가 수료증에 즉각 반영됩니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 400 vs 401 : 리졸버는 통과했지만 DB에 회원이 없는 특수한 상황에 대해 401 (INVALID_TOKEN)을 채택했습니다. 더 좋은 선택이 있을까요? 
  - `400`: 요청 파라미터가 비정상적이라는 의미이나, memberId는 클라이언트가 직접 입력한 값이 아닌 인증 시스템(JWT 등)에서 추출된 신뢰할 수 있는 값이므로 '입력값 오류'로 정의하기엔 부적절하다고 판단했습니다.
  - `401` (선택) : 토큰의 서명은 맞지만, 그 토큰이 대변하는 '실체'가 사라졌으므로 **"이 인증 정보는 더 이상 유효하지 않다"** 고 정의하는 것이 가장 적절하다고 판단했습니다. 