### PR TITLE
[BOM-924] feat: 구독 자동 취소 AWS lambda로 구현 및 재시도 알림

### DIFF
--- a/backend/bom-bom-server/build.gradle.kts
+++ b/backend/bom-bom-server/build.gradle.kts
@@ -90,6 +90,13 @@ dependencies {
 
     // for : webhook
     implementation("org.springframework.boot:spring-boot-starter-webflux")
+
+    // AWS SDK
+    implementation(platform("software.amazon.awssdk:bom:2.41.21"))
+    implementation("software.amazon.awssdk:lambda")
+
+    // Annotations
+    implementation("jakarta.annotation:jakarta.annotation-api")
 }
 
 // Querydsl 생성된 파일 정리

--- a/backend/bom-bom-server/src/main/java/me/bombom/BomBomServerApplication.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/BomBomServerApplication.java
@@ -3,6 +3,7 @@ package me.bombom;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
@@ -11,6 +12,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan
 @EnableSchedulerLock(defaultLockAtMostFor = "PT30S")
 public class BomBomServerApplication {
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/DiscordWebhookNotifier.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/DiscordWebhookNotifier.java
@@ -1,10 +1,13 @@
 package me.bombom.api.v1.common;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.member.service.MemberService;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
+import me.bombom.api.v1.newsletter.service.NewsletterService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -14,10 +17,14 @@ import org.springframework.stereotype.Component;
 public class DiscordWebhookNotifier {
 
     @Value("${discord.webhook.new_member.url}")
-    private String webhookUrl;
+    private String newMemberWebhookUrl;
+
+    @Value("${discord.webhook.unsubscribeError.url}")
+    private String unsubscribeErrorWebhookUrl;
 
     private final WebhookHttpClient webhookClient;
     private final MemberService memberService;
+    private final NewsletterService newsletterService;
 
     public void sendNewMemberNotification(String nickname) {
         long totalMemberCount = memberService.countNormalMembers();
@@ -28,12 +35,36 @@ public class DiscordWebhookNotifier {
                         "color", 0x00C853,
                         "fields", List.of(
                                 Map.of("name", "🧑‍💻 닉네임 : ", "value", "**" + nickname + "**", "inline", true),
-                                Map.of("name", "🕒 가입 시각 : ", "value", "<t:" + (System.currentTimeMillis() / 1000) + ":F>", "inline", true),
+                                Map.of("name", "🕒 가입 시각 : ", "value", "<t:" + (System.currentTimeMillis() / 1000) + ":F>",
+                                        "inline", true),
                                 Map.of("name", "🌸 현재 총 회원 수 : ", "value", totalMemberCount + "명")
                         )
                 )
         ));
 
-        webhookClient.post(webhookUrl, body);
+        webhookClient.post(newMemberWebhookUrl, body);
+    }
+
+    public void sendUnsubscribeErrorNotification(
+            String message,
+            Long newsletterId,
+            String url,
+            Long subscribeId
+    ) {
+        Newsletter newsletter = newsletterService.getNewsletter(newsletterId);
+        Map<String, Object> body = Map.of("embeds", List.of(
+                Map.of(
+                        "title", "🚨 구독 자동 취소 실패",
+                        "description", message,
+                        "color", 0xE74C3C,
+                        "fields", List.of(
+                                Map.of("name", "📰 뉴스레터", "value", newsletter.getName() + " (" + newsletter.getEmail() + ")"),
+                                Map.of("name", "❌ 실패 사유", "value", "```" + message + "```"),
+                                Map.of("name", "🔗 해지 URL", "value", url),
+                                Map.of("name", "🆔 ID 정보", "value",
+                                        "Newsletter: " + newsletterId + " / Subscribe: " + subscribeId)),
+                        "timestamp", Instant.now().toString())));
+
+        webhookClient.post(unsubscribeErrorWebhookUrl, body);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/AsyncConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/AsyncConfig.java
@@ -1,0 +1,25 @@
+package me.bombom.api.v1.common.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1); // 기본 1개
+        executor.setMaxPoolSize(3); // 최대 3개
+        executor.setQueueCapacity(50); // 큐 50개
+        executor.setThreadNamePrefix("async-");
+        executor.setWaitForTasksToCompleteOnShutdown(true);
+        executor.setAwaitTerminationSeconds(60);
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/LambdaClientConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/LambdaClientConfig.java
@@ -1,0 +1,30 @@
+package me.bombom.api.v1.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+
+@Configuration
+public class LambdaClientConfig {
+
+    @Value("${aws.lambda.playwright.region}")
+    private String region;
+
+    @Value("${aws.lambda.playwright.access-key}")
+    private String accessKey;
+
+    @Value("${aws.lambda.playwright.secret-key}")
+    private String secretKey;
+
+    @Bean(destroyMethod = "close")
+    public LambdaClient lambdaClient() {
+        return LambdaClient.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/ShedLockConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/ShedLockConfig.java
@@ -3,14 +3,21 @@ package me.bombom.api.v1.common.config;
 import javax.sql.DataSource;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "PT10M")
 public class ShedLockConfig {
 
     @Bean
     public LockProvider lockProvider(DataSource dataSource) {
-        return new JdbcTemplateLockProvider(dataSource);
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build());
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/RetryableException.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/RetryableException.java
@@ -1,0 +1,18 @@
+package me.bombom.api.v1.common.exception;
+
+/**
+ * 일시적인 오류로 재시도 가능한 예외
+ * - 네트워크 타임아웃
+ * - 서버 5xx 에러
+ * - Playwright 실행 오류 (브라우저 크래시 등)
+ */
+public class RetryableException extends RuntimeException {
+
+    public RetryableException(String message) {
+        super(message);
+    }
+
+    public RetryableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/service/NewsletterService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/service/NewsletterService.java
@@ -6,6 +6,7 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.newsletter.domain.Newsletter;
 import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
 import me.bombom.api.v1.newsletter.dto.NewsletterWithDetailResponse;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
@@ -30,6 +31,14 @@ public class NewsletterService {
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "newsletter")
                         .addContext(ErrorContextKeys.NEWSLETTER_ID, newsletterId));
+    }
+
+    public Newsletter getNewsletter(Long id) {
+        return newsletterRepository.findById(id)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "newsletter")
+                        .addContext(ErrorContextKeys.OPERATION, "getNewsletter")
+                        .addContext(ErrorContextKeys.NEWSLETTER_ID, id));
     }
 
     private Long getMemberId(Member member) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/client/PlaywrightClient.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/client/PlaywrightClient.java
