### PR TITLE
[BOM-913] feat: 챌린지 코멘트 답글 비공개/공개 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
@@ -25,7 +25,12 @@ public interface ChallengeCommentReplyControllerApi {
 
     @Operation(
             summary = "코멘트 답글 생성",
-            description = "특정 코멘트에 대해 답글을 작성합니다."
+            description = """
+                    특정 코멘트에 대해 답글을 작성합니다.
+                    
+                    - isPrivate=true: 비공개 답글 (코멘트 작성자 및 본인에게만 공개)
+                    - isPrivate=false: 공개 답글 (모든 챌린지 참여자에게 공개)
+                    """
     )
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "코멘트 답글 생성 성공"),

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeCommentReply.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeCommentReply.java
@@ -30,14 +30,19 @@ public class ChallengeCommentReply extends BaseEntity {
     @Column(nullable = false, length = 500)
     private String reply;
 
+    @Column(nullable = false)
+    private boolean isPrivate;
+
     @Builder
     public ChallengeCommentReply(
             @NonNull Long participantId,
             @NonNull Long commentId,
-            @NonNull String reply
+            @NonNull String reply,
+            boolean isPrivate
     ) {
         this.participantId = participantId;
         this.commentId = commentId;
         this.reply = reply;
+        this.isPrivate = isPrivate;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/CreateCommentReplyRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/request/CreateCommentReplyRequest.java
@@ -7,6 +7,8 @@ public record CreateCommentReplyRequest(
 
         @NotNull
         @Size(max = 500, message = "답글은 500자 이하로 작성 가능합니다.")
-        String reply
+        String reply,
+
+        boolean isPrivate
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CommentReplyResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CommentReplyResponse.java
@@ -24,9 +24,6 @@ public record CommentReplyResponse(
         boolean isMyReply,
 
         @Schema(requiredMode = RequiredMode.REQUIRED)
-        boolean isPrivate,
-
-        @Schema(requiredMode = RequiredMode.REQUIRED)
-        boolean isVisible
+        boolean isPrivate
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CommentReplyResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CommentReplyResponse.java
@@ -21,6 +21,12 @@ public record CommentReplyResponse(
         LocalDateTime createdAt,
 
         @Schema(requiredMode = RequiredMode.REQUIRED)
-        boolean isMyReply
+        boolean isMyReply,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        boolean isPrivate,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        boolean isVisible
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
@@ -18,13 +18,7 @@ public interface ChallengeCommentReplyRepository extends JpaRepository<Challenge
                     cr.reply,
                     cr.createdAt,
                     CASE WHEN crAuthor.memberId = :memberId THEN true ELSE false END,
-                    cr.isPrivate,
-                    CASE
-                        WHEN cr.isPrivate = false THEN true
-                        WHEN crAuthor.memberId = :memberId THEN true
-                        WHEN commentAuthor.memberId = :memberId THEN true
-                        ELSE false
-                    END
+                    cr.isPrivate
                 )
                 FROM ChallengeCommentReply cr
                 JOIN ChallengeParticipant crAuthor ON cr.participantId = crAuthor.id

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ChallengeCommentReplyRepository extends JpaRepository<ChallengeCommentReply, Long> {
+
     @Query("""
                 SELECT new me.bombom.api.v1.challenge.dto.response.CommentReplyResponse(
                     cr.id,
@@ -16,11 +17,20 @@ public interface ChallengeCommentReplyRepository extends JpaRepository<Challenge
                     crMember.profileImageUrl,
                     cr.reply,
                     cr.createdAt,
-                    (crAuthor.memberId = :memberId)
+                    CASE WHEN crAuthor.memberId = :memberId THEN true ELSE false END,
+                    cr.isPrivate,
+                    CASE
+                        WHEN cr.isPrivate = false THEN true
+                        WHEN crAuthor.memberId = :memberId THEN true
+                        WHEN commentAuthor.memberId = :memberId THEN true
+                        ELSE false
+                    END
                 )
                 FROM ChallengeCommentReply cr
                 JOIN ChallengeParticipant crAuthor ON cr.participantId = crAuthor.id
                 LEFT JOIN Member crMember ON crAuthor.memberId = crMember.id
+                JOIN ChallengeComment comment ON cr.commentId = comment.id
+                JOIN ChallengeParticipant commentAuthor ON comment.participantId = commentAuthor.id
                 WHERE cr.commentId = :commentId
             """)
     Page<CommentReplyResponse> findAllByCommentId(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentReplyRepository.java
@@ -32,6 +32,11 @@ public interface ChallengeCommentReplyRepository extends JpaRepository<Challenge
                 JOIN ChallengeComment comment ON cr.commentId = comment.id
                 JOIN ChallengeParticipant commentAuthor ON comment.participantId = commentAuthor.id
                 WHERE cr.commentId = :commentId
+                  AND (
+                        cr.isPrivate = false
+                        OR crAuthor.memberId = :memberId
+                        OR commentAuthor.memberId = :memberId
+                  )
             """)
     Page<CommentReplyResponse> findAllByCommentId(
             @Param("commentId") Long commentId,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyService.java
@@ -35,6 +35,7 @@ public class ChallengeCommentReplyService {
                         .commentId(commentId)
                         .participantId(replyAuthor.getId())
                         .reply(request.reply())
+                        .isPrivate(request.isPrivate())
                         .build()
         );
         challengeCommentRepository.updateReplyCount(commentId);

--- a/backend/bom-bom-server/src/main/resources/db/migration/V22.0.0__add_is_private_to_challenge_comment_reply.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V22.0.0__add_is_private_to_challenge_comment_reply.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge_comment_reply
+    ADD COLUMN is_private TINYINT(1) NOT NULL DEFAULT 0 AFTER reply;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -7,6 +7,7 @@ import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.domain.RecentArticle;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeComment;
+import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyTodo;
@@ -711,6 +712,23 @@ public final class TestFixture {
                 .guideId(guideId)
                 .participantId(participantId)
                 .content(content)
+                .build();
+    }
+
+    /**
+     * ChallengeCommentReply
+     */
+    public static ChallengeCommentReply createChallengeCommentReply(
+            Long commentId,
+            Long participantId,
+            String reply,
+            boolean isPrivate
+    ) {
+        return ChallengeCommentReply.builder()
+                .commentId(commentId)
+                .participantId(participantId)
+                .reply(reply)
+                .isPrivate(isPrivate)
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerTest.java
@@ -126,7 +126,7 @@ class ChallengeCommentReplyControllerTest {
     @Test
     void commentId가_1_미만이면_400을_응답한다() throws Exception {
         // given
-        CreateCommentReplyRequest request = new CreateCommentReplyRequest("감사합니다!");
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("감사합니다!", false);
 
         // when & then
         mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), 0L)
@@ -139,13 +139,14 @@ class ChallengeCommentReplyControllerTest {
     @Test
     void 답글_내용이_null이면_400을_응답한다() throws Exception {
         // given
-        CreateCommentReplyRequest request = new CreateCommentReplyRequest(null);
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest(null, false);
 
         // when & then
-        mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
-                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(
+                        post("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
     }
 
@@ -153,23 +154,25 @@ class ChallengeCommentReplyControllerTest {
     void 답글_내용이_500자를_초과하면_400을_응답한다() throws Exception {
         // given
         String longReply = "a".repeat(501);
-        CreateCommentReplyRequest request = new CreateCommentReplyRequest(longReply);
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest(longReply, false);
 
         // when & then
-        mockMvc.perform(post("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
-                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
+        mockMvc.perform(
+                        post("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
     void 코멘트_답글_목록을_조회하면_200과_페이지정보를_반환한다() throws Exception {
         // when & then
-        mockMvc.perform(get("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
-                        .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
-                        .param("size", "10")
-                        .accept(MediaType.APPLICATION_JSON))
+        mockMvc.perform(
+                        get("/api/v1/challenges/{challengeId}/comments/{commentId}/replies", challenge.getId(), challengeComment.getId())
+                                .with(SecurityMockMvcRequestPostProcessors.authentication(authToken))
+                                .param("size", "10")
+                                .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.content", hasSize(1)))
                 .andExpect(jsonPath("$.content[0].reply", is("첫번째 답글")))

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
@@ -282,7 +282,7 @@ class ChallengeCommentReplyServiceTest {
     }
 
     @Test
-    void 비공개_답글을_제3자가_조회하면_isVisible은_false이다() {
+    void 비공개_답글을_제3자가_조회하면_목록에_포함되지_않는다() {
         // given
         challengeCommentReplyRepository.save(
                 TestFixture.createChallengeCommentReply(
@@ -299,13 +299,9 @@ class ChallengeCommentReplyServiceTest {
                 PageRequest.of(0, 10));
 
         // then
-        CommentReplyResponse response = page.getContent().get(0);
         assertSoftly(softly -> {
-            softly.assertThat(page.getTotalElements()).isEqualTo(1);
-            softly.assertThat(response.reply()).isEqualTo("비공개 답글입니다.");
-            softly.assertThat(response.isPrivate()).isTrue();
-            softly.assertThat(response.isVisible()).isFalse();
-            softly.assertThat(response.isMyReply()).isFalse();
+            softly.assertThat(page.getTotalElements()).isZero();
+            softly.assertThat(page.getContent()).isEmpty();
         });
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
@@ -198,7 +198,7 @@ class ChallengeCommentReplyServiceTest {
     }
 
     @Test
-    void 공개_답글을_제3자가_조회하면_isVisible이_true이다() {
+    void 공개_답글을_제3자가_조회하면_조회된다() {
         // given
         challengeCommentReplyRepository.save(
                 TestFixture.createChallengeCommentReply(
@@ -220,13 +220,12 @@ class ChallengeCommentReplyServiceTest {
             softly.assertThat(page.getTotalElements()).isEqualTo(1);
             softly.assertThat(response.reply()).isEqualTo("공개 답글입니다.");
             softly.assertThat(response.isPrivate()).isFalse();
-            softly.assertThat(response.isVisible()).isTrue();
             softly.assertThat(response.isMyReply()).isFalse();
         });
     }
 
     @Test
-    void 비공개_답글을_답글_작성자가_조회하면_isVisible이_true이다() {
+    void 비공개_답글을_답글_작성자가_조회하면_조회된다() {
         // given
         challengeCommentReplyRepository.save(
                 TestFixture.createChallengeCommentReply(
@@ -248,13 +247,12 @@ class ChallengeCommentReplyServiceTest {
             softly.assertThat(page.getTotalElements()).isEqualTo(1);
             softly.assertThat(response.reply()).isEqualTo("비공개 답글입니다.");
             softly.assertThat(response.isPrivate()).isTrue();
-            softly.assertThat(response.isVisible()).isTrue();
             softly.assertThat(response.isMyReply()).isTrue();
         });
     }
 
     @Test
-    void 비공개_답글을_코멘트_작성자가_조회하면_isVisible이_true이다() {
+    void 비공개_답글을_코멘트_작성자가_조회하면_조회된다() {
         // given
         challengeCommentReplyRepository.save(
                 TestFixture.createChallengeCommentReply(
@@ -276,7 +274,6 @@ class ChallengeCommentReplyServiceTest {
             softly.assertThat(page.getTotalElements()).isEqualTo(1);
             softly.assertThat(response.reply()).isEqualTo("비공개 답글입니다.");
             softly.assertThat(response.isPrivate()).isTrue();
-            softly.assertThat(response.isVisible()).isTrue();
             softly.assertThat(response.isMyReply()).isFalse();
         });
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentReplyServiceTest.java
@@ -49,8 +49,11 @@ class ChallengeCommentReplyServiceTest {
 
     private Member commentAuthorMember;
     private Member replyMember;
+    private Member thirdPartyMember;
     private Challenge challenge;
     private ChallengeParticipant commentAuthorParticipant;
+    private ChallengeParticipant replyParticipant;
+    private ChallengeParticipant thirdPartyParticipant;
     private ChallengeComment challengeComment;
 
     @BeforeEach
@@ -65,6 +68,8 @@ class ChallengeCommentReplyServiceTest {
                 TestFixture.createUniqueMember("commentAuthor", java.util.UUID.randomUUID().toString()));
         replyMember = memberRepository.save(
                 TestFixture.createUniqueMember("replyAuthor", java.util.UUID.randomUUID().toString()));
+        thirdPartyMember = memberRepository.save(
+                TestFixture.createUniqueMember("thirdParty", java.util.UUID.randomUUID().toString()));
 
         challenge = challengeRepository.save(TestFixture.createChallenge(
                 "reply-challenge",
@@ -76,6 +81,18 @@ class ChallengeCommentReplyServiceTest {
                 TestFixture.createChallengeParticipant(
                         challenge.getId(),
                         commentAuthorMember.getId(),
+                        0));
+
+        replyParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        replyMember.getId(),
+                        0));
+
+        thirdPartyParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(
+                        challenge.getId(),
+                        thirdPartyMember.getId(),
                         0));
 
         challengeComment = challengeCommentRepository.save(
@@ -90,15 +107,9 @@ class ChallengeCommentReplyServiceTest {
     @Test
     void 코멘트에_답글을_작성한다() {
         // given
-        ChallengeParticipant replyParticipant = challengeParticipantRepository.save(
-                TestFixture.createChallengeParticipant(
-                        challenge.getId(),
-                        replyMember.getId(),
-                        0));
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("감사합니다!", false);
 
-        CreateCommentReplyRequest request = new CreateCommentReplyRequest("감사합니다!");
-
-        //when
+        // when
         challengeCommentReplyService.createCommentReply(
                 challenge.getId(),
                 challengeComment.getId(),
@@ -113,6 +124,29 @@ class ChallengeCommentReplyServiceTest {
             softly.assertThat(replies.get(0).getCommentId()).isEqualTo(challengeComment.getId());
             softly.assertThat(replies.get(0).getParticipantId()).isEqualTo(replyParticipant.getId());
             softly.assertThat(replies.get(0).getReply()).isEqualTo("감사합니다!");
+            softly.assertThat(replies.get(0).isPrivate()).isFalse();
+        });
+    }
+
+    @Test
+    void 비공개_답글을_작성한다() {
+        // given
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("비공개 답글입니다.", true);
+
+        // when
+        challengeCommentReplyService.createCommentReply(
+                challenge.getId(),
+                challengeComment.getId(),
+                replyMember.getId(),
+                request
+        );
+
+        // then
+        List<ChallengeCommentReply> replies = challengeCommentReplyRepository.findAll();
+        assertSoftly(softly -> {
+            softly.assertThat(replies).hasSize(1);
+            softly.assertThat(replies.get(0).getReply()).isEqualTo("비공개 답글입니다.");
+            softly.assertThat(replies.get(0).isPrivate()).isTrue();
         });
     }
 
@@ -120,7 +154,7 @@ class ChallengeCommentReplyServiceTest {
     void 존재하지_않는_코멘트에_답글을_작성하면_예외가_발생한다() {
         // given
         Long notExistCommentId = 999L;
-        CreateCommentReplyRequest request = new CreateCommentReplyRequest("reply");
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("reply", false);
 
         // when & then
         assertThatThrownBy(
@@ -135,32 +169,71 @@ class ChallengeCommentReplyServiceTest {
     @Test
     void 챌린지_참여자가_아닌_회원은_답글을_작성할_수_없다() {
         // given
-        CreateCommentReplyRequest request = new CreateCommentReplyRequest("reply");
+        Member outsider = memberRepository.save(
+                TestFixture.createUniqueMember("outsider", java.util.UUID.randomUUID().toString()));
+        CreateCommentReplyRequest request = new CreateCommentReplyRequest("reply", false);
 
         // when & then
         assertThatThrownBy(() -> challengeCommentReplyService.createCommentReply(
                 challenge.getId(),
                 challengeComment.getId(),
-                replyMember.getId(),
+                outsider.getId(),
                 request))
                 .isInstanceOf(CIllegalArgumentException.class);
     }
 
     @Test
-    void 코멘트에_달린_답글을_조회한다() {
+    void 챌린지_참여자가_아니면_답글을_조회할_수_없다() {
         // given
-        ChallengeParticipant replyParticipant = challengeParticipantRepository.save(
-                TestFixture.createChallengeParticipant(
-                        challenge.getId(),
-                        replyMember.getId(),
-                        0));
+        Member outsider = memberRepository.save(
+                TestFixture.createUniqueMember("outsider", java.util.UUID.randomUUID().toString()));
 
+        // when & then
+        assertThatThrownBy(() -> challengeCommentReplyService.getCommentReplies(
+                outsider.getId(),
+                challenge.getId(),
+                challengeComment.getId(),
+                PageRequest.of(0, 10)))
+                .isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
+    void 공개_답글을_제3자가_조회하면_isVisible이_true이다() {
+        // given
         challengeCommentReplyRepository.save(
-                ChallengeCommentReply.builder()
-                        .commentId(challengeComment.getId())
-                        .participantId(replyParticipant.getId())
-                        .reply("첫번째 답글")
-                        .build());
+                TestFixture.createChallengeCommentReply(
+                        challengeComment.getId(),
+                        replyParticipant.getId(),
+                        "공개 답글입니다.",
+                        false));
+
+        // when
+        Page<CommentReplyResponse> page = challengeCommentReplyService.getCommentReplies(
+                thirdPartyMember.getId(),
+                challenge.getId(),
+                challengeComment.getId(),
+                PageRequest.of(0, 10));
+
+        // then
+        CommentReplyResponse response = page.getContent().get(0);
+        assertSoftly(softly -> {
+            softly.assertThat(page.getTotalElements()).isEqualTo(1);
+            softly.assertThat(response.reply()).isEqualTo("공개 답글입니다.");
+            softly.assertThat(response.isPrivate()).isFalse();
+            softly.assertThat(response.isVisible()).isTrue();
+            softly.assertThat(response.isMyReply()).isFalse();
+        });
+    }
+
+    @Test
+    void 비공개_답글을_답글_작성자가_조회하면_isVisible이_true이다() {
+        // given
+        challengeCommentReplyRepository.save(
+                TestFixture.createChallengeCommentReply(
+                        challengeComment.getId(),
+                        replyParticipant.getId(),
+                        "비공개 답글입니다.",
+                        true));
 
         // when
         Page<CommentReplyResponse> page = challengeCommentReplyService.getCommentReplies(
@@ -170,25 +243,69 @@ class ChallengeCommentReplyServiceTest {
                 PageRequest.of(0, 10));
 
         // then
+        CommentReplyResponse response = page.getContent().get(0);
         assertSoftly(softly -> {
             softly.assertThat(page.getTotalElements()).isEqualTo(1);
-            softly.assertThat(page.getContent().get(0).reply()).isEqualTo("첫번째 답글");
-            softly.assertThat(page.getContent().get(0).isMyReply()).isTrue();
+            softly.assertThat(response.reply()).isEqualTo("비공개 답글입니다.");
+            softly.assertThat(response.isPrivate()).isTrue();
+            softly.assertThat(response.isVisible()).isTrue();
+            softly.assertThat(response.isMyReply()).isTrue();
         });
     }
 
     @Test
-    void 챌린지_참여자가_아니면_답글을_조회할_수_없다() {
+    void 비공개_답글을_코멘트_작성자가_조회하면_isVisible이_true이다() {
         // given
-        Member outsider = memberRepository.save(
-                TestFixture.createUniqueMember("챌린지 참여 안한 사람", java.util.UUID.randomUUID().toString()));
+        challengeCommentReplyRepository.save(
+                TestFixture.createChallengeCommentReply(
+                        challengeComment.getId(),
+                        replyParticipant.getId(),
+                        "비공개 답글입니다.",
+                        true));
 
-        // when & then
-        assertThatThrownBy(() -> challengeCommentReplyService.getCommentReplies(
-                outsider.getId(),
+        // when
+        Page<CommentReplyResponse> page = challengeCommentReplyService.getCommentReplies(
+                commentAuthorMember.getId(),
                 challenge.getId(),
                 challengeComment.getId(),
-                PageRequest.of(0, 10)))
-                .isInstanceOf(CIllegalArgumentException.class);
+                PageRequest.of(0, 10));
+
+        // then
+        CommentReplyResponse response = page.getContent().get(0);
+        assertSoftly(softly -> {
+            softly.assertThat(page.getTotalElements()).isEqualTo(1);
+            softly.assertThat(response.reply()).isEqualTo("비공개 답글입니다.");
+            softly.assertThat(response.isPrivate()).isTrue();
+            softly.assertThat(response.isVisible()).isTrue();
+            softly.assertThat(response.isMyReply()).isFalse();
+        });
+    }
+
+    @Test
+    void 비공개_답글을_제3자가_조회하면_isVisible은_false이다() {
+        // given
+        challengeCommentReplyRepository.save(
+                TestFixture.createChallengeCommentReply(
+                        challengeComment.getId(),
+                        replyParticipant.getId(),
+                        "비공개 답글입니다.",
+                        true));
+
+        // when
+        Page<CommentReplyResponse> page = challengeCommentReplyService.getCommentReplies(
+                thirdPartyMember.getId(),
+                challenge.getId(),
+                challengeComment.getId(),
+                PageRequest.of(0, 10));
+
+        // then
+        CommentReplyResponse response = page.getContent().get(0);
+        assertSoftly(softly -> {
+            softly.assertThat(page.getTotalElements()).isEqualTo(1);
+            softly.assertThat(response.reply()).isEqualTo("비공개 답글입니다.");
+            softly.assertThat(response.isPrivate()).isTrue();
+            softly.assertThat(response.isVisible()).isFalse();
+            softly.assertThat(response.isMyReply()).isFalse();
+        });
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 코멘트에 대한 답글을 작성할 때 비공개/공개를 설정할 수 있습니다.
비공개로 설정된 답글은 코멘트 작성자와 답글 작성자만 조회 가능합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 답글이 공개적인 면에 있어서 소통의 부담을 줄이고 자유롭게 의견을 나누기 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
### UI 및 기능 설명 
(UI가 아직 확정은 아니어서 참고용으로만 봐주시면 감사하겠습니다)
1. 답글 작성 시, '비공개' 박스를 체크하면 코멘트 작성자와 답글 작성자 본인만 볼 수 있도록 설정합니다.
2. 비공개 답글에는 '(비공개)'라는 표시가 있습니다.
3. 비공개 답글이라 다른 참여자들에게는 보이지 않을텐데, 이건 아직 "비공개 답글입니다." 아니면 아예 안보이게 할지 결정이 안났습니다.
<img width="828" height="783" alt="image" src="https://github.com/user-attachments/assets/8c22b18c-b686-4464-9978-132b0790eba0" />

### 백엔드 구현 사항
#### 1. 답글 작성 시 비공개 여부 요청 필드 추가
- 답글 작성 요청 body에 `boolean isPrivate` 필드가 추가되었습니다.

#### 2. 답글 목록 조회 시 비공개 여부, 조회 가능 여부 응답 추가
- 비공개 여부 : 해당 답글이 비공개인지 true/false로 반환합니다.
- 조회 가능 여부 : 현재 회원이 해당 답글을 볼 수 있는 대상인지 판별하도록 true/false로 반환합니다.
- 따라서 로직은 다음과 같습니다.
  - 공개 답글일 경우 -> 모든 참여자 조회 가능
  - 비공개 답글일 경우 -> 코멘트 작성자 & 답글 작성자만 조회 가능

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 전반적으로 로직에서 놓친 부분 없는지 봐주시면 감사하겠습니다.