@@ -1,0 +1,62 @@
+package me.bombom.api.v1.subscribe.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.subscribe.dto.UnsubscribePatterns;
+import me.bombom.api.v1.subscribe.dto.request.PlaywrightRequest;
+import me.bombom.api.v1.subscribe.dto.response.PlaywrightResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.services.lambda.LambdaClient;
+import software.amazon.awssdk.services.lambda.model.InvokeRequest;
+import software.amazon.awssdk.services.lambda.model.InvokeResponse;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PlaywrightClient {
+
+    private final ObjectMapper objectMapper;
+    private final LambdaClient lambdaClient;
+
+    @Value("${aws.lambda.playwright.function-name}")
+    private String functionName;
+
+    public PlaywrightResponse executeUnsubscribe(String url, UnsubscribePatterns patterns) {
+        PlaywrightRequest requestBody = PlaywrightRequest.of(url, patterns);
+        try {
+            String payload = objectMapper.writeValueAsString(requestBody);
+            InvokeRequest invokeRequest = InvokeRequest.builder()
+                    .functionName(functionName)
+                    .payload(SdkBytes.fromUtf8String(payload))
+                    .build();
+
+            InvokeResponse response = lambdaClient.invoke(invokeRequest);
+
+            if (response.functionError() != null) {
+                log.error("Lambda 실행 오류: {}", response.functionError());
+                return new PlaywrightResponse(
+                        HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        false,
+                        null,
+                        "Lambda 실행 오류: " + response.functionError(),
+                        null
+                );
+            }
+            String responsePayload = response.payload().asUtf8String();
+            return objectMapper.readValue(responsePayload, PlaywrightResponse.class);
+        } catch (Exception e) {
+            log.error("Lambda 호출 중 예외 발생", e);
+            return new PlaywrightResponse(
+                    HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                    false,
+                    null,
+                    "내부 오류: " + e.getMessage(),
+                    null
+            );
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/config/SubscribePatternProperties.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/config/SubscribePatternProperties.java
@@ -1,0 +1,19 @@
+package me.bombom.api.v1.subscribe.config;
+
+import java.util.List;
+import java.util.regex.Pattern;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "subscribe.patterns")
+public class SubscribePatternProperties {
+
+    private final Pattern unsubscribePattern;
+    private final Pattern successPattern;
+    private final Pattern alreadyUnsubscribedPattern;
+    private final Pattern errorPattern;
+    private final List<String> adDomains;
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/controller/SubscribeController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/controller/SubscribeController.java
@@ -5,8 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.subscribe.dto.UnsubscribeResponse;
-import me.bombom.api.v1.subscribe.dto.SubscribedNewsletterResponse;
+import me.bombom.api.v1.subscribe.dto.response.SubscribedNewsletterResponse;
 import me.bombom.api.v1.subscribe.service.SubscribeService;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,10 +30,9 @@ public class SubscribeController implements SubscribeControllerApi {
 
     @Override
     @PostMapping("/me/subscriptions/{subscriptionId}/unsubscribe")
-    public UnsubscribeResponse unsubscribe(
-        @LoginMember Member member,
-        @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long subscriptionId
-    ) {
-        return subscribeService.unsubscribe(member.getId(), subscriptionId);
+    public void unsubscribe(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long subscriptionId) {
+        subscribeService.unsubscribe(member.getId(), subscriptionId);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerApi.java
@@ -9,8 +9,7 @@ import jakarta.validation.constraints.Positive;
 import java.util.List;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
-import me.bombom.api.v1.subscribe.dto.UnsubscribeResponse;
-import me.bombom.api.v1.subscribe.dto.SubscribedNewsletterResponse;
+import me.bombom.api.v1.subscribe.dto.response.SubscribedNewsletterResponse;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Subscription", description = "구독 관련 API")
@@ -23,12 +22,13 @@ public interface SubscribeControllerApi {
     })
     List<SubscribedNewsletterResponse> getSubscribedNewsletters(@Parameter(hidden = true) @LoginMember Member member);
 
-    @Operation(summary = "뉴스레터 구독 취소", description = "뉴스레터 구독을 취소합니다. 구독 리스트에서 삭제하고 unsubscribeUrl이 존재하는 경우 반환됩니다.")
+    @Operation(summary = "뉴스레터 구독 취소", description = "뉴스레터 구독 취소를 요청합니다. 자동 취소가 비동기로 진행되며, 실패 시 구독 목록에서 수동 취소 링크를 확인할 수 있습니다.")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "구독 취소 성공"),
         @ApiResponse(responseCode = "401", description = "인증 실패")
     })
-    UnsubscribeResponse unsubscribe(
+    void unsubscribe(
             @Parameter(hidden = true) @LoginMember Member member,
-            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long subscriptionId);
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long subscriptionId
+    );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/Subscribe.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/Subscribe.java
@@ -2,6 +2,8 @@ package me.bombom.api.v1.subscribe.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -32,7 +34,24 @@ public class Subscribe extends BaseEntity {
     @Column(length = 512)
     private String unsubscribeUrl;
 
+    @Builder.Default
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private SubscribeStatus status = SubscribeStatus.SUBSCRIBED;
+
+    public void changeStatus(SubscribeStatus status) {
+        this.status = status;
+    }
+
     public boolean isNotOwner(Long memberId) {
         return !this.memberId.equals(memberId);
+    }
+
+    public boolean isFailed() {
+        return status == SubscribeStatus.UNSUBSCRIBE_FAILED;
+    }
+
+    public boolean isUnsubscribing() {
+        return status == SubscribeStatus.UNSUBSCRIBING;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/SubscribeRetry.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/SubscribeRetry.java
@@ -1,0 +1,73 @@
+package me.bombom.api.v1.subscribe.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubscribeRetry extends BaseEntity {
+
+    private static final List<Duration> BACKOFF_STRATEGY = List.of(
+            Duration.ofMinutes(10), //네트워크 문제
+            Duration.ofMinutes(30), //짧은 점검
+            Duration.ofHours(2) //점검
+    );
+    private static final int MAX_RETRY_COUNT = BACKOFF_STRATEGY.size();
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private Long subscribeId;
+
+    @Column(nullable = false)
+    private int retryCount;
+
+    @Column(nullable = false)
+    private LocalDateTime nextRetryAt;
+
+    private String lastError;
+
+    @Builder
+    public SubscribeRetry(
+            Long id,
+            @NonNull Long subscribeId,
+            @NonNull LocalDateTime nextRetryAt,
+            String lastError
+    ) {
+        this.id = id;
+        this.subscribeId = subscribeId;
+        this.nextRetryAt = nextRetryAt;
+        this.lastError = lastError;
+        this.retryCount = 0;
+    }
+
+    public void increaseRetryCount(LocalDateTime now, String errorMsg) {
+        this.nextRetryAt = calculateNextRetryTime(now);
+        this.retryCount += 1;
+        this.lastError = errorMsg;
+    }
+
+    private LocalDateTime calculateNextRetryTime(LocalDateTime now) {
+        int index = Math.min(this.retryCount, BACKOFF_STRATEGY.size() - 1);
+        return now.plus(BACKOFF_STRATEGY.get(index));
+    }
+
+    public boolean isMaxRetryReached() {
+        return this.retryCount >= MAX_RETRY_COUNT;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/SubscribeStatus.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/SubscribeStatus.java
@@ -1,0 +1,8 @@
+package me.bombom.api.v1.subscribe.domain;
+
+public enum SubscribeStatus {
+
+    SUBSCRIBED,
+    UNSUBSCRIBING,
+    UNSUBSCRIBE_FAILED
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/dto/UnsubscribePatterns.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/dto/UnsubscribePatterns.java
@@ -1,0 +1,9 @@
+package me.bombom.api.v1.subscribe.dto;
+
+public record UnsubscribePatterns(
+        String unsubscribe,
+        String success,
+        String alreadyUnsubscribed,
+        String error
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/dto/request/PlaywrightRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/dto/request/PlaywrightRequest.java
@@ -1,0 +1,13 @@
+package me.bombom.api.v1.subscribe.dto.request;
+
+import me.bombom.api.v1.subscribe.dto.UnsubscribePatterns;
+
+public record PlaywrightRequest(
+        String url,
+        UnsubscribePatterns patterns
+) {
+
+    public static PlaywrightRequest of(String url, UnsubscribePatterns patterns) {
+        return new PlaywrightRequest(url, patterns);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/dto/response/PlaywrightResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/dto/response/PlaywrightResponse.java
@@ -1,0 +1,10 @@
+package me.bombom.api.v1.subscribe.dto.response;
+
+public record PlaywrightResponse(
+        Integer statusCode,
+        boolean success,
+        String message,
+        String error,
+        String method
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/dto/response/SubscribedNewsletterResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/dto/response/SubscribedNewsletterResponse.java
@@ -1,0 +1,52 @@
+package me.bombom.api.v1.subscribe.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+import me.bombom.api.v1.subscribe.domain.SubscribeStatus;
+
+public record SubscribedNewsletterResponse(
+
+        @NotNull
+        Long subscriptionId,
+
+        @NotNull
+        Long newsletterId,
+
+        @NotNull
+        String name,
+
+        String imageUrl,
+
+        @NotNull
+        String description,
+
+        @NotNull
+        String category,
+
+        String unsubscribeUrl,
+
+        @NotNull
+        SubscribeStatus status
+) {
+
+    public static SubscribedNewsletterResponse of(
+            Long subscriptionId,
+            Long newsletterId,
+            String name,
+            String imageUrl,
+            String description,
+            String category,
+            String unsubscribeUrl,
+            SubscribeStatus status
+    ) {
+        return new SubscribedNewsletterResponse(
+                subscriptionId,
+                newsletterId,
+                name,
+                imageUrl,
+                description,
+                category,
+                unsubscribeUrl,
+                status
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/event/AutoUnsubscribeCompletedEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/event/AutoUnsubscribeCompletedEvent.java
@@ -1,0 +1,11 @@
+package me.bombom.api.v1.subscribe.event;
+
+public record AutoUnsubscribeCompletedEvent(
+        Long subscribeId,
+        boolean isSuccess
+) {
+
+    public static AutoUnsubscribeCompletedEvent of(Long subscribeId, boolean isSuccess) {
+        return new AutoUnsubscribeCompletedEvent(subscribeId, isSuccess);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/event/AutoUnsubscribeEventListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/event/AutoUnsubscribeEventListener.java
@@ -1,0 +1,37 @@
+package me.bombom.api.v1.subscribe.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.subscribe.service.SubscribeService;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AutoUnsubscribeEventListener {
+
+    private final SubscribeService subscribeService;
+
+    @Async
+    @TransactionalEventListener
+    public void handleUnsubscribeRequested(UnsubscribeRequestedEvent event) {
+        Long subscribeId = event.subscribeId();
+        String unsubscribeUrl = event.unsubscribeUrl();
+        Long newsletterId = event.newsletterId();
+
+        log.info("구독 자동 취소 처리 시작 subscribeId: {}", subscribeId);
+        subscribeService.processUnsubscribe(subscribeId, newsletterId, unsubscribeUrl);
+        log.info("구독 자동 취소 처리 종료 subscribeId: {}", subscribeId);
+    }
+
+    @EventListener
+    public void handleUnsubscribeCompleted(AutoUnsubscribeCompletedEvent event) {
+        Long subscribeId = event.subscribeId();
+        log.info("구독 자동 취소 결과 처리 시작 subscribeId: {}", subscribeId);
+        subscribeService.handleUnsubscribeResult(subscribeId, event.isSuccess());
+        log.info("구독 자동 취소 결과 처리 종료 subscribeId: {}", subscribeId);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/event/UnsubscribeRequestedEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/event/UnsubscribeRequestedEvent.java
@@ -1,0 +1,17 @@
+package me.bombom.api.v1.subscribe.event;
+
+public record UnsubscribeRequestedEvent(
+
+        Long subscribeId,
+        String unsubscribeUrl,
+        Long newsletterId
+) {
+
+    public static UnsubscribeRequestedEvent of (
+            Long subscribeId,
+            String unsubscribeUrl,
+            Long newsletterId
+    ) {
+        return new UnsubscribeRequestedEvent(subscribeId, unsubscribeUrl, newsletterId);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/exception/AutoUnsubscribeFailedException.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/exception/AutoUnsubscribeFailedException.java
@@ -1,0 +1,29 @@
+package me.bombom.api.v1.subscribe.exception;
+
+import lombok.Getter;
+
+/**
+ * 구독 자동 취소 실패 예외
+ * 
+ * 다음 케이스에서 발생:
+ * - 버튼/링크를 찾지 못함 (패턴 불일치)
+ * - 에러 다이얼로그 감지 (사이트 에러)
+ * - HTTP 4xx 클라이언트 에러
+ * 
+ * 재시도 불가. 디스코드 알림 후 사용자에게 수동 취소 안내.
+ * 
+ * 참고: "시스템 점검 중" 등 일시적 에러도 포함될 수 있으나,
+ * 자동 구분이 불가능하므로 수동 개입으로 처리.
+ */
+@Getter
+public class AutoUnsubscribeFailedException extends RuntimeException {
+
+    private final Long newsletterId;
+    private final String url;
+
+    public AutoUnsubscribeFailedException(String message, Long newsletterId, String url) {
+        super(message);
+        this.newsletterId = newsletterId;
+        this.url = url;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/repository/SubscribeRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/repository/SubscribeRepository.java
@@ -2,7 +2,7 @@ package me.bombom.api.v1.subscribe.repository;
 
 import java.util.List;
 import me.bombom.api.v1.subscribe.domain.Subscribe;
-import me.bombom.api.v1.subscribe.dto.SubscribedNewsletterResponse;
+import me.bombom.api.v1.subscribe.dto.response.SubscribedNewsletterResponse;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -11,9 +11,15 @@ import org.springframework.data.repository.query.Param;
 public interface SubscribeRepository extends JpaRepository<Subscribe, Long> {
 
     @Query("""
-        SELECT new me.bombom.api.v1.subscribe.dto.SubscribedNewsletterResponse(
-            s.id, n.id, n.name, n.imageUrl, n.description, c.name,
-            CASE WHEN s.unsubscribeUrl IS NOT NULL AND s.unsubscribeUrl <> '' THEN true ELSE false END
+        SELECT new me.bombom.api.v1.subscribe.dto.response.SubscribedNewsletterResponse(
+            s.id,
+            n.id,
+            n.name,
+            n.imageUrl,
+            n.description,
+            c.name,
+            s.unsubscribeUrl,
+            s.status
         )
         FROM Subscribe s
         JOIN Newsletter n ON s.newsletterId = n.id

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/repository/SubscribeRetryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/repository/SubscribeRetryRepository.java
@@ -1,0 +1,25 @@
+package me.bombom.api.v1.subscribe.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import me.bombom.api.v1.subscribe.domain.SubscribeRetry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SubscribeRetryRepository extends JpaRepository<SubscribeRetry, Long> {
+    Optional<SubscribeRetry> findBySubscribeId(Long subscribeId);
+
+    @Query(value = """
+            SELECT sr
+            FROM SubscribeRetry sr
+            WHERE sr.nextRetryAt < :now
+            ORDER BY sr.nextRetryAt
+            LIMIT :limit
+    """)
+    List<SubscribeRetry> findPendingRetries(
+            @Param("now") LocalDateTime now,
+            @Param("limit") int limit
+    );
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/scheduler/SubscribeRetryScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/scheduler/SubscribeRetryScheduler.java
@@ -1,0 +1,45 @@
+package me.bombom.api.v1.subscribe.scheduler;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.subscribe.domain.SubscribeRetry;
+import me.bombom.api.v1.subscribe.service.SubscribeRetryService;
+import me.bombom.api.v1.subscribe.service.SubscribeService;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SubscribeRetryScheduler {
+
+    public static final int RETRY_INTERVAL_MS = 300000; // 5분
+    private static final int RETRY_BATCH_SIZE = 10;
+
+    private final SubscribeService subscribeService;
+    private final SubscribeRetryService subscribeRetryService;
+
+    @Scheduled(fixedDelay = RETRY_INTERVAL_MS)
+    @SchedulerLock(name = "retryUnsubscribe", lockAtLeastFor = "30s", lockAtMostFor = "4m")
+    public void retryUnsubscribe() {
+        List<SubscribeRetry> retries = subscribeRetryService.findPendingRetries(RETRY_BATCH_SIZE);
+        if (!retries.isEmpty()) {
+            log.info("재시도 대상 {}건 발견. 처리를 시작합니다.", retries.size());
+        }
+
+        for (SubscribeRetry retry : retries) {
+            try {
+                processRetry(retry);
+            } catch (Exception e) {
+                log.error("재시도 처리 중 알 수 없는 오류 발생 - retryId: {}", retry.getId(), e);
+            }
+        }
+    }
+
+    private void processRetry(SubscribeRetry retry) {
+        log.info("구독 취소 재시도 실행 - subscribeId: {}, retryCount: {}", retry.getSubscribeId(), retry.getRetryCount());
+        subscribeService.retryUnsubscribe(retry.getSubscribeId());
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/service/SubscribeRetryService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/service/SubscribeRetryService.java
@@ -1,0 +1,67 @@
+package me.bombom.api.v1.subscribe.service;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.subscribe.domain.SubscribeRetry;
+import me.bombom.api.v1.subscribe.repository.SubscribeRetryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SubscribeRetryService {
+
+    private final SubscribeRetryRepository subscribeRetryRepository;
+    private final Clock clock;
+
+    @Transactional
+    public boolean scheduleRetry(Long subscribeId, String errorMsg) {
+        Optional<SubscribeRetry> existingRetry = subscribeRetryRepository.findBySubscribeId(subscribeId);
+        LocalDateTime now = LocalDateTime.now(clock);
+
+        if (existingRetry.isEmpty()) {
+            SubscribeRetry newRetry = SubscribeRetry.builder()
+                    .subscribeId(subscribeId)
+                    .nextRetryAt(now)
+                    .lastError(errorMsg)
+                    .build();
+            newRetry.increaseRetryCount(now, errorMsg);
+            subscribeRetryRepository.save(newRetry);
+
+            log.info("구독 취소 {}번째 재시도 예약 - subscribeId: {}, next: {}", newRetry.getRetryCount(), subscribeId, newRetry.getNextRetryAt());
+            return true;
+        }
+
+        SubscribeRetry retry = existingRetry.get();
+        if (retry.isMaxRetryReached()) {
+            log.error("구독 취소 재시도 횟수 초과 - subscribeId: {}", subscribeId);
+            subscribeRetryRepository.delete(retry);
+            return false;
+        }
+
+        retry.increaseRetryCount(now, errorMsg);
+        log.info("구독 취소 {}번째 재시도 예약 - subscribeId: {}, next: {}", retry.getRetryCount(), subscribeId, retry.getNextRetryAt());
+        return true;
+    }
+
+    @Transactional
+    public void deleteIfExists(Long subscribeId) {
+        subscribeRetryRepository.findBySubscribeId(subscribeId)
+                .ifPresent(subscribeRetryRepository::delete);
+    }
+
+    @Transactional
+    public void delete(SubscribeRetry retry) {
+        subscribeRetryRepository.delete(retry);
+    }
+
+    public List<SubscribeRetry> findPendingRetries(int limit) {
+        return subscribeRetryRepository.findPendingRetries(LocalDateTime.now(clock), limit);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/service/SubscribeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/service/SubscribeService.java
@@ -1,17 +1,24 @@
 package me.bombom.api.v1.subscribe.service;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.common.DiscordWebhookNotifier;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.common.exception.RetryableException;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.subscribe.domain.Subscribe;
-import me.bombom.api.v1.subscribe.dto.UnsubscribeResponse;
-import me.bombom.api.v1.subscribe.dto.SubscribedNewsletterResponse;
+import me.bombom.api.v1.subscribe.domain.SubscribeStatus;
+import me.bombom.api.v1.subscribe.dto.response.SubscribedNewsletterResponse;
+import me.bombom.api.v1.subscribe.event.AutoUnsubscribeCompletedEvent;
+import me.bombom.api.v1.subscribe.event.UnsubscribeRequestedEvent;
+import me.bombom.api.v1.subscribe.exception.AutoUnsubscribeFailedException;
 import me.bombom.api.v1.subscribe.repository.SubscribeRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +30,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class SubscribeService {
 
     private final SubscribeRepository subscribeRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
+    private final UnsubscribeAgent unsubscribeAgent;
+    private final DiscordWebhookNotifier discordNotifier;
+    private final SubscribeRetryService subscribeRetryService;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void deleteAllByMemberId(Long memberId) {
@@ -34,7 +45,7 @@ public class SubscribeService {
     }
 
     @Transactional
-    public UnsubscribeResponse unsubscribe(Long memberId, Long subscribeId) {
+    public void unsubscribe(Long memberId, Long subscribeId) {
         Subscribe subscribe = subscribeRepository.findById(subscribeId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "subscribe")
@@ -43,15 +54,83 @@ public class SubscribeService {
 
         if (subscribe.isNotOwner(memberId)) {
             throw new UnauthorizedException(ErrorDetail.FORBIDDEN_RESOURCE)
-                .addContext(ErrorContextKeys.ENTITY_TYPE, "subscribe")
-                .addContext(ErrorContextKeys.MEMBER_ID, memberId)
-                .addContext(ErrorContextKeys.ACTUAL_OWNER_ID, subscribe.getMemberId())
-                .addContext("subscribeId", subscribeId);
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "subscribe")
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.ACTUAL_OWNER_ID, subscribe.getMemberId())
+                    .addContext("subscribeId", subscribeId);
         }
 
-        String unsubscribeUrl = subscribe.getUnsubscribeUrl();
-        subscribeRepository.delete(subscribe);
+        // 자동 취소가 불가능한 경우 사용자가 직접 구독 취소 유도 후 삭제 버튼 클릭
+        if (subscribe.isFailed()) {
+            log.info("구독 취소 실패 상태인 항목 강제 삭제 subscribeId: {}", subscribeId);
+            subscribeRepository.delete(subscribe);
+            return;
+        }
 
-        return UnsubscribeResponse.of(unsubscribeUrl);
+        // 구독 취소 이미 진행 중
+        if (subscribe.isUnsubscribing()) {
+            return;
+        }
+
+        subscribe.changeStatus(SubscribeStatus.UNSUBSCRIBING);
+        applicationEventPublisher.publishEvent(UnsubscribeRequestedEvent.of(
+                subscribe.getId(),
+                subscribe.getUnsubscribeUrl(),
+                subscribe.getNewsletterId()));
+    }
+
+    @Transactional
+    public void handleUnsubscribeResult(Long subscribeId, boolean isSuccess) {
+        if (isSuccess) {
+            subscribeRepository.deleteById(subscribeId);
+            return;
+        }
+
+        Subscribe subscribe = subscribeRepository.findById(subscribeId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "subscribe")
+                        .addContext("subscribeId", subscribeId));
+        subscribe.changeStatus(SubscribeStatus.UNSUBSCRIBE_FAILED);
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void processUnsubscribe(Long subscribeId, Long newsletterId, String unsubscribeUrl) {
+        try {
+            unsubscribeAgent.unsubscribe(unsubscribeUrl, newsletterId);
+            applicationEventPublisher.publishEvent(AutoUnsubscribeCompletedEvent.of(subscribeId, true));
+            subscribeRetryService.deleteIfExists(subscribeId);
+        } catch (RetryableException e) {
+            handleRetryableFailure(subscribeId, newsletterId, unsubscribeUrl, e.getMessage());
+        } catch (AutoUnsubscribeFailedException e) {
+            handlePermanentFailure(subscribeId, newsletterId, unsubscribeUrl, e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 예외가 발생했습니다.", e);
+        }
+    }
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void retryUnsubscribe(Long subscribeId) {
+        Optional<Subscribe> subscribeOpt = subscribeRepository.findById(subscribeId);
+        if (subscribeOpt.isEmpty()) {
+            log.warn("구독 정보가 존재하지 않아 재시도 항목 삭제 - subscribeId: {}", subscribeId);
+            subscribeRetryService.deleteIfExists(subscribeId);
+            return;
+        }
+
+        Subscribe subscribe = subscribeOpt.get();
+        processUnsubscribe(subscribe.getId(), subscribe.getNewsletterId(), subscribe.getUnsubscribeUrl());
+    }
+
+    private void handleRetryableFailure(Long subscribeId, Long newsletterId, String url, String errorMsg) {
+        boolean scheduled = subscribeRetryService.scheduleRetry(subscribeId, errorMsg);
+        if (!scheduled) {
+            handlePermanentFailure(subscribeId, newsletterId, url, "최대 재시도 횟수에 도달했습니다 : " + errorMsg);
+        }
+    }
+
+    private void handlePermanentFailure(Long subscribeId, Long newsletterId, String url, String errorMsg) {
+        subscribeRetryService.deleteIfExists(subscribeId);
+        applicationEventPublisher.publishEvent(AutoUnsubscribeCompletedEvent.of(subscribeId, false));
+        discordNotifier.sendUnsubscribeErrorNotification(errorMsg, newsletterId, url, subscribeId);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/service/UnsubscribeAgent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/service/UnsubscribeAgent.java
@@ -1,0 +1,53 @@
+package me.bombom.api.v1.subscribe.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.common.exception.RetryableException;
+import me.bombom.api.v1.subscribe.client.PlaywrightClient;
+import me.bombom.api.v1.subscribe.config.SubscribePatternProperties;
+import me.bombom.api.v1.subscribe.dto.UnsubscribePatterns;
+import me.bombom.api.v1.subscribe.dto.response.PlaywrightResponse;
+import me.bombom.api.v1.subscribe.exception.AutoUnsubscribeFailedException;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Transactional(propagation = Propagation.NEVER)
+public class UnsubscribeAgent {
+
+    private final PlaywrightClient playwrightClient;
+    private final SubscribePatternProperties properties;
+
+    public void unsubscribe(String url, Long newsletterId) {
+        UnsubscribePatterns patterns = new UnsubscribePatterns(
+                properties.getUnsubscribePattern().pattern(),
+                properties.getSuccessPattern().pattern(),
+                properties.getAlreadyUnsubscribedPattern().pattern(),
+                properties.getErrorPattern().pattern()
+        );
+
+        PlaywrightResponse response = playwrightClient.executeUnsubscribe(url, patterns);
+
+        if (response.success()) {
+            log.info("구독 취소 성공 - newsletterId: {}, method: {}", newsletterId, response.method());
+        } else {
+            String errorMsg = StringUtils.hasText(response.error()) ? response.error() : response.message();
+            Integer statusCode = response.statusCode();
+            log.warn("구독 취소 실패 - newsletterId: {}, status: {}, error: {}", newsletterId, statusCode, errorMsg);
+
+            if (isRetryableError(statusCode)) {
+                throw new RetryableException(errorMsg);
+            }
+
+            throw new AutoUnsubscribeFailedException(errorMsg, newsletterId, url);
+        }
+    }
+
+    private boolean isRetryableError(Integer statusCode) {
+        return statusCode != null && statusCode >= 500;
+    }
+}

--- a/backend/bom-bom-server/src/main/resources/db/migration/V20.1.0__add_subscribe_status.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V20.1.0__add_subscribe_status.sql
@@ -1,0 +1,5 @@
+-- status 컬럼 추가 (기본값: SUBSCRIBED)
+ALTER TABLE subscribe ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'SUBSCRIBED';
+
+-- 기존 데이터 명시적 업데이트
+UPDATE subscribe SET status = 'SUBSCRIBED' WHERE status IS NULL OR status = '';

--- a/backend/bom-bom-server/src/main/resources/db/migration/V20.2.0__create_subscribe_retry_table.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V20.2.0__create_subscribe_retry_table.sql
@@ -1,0 +1,12 @@
+CREATE TABLE subscribe_retry (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    subscribe_id BIGINT NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    next_retry_at DATETIME(6) NOT NULL,
+    last_error VARCHAR(255),
+    created_at DATETIME(6) NOT NULL,
+    modified_at DATETIME(6) NOT NULL,
+    CONSTRAINT uk_subscribe_retry_subscribe_id UNIQUE (subscribe_id)
+);
+
+CREATE INDEX idx_subscribe_retry_next_retry_at ON subscribe_retry (next_retry_at);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
@@ -1,9 +1,9 @@
 package me.bombom.api.v1.subscribe.controller;
 
-import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -12,13 +12,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.enums.Gender;
-import me.bombom.api.v1.member.repository.MemberRepository;
-import me.bombom.api.v1.subscribe.dto.UnsubscribeResponse;
 import me.bombom.api.v1.subscribe.service.SubscribeService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -40,92 +37,82 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @AutoConfigureMockMvc
 @WebMvcTest(controllers = SubscribeController.class)
-@Import({SubscribeController.class, SubscribeControllerTest.TestConfig.class})
+@Import({ SubscribeController.class, SubscribeControllerTest.TestConfig.class })
 class SubscribeControllerTest {
 
-    @Configuration
-    @EnableWebSecurity
-    static class TestConfig implements WebMvcConfigurer {
+        @Configuration
+        @EnableWebSecurity
+        static class TestConfig implements WebMvcConfigurer {
+
+                @Bean
+                public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+                        return http
+                                        .csrf(AbstractHttpConfigurer::disable)
+                                        .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+                                        .exceptionHandling(ex -> ex
+                                                        .authenticationEntryPoint((request, response,
+                                                                        authException) -> response.sendError(
+                                                                                        HttpServletResponse.SC_UNAUTHORIZED)))
+                                        .build();
+                }
+
+                @Override
+                public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+                        resolvers.add(new LoginMemberArgumentResolver());
+                }
+        }
 
         @Autowired
-        private MemberRepository memberRepository;
+        MockMvc mockMvc;
 
-        @Bean
-        public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-            return http
-                    .csrf(AbstractHttpConfigurer::disable)
-                    .authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
-                    .exceptionHandling(ex -> ex
-                            .authenticationEntryPoint((request, response,
-                                                       authException) -> response.sendError(
-                                    HttpServletResponse.SC_UNAUTHORIZED)))
-                    .build();
+        @MockitoBean
+        SubscribeService subscribeService;
+
+        private OAuth2AuthenticationToken authToken;
+
+        @BeforeEach
+        void setUp() {
+                Member member = Member.builder()
+                                .id(1L)
+                                .provider("apple")
+                                .providerId("providerId")
+                                .email("email@bombom.news")
+                                .nickname("nickname")
+                                .gender(Gender.FEMALE)
+                                .roleId(1L)
+                                .build();
+
+                Map<String, Object> attrs = Map.of(
+                                "id", "1",
+                                "email", "email@bombom.news",
+                                "name", "nickname");
+
+                CustomOAuth2User user = new CustomOAuth2User(attrs, member, null, null);
+                authToken = new OAuth2AuthenticationToken(user, user.getAuthorities(), "registrationId");
         }
 
-        @Override
-        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-            resolvers.add(new LoginMemberArgumentResolver(memberRepository));
+        @Test
+        void 인증된_사용자는_구독_목록을_조회할_수_있다() throws Exception {
+                given(subscribeService.getSubscribedNewsletters(any(Member.class)))
+                                .willReturn(List.of());
+
+                mockMvc.perform(get("/api/v1/members/me/subscriptions")
+                                .with(authentication(authToken)))
+                                .andExpect(status().isOk());
         }
-    }
 
-    @Autowired
-    MockMvc mockMvc;
+        @Test
+        void 인증되지_않은_사용자는_403을_반환한다() throws Exception {
+                mockMvc.perform(get("/api/v1/members/me/subscriptions"))
+                                .andExpect(status().isUnauthorized());
+        }
 
-    @MockitoBean
-    SubscribeService subscribeService;
+        @Test
+        void 인증된_사용자는_구독_취소를_요청할_수_있다() throws Exception {
+                doNothing().when(subscribeService).unsubscribe(anyLong(), anyLong());
 
-    @MockitoBean
-    MemberRepository memberRepository;
-
-    private OAuth2AuthenticationToken authToken;
-
-    @BeforeEach
-    void setUp() {
-        Member member = Member.builder()
-                .id(1L)
-                .provider("apple")
-                .providerId("providerId")
-                .email("email@bombom.news")
-                .nickname("nickname")
-                .gender(Gender.FEMALE)
-                .roleId(1L)
-                .build();
-
-        given(memberRepository.findById(member.getId())).willReturn(Optional.of(member));
-
-        Map<String, Object> attrs = Map.of(
-                "id", "1",
-                "email", "email@bombom.news",
-                "name", "nickname"
-        );
-
-        CustomOAuth2User user = new CustomOAuth2User(attrs, member, null, null);
-        authToken = new OAuth2AuthenticationToken(user, user.getAuthorities(), "registrationId");
-    }
-
-    @Test
-    void 인증된_사용자는_구독_목록을_조회할_수_있다() throws Exception {
-        given(subscribeService.getSubscribedNewsletters(any(Member.class)))
-                .willReturn(List.of());
-
-        mockMvc.perform(get("/api/v1/members/me/subscriptions")
-                        .with(authentication(authToken)))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    void 인증되지_않은_사용자는_403을_반환한다() throws Exception {
-        mockMvc.perform(get("/api/v1/members/me/subscriptions"))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void 인증된_사용자는_구독_취소를_요청할_수_있다() throws Exception {
-        given(subscribeService.unsubscribe(anyLong(), anyLong()))
-                .willReturn(UnsubscribeResponse.of(null));
-
-        mockMvc.perform(post("/api/v1/members/me/subscriptions/{id}/unsubscribe", 1L)
-                        .with(authentication(authToken)))
-                .andExpect(status().isOk());
-    }
+                mockMvc.perform(post("/api/v1/members/me/subscriptions/{id}/unsubscribe", 1L)
+                                .with(authentication(authToken)))
+                                .andExpect(status().isOk());
+        }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/service/SubscribeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/service/SubscribeServiceTest.java
@@ -2,10 +2,19 @@ package me.bombom.api.v1.subscribe.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.common.DiscordWebhookNotifier;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.RetryableException;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
@@ -16,15 +25,16 @@ import me.bombom.api.v1.newsletter.repository.CategoryRepository;
 import me.bombom.api.v1.newsletter.repository.NewsletterDetailRepository;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
 import me.bombom.api.v1.subscribe.domain.Subscribe;
-import me.bombom.api.v1.subscribe.dto.UnsubscribeResponse;
-import me.bombom.api.v1.subscribe.dto.SubscribedNewsletterResponse;
+import me.bombom.api.v1.subscribe.domain.SubscribeStatus;
+import me.bombom.api.v1.subscribe.dto.response.SubscribedNewsletterResponse;
+import me.bombom.api.v1.subscribe.exception.AutoUnsubscribeFailedException;
 import me.bombom.api.v1.subscribe.repository.SubscribeRepository;
 import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
-@Transactional
 @IntegrationTest
 class SubscribeServiceTest {
 
@@ -42,8 +52,27 @@ class SubscribeServiceTest {
 
     @Autowired
     private SubscribeRepository subscribeRepository;
+
     @Autowired
     private NewsletterDetailRepository newsletterDetailRepository;
+
+    @MockitoBean
+    private UnsubscribeAgent unsubscribeAgent;
+
+    @MockitoBean
+    private DiscordWebhookNotifier discordNotifier;
+
+    @MockitoBean
+    private SubscribeRetryService subscribeRetryService;
+
+    @AfterEach
+    void tearDown() {
+        subscribeRepository.deleteAllInBatch();
+        newsletterRepository.deleteAllInBatch();
+        newsletterDetailRepository.deleteAllInBatch();
+        categoryRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
 
     @Test
     void 구독중인_뉴스레터를_조회한다() {
@@ -69,8 +98,8 @@ class SubscribeServiceTest {
 
         // then
         assertThat(result).hasSize(2)
-            .extracting("name")
-            .containsExactlyInAnyOrder(newsletters.getFirst().getName(), newsletters.getLast().getName());
+                .extracting("name")
+                .containsExactlyInAnyOrder(newsletters.getFirst().getName(), newsletters.getLast().getName());
     }
 
     @Test
@@ -82,17 +111,18 @@ class SubscribeServiceTest {
         Category category = categoryRepository.save(TestFixture.createCategory());
         NewsletterDetail newsletterDetail = newsletterDetailRepository.save(TestFixture.createNewsletterDetail(true));
         Newsletter newsletter = newsletterRepository.save(
-            TestFixture.createNewsletter("테스트 뉴스레터", "test@test.com", category.getId(), newsletterDetail.getId()));
+                TestFixture.createNewsletter("테스트 뉴스레터", "test@test.com", category.getId(), newsletterDetail.getId()));
         Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
-            .memberId(member.getId())
-            .newsletterId(newsletter.getId())
-            .build());
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .build());
 
         // when
-        UnsubscribeResponse response = subscribeService.unsubscribe(member.getId(), subscribe.getId());
+        subscribeService.unsubscribe(member.getId(), subscribe.getId());
 
         // then
-        assertThat(subscribeRepository.findById(subscribe.getId())).isEmpty();
+        Subscribe result = subscribeRepository.findById(subscribe.getId()).orElseThrow();
+        assertThat(result.getStatus()).isEqualTo(me.bombom.api.v1.subscribe.domain.SubscribeStatus.UNSUBSCRIBING);
     }
 
     @Test
@@ -107,15 +137,15 @@ class SubscribeServiceTest {
         Category category = categoryRepository.save(TestFixture.createCategory());
         NewsletterDetail newsletterDetail = newsletterDetailRepository.save(TestFixture.createNewsletterDetail(true));
         Newsletter newsletter = newsletterRepository.save(
-            TestFixture.createNewsletter("테스트 뉴스레터", "test@test.com", category.getId(), newsletterDetail.getId()));
+                TestFixture.createNewsletter("테스트 뉴스레터", "test@test.com", category.getId(), newsletterDetail.getId()));
         Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
-            .memberId(otherMember.getId())
-            .newsletterId(newsletter.getId())
-            .build());
+                .memberId(otherMember.getId())
+                .newsletterId(newsletter.getId())
+                .build());
 
         // when & then
         assertThatThrownBy(() -> subscribeService.unsubscribe(member.getId(), subscribe.getId()))
-            .isInstanceOf(UnauthorizedException.class);
+                .isInstanceOf(UnauthorizedException.class);
     }
 
     @Test
@@ -126,7 +156,7 @@ class SubscribeServiceTest {
 
         // when & then
         assertThatThrownBy(() -> subscribeService.unsubscribe(member.getId(), 999L))
-            .isInstanceOf(CIllegalArgumentException.class);
+                .isInstanceOf(CIllegalArgumentException.class);
     }
 
     @Test
@@ -138,19 +168,276 @@ class SubscribeServiceTest {
         Category category = categoryRepository.save(TestFixture.createCategory());
         NewsletterDetail newsletterDetail = newsletterDetailRepository.save(TestFixture.createNewsletterDetail(true));
         Newsletter newsletter = newsletterRepository.save(
-            TestFixture.createNewsletter("테스트 뉴스레터", "test@test.com", category.getId(), newsletterDetail.getId()));
-        String expectedUnsubscribeUrl = "https://example.com/unsubscribe";
+                TestFixture.createNewsletter(
+                        "테스트 뉴스레터",
+                        "test@test.com",
+                        category.getId(),
+                        newsletterDetail.getId()
+                )
+        );
+        String unsubscribeUrl = "https://example.com/unsubscribe";
         Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
-            .memberId(member.getId())
-            .newsletterId(newsletter.getId())
-            .unsubscribeUrl(expectedUnsubscribeUrl)
-            .build());
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .unsubscribeUrl(unsubscribeUrl)
+                .build()
+        );
 
         // when
-        UnsubscribeResponse response = subscribeService.unsubscribe(member.getId(), subscribe.getId());
+        subscribeService.unsubscribe(member.getId(), subscribe.getId());
+
+        // then
+        Subscribe result = subscribeRepository.findById(subscribe.getId()).orElseThrow();
+        assertThat(result.getStatus()).isEqualTo(SubscribeStatus.UNSUBSCRIBING);
+    }
+
+    @Test
+    void FAILED_상태의_구독을_취소하면_강제_삭제된다() {
+        // given
+        Member member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        Category category = categoryRepository.save(TestFixture.createCategory());
+        NewsletterDetail newsletterDetail = newsletterDetailRepository.save(TestFixture.createNewsletterDetail(true));
+        Newsletter newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter(
+                        "테스트 뉴스레터",
+                        "test@test.com",
+                        category.getId(),
+                        newsletterDetail.getId()
+                )
+        );
+
+        Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .build()
+        );
+
+        // FAILED 상태로 변경
+        subscribe.changeStatus(me.bombom.api.v1.subscribe.domain.SubscribeStatus.UNSUBSCRIBE_FAILED);
+        subscribeRepository.save(subscribe);
+
+        // when
+        subscribeService.unsubscribe(member.getId(), subscribe.getId());
 
         // then
         assertThat(subscribeRepository.findById(subscribe.getId())).isEmpty();
-        assertThat(response.unsubscribeUrl()).isEqualTo(expectedUnsubscribeUrl);
+    }
+
+    @Test
+    void UNSUBSCRIBING_상태의_구독을_취소하면_중복_방지로_응답만_반환한다() {
+        // given
+        Member member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        Category category = categoryRepository.save(TestFixture.createCategory());
+        NewsletterDetail newsletterDetail = newsletterDetailRepository.save(TestFixture.createNewsletterDetail(true));
+        Newsletter newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter(
+                        "테스트 뉴스레터",
+                        "test@test.com",
+                        category.getId(),
+                        newsletterDetail.getId())
+        );
+
+        String unsubscribeUrl = "https://example.com/unsubscribe";
+        Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .unsubscribeUrl(unsubscribeUrl)
+                .build()
+        );
+
+        // UNSUBSCRIBING 상태로 변경
+        subscribe.changeStatus(SubscribeStatus.UNSUBSCRIBING);
+        subscribeRepository.save(subscribe);
+
+        // when
+        subscribeService.unsubscribe(member.getId(), subscribe.getId());
+
+        // then
+        assertThat(subscribeRepository.findById(subscribe.getId())).isPresent();
+    }
+
+    @Test
+    void SUBSCRIBED_상태의_구독을_취소하면_UNSUBSCRIBING_상태로_변경된다() {
+        // given
+        Member member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        Category category = categoryRepository.save(TestFixture.createCategory());
+        NewsletterDetail newsletterDetail = newsletterDetailRepository.save(TestFixture.createNewsletterDetail(true));
+        Newsletter newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter(
+                        "테스트 뉴스레터",
+                        "test@test.com",
+                        category.getId(),
+                        newsletterDetail.getId())
+        );
+
+        Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .build()
+        );
+
+        // when
+        subscribeService.unsubscribe(member.getId(), subscribe.getId());
+
+        // then
+        Subscribe result = subscribeRepository.findById(subscribe.getId()).orElseThrow();
+        assertThat(result.getStatus()).isEqualTo(SubscribeStatus.UNSUBSCRIBING);
+    }
+
+    @Test
+    void handleUnsubscribeResult_성공시_구독을_삭제한다() {
+        // given
+        Member member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        Category category = categoryRepository.save(TestFixture.createCategory());
+        NewsletterDetail newsletterDetail = newsletterDetailRepository.save(TestFixture.createNewsletterDetail(true));
+        Newsletter newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter(
+                        "테스트 뉴스레터",
+                        "test@test.com",
+                        category.getId(),
+                        newsletterDetail.getId()
+                )
+        );
+
+        Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .build()
+        );
+
+        // when
+        subscribeService.handleUnsubscribeResult(subscribe.getId(), true);
+
+        // then
+        assertThat(subscribeRepository.findById(subscribe.getId())).isEmpty();
+    }
+
+    @Test
+    void handleUnsubscribeResult_실패시_FAILED_상태로_변경한다() {
+        // given
+        Member member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        Category category = categoryRepository.save(TestFixture.createCategory());
+        NewsletterDetail newsletterDetail = newsletterDetailRepository.save(TestFixture.createNewsletterDetail(true));
+        Newsletter newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter(
+                        "테스트 뉴스레터",
+                        "test@test.com",
+                        category.getId(),
+                        newsletterDetail.getId())
+        );
+
+        Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .build()
+        );
+
+        // when
+        subscribeService.handleUnsubscribeResult(subscribe.getId(), false);
+
+        // then
+        Subscribe result = subscribeRepository.findById(subscribe.getId()).orElseThrow();
+        assertThat(result.getStatus()).isEqualTo(me.bombom.api.v1.subscribe.domain.SubscribeStatus.UNSUBSCRIBE_FAILED);
+    }
+
+    @Test
+    void 구독_해지_성공_시_람다를_호출하고_완료_처리한다() {
+        // given
+        Member member = memberRepository.save(TestFixture.normalMemberFixture());
+        Category category = categoryRepository.save(TestFixture.createCategory());
+        NewsletterDetail newsletterDetail = newsletterDetailRepository
+                .save(TestFixture.createNewsletterDetail(true));
+        Newsletter newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter("테스트 뉴스레터", "test@test.com", category.getId(),
+                        newsletterDetail.getId()));
+        Subscribe s = subscribeRepository.save(Subscribe.builder()
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .build());
+
+        Long subscribeId = s.getId();
+        Long newsletterId = newsletter.getId();
+        String unsubscribeUrl = "https://example.com/unsub";
+
+        // when
+        subscribeService.processUnsubscribe(subscribeId, newsletterId, unsubscribeUrl);
+
+        // then
+        verify(unsubscribeAgent, times(1)).unsubscribe(unsubscribeUrl, newsletterId);
+        verify(subscribeRetryService, times(1)).deleteIfExists(subscribeId);
+        assertThat(subscribeRepository.findById(subscribeId)).isEmpty();
+    }
+
+    @Test
+    void 재시도_가능_에러_발생_시_재시도를_스케줄링한다() {
+        // given
+        Member member = memberRepository.save(TestFixture.normalMemberFixture());
+        Category category = categoryRepository.save(TestFixture.createCategory());
+        NewsletterDetail newsletterDetail = newsletterDetailRepository
+                .save(TestFixture.createNewsletterDetail(true));
+        Newsletter newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter("테스트 뉴스레터", "test@test.com", category.getId(),
+                        newsletterDetail.getId()));
+        Subscribe s = subscribeRepository.save(Subscribe.builder()
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .build());
+
+        Long subscribeId = s.getId();
+        Long newsletterId = newsletter.getId();
+        String unsubscribeUrl = "https://example.com/unsub";
+        doThrow(new RetryableException("Server Error"))
+                .when(unsubscribeAgent).unsubscribe(anyString(), anyLong());
+        given(subscribeRetryService.scheduleRetry(anyLong(), anyString())).willReturn(true);
+
+        // when
+        subscribeService.processUnsubscribe(subscribeId, newsletterId, unsubscribeUrl);
+
+        // then
+        verify(subscribeRetryService, times(1)).scheduleRetry(eq(subscribeId), eq("Server Error"));
+    }
+
+    @Test
+    void 영구_실패_에러_발생_시_알림을_보낸다() {
+        // given
+        Member member = memberRepository.save(TestFixture.normalMemberFixture());
+        Category category = categoryRepository.save(TestFixture.createCategory());
+        NewsletterDetail newsletterDetail = newsletterDetailRepository
+                .save(TestFixture.createNewsletterDetail(true));
+        Newsletter newsletter = newsletterRepository.save(
+                TestFixture.createNewsletter("테스트 뉴스레터", "test@test.com", category.getId(),
+                        newsletterDetail.getId()));
+        Subscribe s = subscribeRepository.save(Subscribe.builder()
+                .memberId(member.getId())
+                .newsletterId(newsletter.getId())
+                .build());
+
+        Long subscribeId = s.getId();
+        Long newsletterId = newsletter.getId();
+        String unsubscribeUrl = "https://example.com/unsub";
+        doThrow(new AutoUnsubscribeFailedException("Invalid URL", newsletterId, unsubscribeUrl))
+                .when(unsubscribeAgent).unsubscribe(anyString(), anyLong());
+
+        // when
+        subscribeService.processUnsubscribe(subscribeId, newsletterId, unsubscribeUrl);
+
+        // then
+        verify(discordNotifier, times(1))
+                .sendUnsubscribeErrorNotification(eq("Invalid URL"), eq(newsletterId),
+                        eq(unsubscribeUrl),
+                        eq(subscribeId));
+
+        Subscribe result = subscribeRepository.findById(subscribeId).orElseThrow();
+        assertThat(result.getStatus()).isEqualTo(SubscribeStatus.UNSUBSCRIBE_FAILED);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/service/UnsubscribeAgentTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/service/UnsubscribeAgentTest.java
@@ -1,0 +1,93 @@
+package me.bombom.api.v1.subscribe.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import java.util.regex.Pattern;
+import me.bombom.api.v1.common.exception.RetryableException;
+import me.bombom.api.v1.subscribe.client.PlaywrightClient;
+import me.bombom.api.v1.subscribe.config.SubscribePatternProperties;
+import me.bombom.api.v1.subscribe.dto.UnsubscribePatterns;
+import me.bombom.api.v1.subscribe.dto.response.PlaywrightResponse;
+import me.bombom.api.v1.subscribe.exception.AutoUnsubscribeFailedException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UnsubscribeAgentTest {
+
+    private static final long MOCK_NEWSLETTER_ID = 1L;
+    private static final String MOCK_URL = "https://example.com/unsubscribe";
+
+    @Mock
+    private PlaywrightClient playwrightClient;
+
+    @Mock
+    private SubscribePatternProperties properties;
+
+    @InjectMocks
+    private UnsubscribeAgent agent;
+
+    @BeforeEach
+    void setUp() {
+        given(properties.getUnsubscribePattern()).willReturn(Pattern.compile("unsub"));
+        given(properties.getSuccessPattern()).willReturn(Pattern.compile("success"));
+        given(properties.getAlreadyUnsubscribedPattern()).willReturn(Pattern.compile("already"));
+        given(properties.getErrorPattern()).willReturn(Pattern.compile("error"));
+    }
+
+    @Test
+    @DisplayName("구독 취소 성공 시 예외가 발생하지 않는다")
+    void 구독_취소_성공() {
+        // given
+        given(playwrightClient.executeUnsubscribe(eq(MOCK_URL), any(UnsubscribePatterns.class)))
+                .willReturn(new PlaywrightResponse(200, true, "Success", null, "text_match"));
+
+        // when & then
+        assertThatCode(() -> agent.unsubscribe(MOCK_URL, MOCK_NEWSLETTER_ID))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("5xx 에러 발생 시 RetryableException을 발생시킨다")
+    void 구독_취소_재시도_가능한_에러() {
+        // given
+        given(playwrightClient.executeUnsubscribe(eq(MOCK_URL), any(UnsubscribePatterns.class)))
+                .willReturn(new PlaywrightResponse(500, false, "Server Error", "internal error", null));
+
+        // when & then
+        assertThatThrownBy(() -> agent.unsubscribe(MOCK_URL, MOCK_NEWSLETTER_ID))
+                .isInstanceOf(RetryableException.class);
+    }
+
+    @Test
+    @DisplayName("4xx 에러 발생 시 AutoUnsubscribeFailedException을 발생시킨다")
+    void 구독_취소_실패_에러() {
+        // given
+        given(playwrightClient.executeUnsubscribe(eq(MOCK_URL), any(UnsubscribePatterns.class)))
+                .willReturn(new PlaywrightResponse(404, false, "Not Found", "page missing", null));
+
+        // when & then
+        assertThatThrownBy(() -> agent.unsubscribe(MOCK_URL, MOCK_NEWSLETTER_ID))
+                .isInstanceOf(AutoUnsubscribeFailedException.class);
+    }
+
+    @Test
+    @Disabled("실제 Lambda를 호출하여 구독 취소를 수행한다 (실제 AWS 환경 변수 필요)")
+    void 실제_람다_연동_테스트() {
+        // given
+        String realUnsubscribeUrl = "...";
+
+        // when
+        agent.unsubscribe(realUnsubscribeUrl, MOCK_NEWSLETTER_ID);
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
구독 자동 해지 시스템을 로컬 실행 방식(Playwright)에서 AWS Lambda 기반으로 전환하고, 실패 건에 대한 재시도 메커니즘 및 디스코드 모니터링 알림을 고도화했습니다.


**이전에 Revert된거 다시 살려서 작업하고, 아래 PR 올렸다가 충돌이 너무 나서 새로운 브랜치에 체리픽하고 올렸습니다!**
cc. https://github.com/woowacourse-teams/2025-bom-bom/pull/648

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 서버 자원 효율화: 로컬 서버에서 브라우저를 직접 띄우는 방식은 리소스 점유가 크고 불안정하여 독립적인 Lambda 환경으로 분리했습니다.
- 시스템 안정성 확보: 일시적인 통신 장애 등으로 인한 실패 건을 배치를 통해 자동으로 재시도하여 해지 성공률을 높였습니다.
- 운영/대응 편의성: 해지 실패 시 상세한 원인과 뉴스레터 정보를 디스코드 알림으로 함께 제공하여 관리자가 즉각적으로 대응할 수 있도록 했습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- AWS Lambda 연동: AWS SDK를 사용하여 람다 함수를 호출하도록 `LambdaClient`를 구현하고, 기존 Local Playwright 의존성을 제거했습니다.
- 재시도 시스템: Shedlock과 스케줄러를 활용해 분산 환경에서도 안전한 재시도 로직을 구축하였으며, `RetryableException` 여부에 따라 재시도 전략을 차등화했습니다.
- 디스코드 알림 고도화: 알림 필드에 상세한 **실패 사유(에러 메시지)**와 뉴스레터의 발신 이메일 정보를 추가하여 관리 가시성을 높였습니다.
<img width="268" height="288" alt="image" src="https://github.com/user-attachments/assets/12aae7a8-59fd-4596-9fd0-15a2642fd83f" />


### 상세한 구현 방식은 정리해서 PR 오픈 예정

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->



## 확인한 뉴스레터

**스티비 성공 확인**
<img width="1778" height="414" alt="image" src="https://github.com/user-attachments/assets/597d1eb1-6b8b-49a8-a875-a358eaebc735" />

**메일리 성공 확인**
<img width="962" height="332" alt="image" src="https://github.com/user-attachments/assets/e05efa85-5474-4899-b80b-b81ca2627719" />

**매일메일 성공 확인**
<img width="1058" height="329" alt="image" src="https://github.com/user-attachments/assets/e386291d-a0c3-4ead-86fe-6e297bf6492a" />

**뉴욕 타임즈 성공 확인**
<img width="740" height="336" alt="image" src="https://github.com/user-attachments/assets/d186391f-3af2-4253-bdbe-785e2a247dcd" />
