### PR TITLE
[BOM-931] hotfix: 챌린지 1일차 투두 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeTodoType.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeTodoType.java
@@ -4,5 +4,6 @@ public enum ChallengeTodoType {
 
     READ,
     COMMENT,
+    MINDSET
     ;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -40,7 +40,7 @@ public class ChallengeDailyGuideService {
     private final ChallengeDailyGuideRepository challengeDailyGuideRepository;
     private final ChallengeDailyGuideCommentRepository challengeDailyGuideCommentRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
-
+    private final ChallengeDailyTodoService challengeDailyTodoService;
     private final ChallengeTodoService challengeTodoService;
     private final ChallengeTeamService challengeTeamService;
 
@@ -149,12 +149,15 @@ public class ChallengeDailyGuideService {
         if (dayIndex == 1) {
             // MINDSET 투두 생성 (마인드셋 댓글 작성)
             challengeTodoService.insertMindsetDone(participant, today);
+            // TODO: 과도기라서 모두 완료 처리가 필요해 보임. 추후 삭제 필요
+            // READ 투두 자동 생성 (뉴스레터 1개 읽기)
+            challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
+            // COMMENT 투두 생성 (한 줄 코멘트 작성)
+            challengeTodoService.insertCommentDone(participant, today);
 
             // 이미 완료되지 않았으면 progress 처리
-            // day1은 MINDSET 투두 하나만 존재하므로 바로 완료 처리
             if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
                 challengeTodoService.completeDailyTodo(participant, today);
-
                 if (participant.getChallengeTeamId() != null) {
                     ChallengeTeam challengeTeam = challengeTeamService.getChallengeTeamByParticipant(participant);
                     challengeTeamService.updateTeamProgress(challengeTeam);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -10,6 +10,7 @@ import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
@@ -39,7 +40,7 @@ public class ChallengeDailyGuideService {
     private final ChallengeDailyGuideRepository challengeDailyGuideRepository;
     private final ChallengeDailyGuideCommentRepository challengeDailyGuideCommentRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
-    private final ChallengeDailyTodoService challengeDailyTodoService;
+
     private final ChallengeTodoService challengeTodoService;
     private final ChallengeTeamService challengeTeamService;
 
@@ -58,7 +59,7 @@ public class ChallengeDailyGuideService {
 
         int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
         TodayDailyGuideRow row = challengeDailyGuideRepository.findTodayGuide(
-                        challengeId, memberId, dayIndex)
+                challengeId, memberId, dayIndex)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
@@ -71,11 +72,11 @@ public class ChallengeDailyGuideService {
                 row.getImageUrl(),
                 row.getNotice(),
                 row.isCommentEnabled(),
-                myComment
-        );
+                myComment);
     }
 
-    public Page<DailyGuideCommentResponse> getTotalComments(Long challengeId, int dayIndex, Long memberId, Pageable pageable) {
+    public Page<DailyGuideCommentResponse> getTotalComments(Long challengeId, int dayIndex, Long memberId,
+            Pageable pageable) {
         Challenge challenge = getChallenge(challengeId);
 
         validateChallengeParticipant(challengeId, memberId);
@@ -99,11 +100,11 @@ public class ChallengeDailyGuideService {
 
     @Transactional
     public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
-                                        DailyGuideCommentRequest request, LocalDate today) {
+            DailyGuideCommentRequest request, LocalDate today) {
         Challenge challenge = getChallenge(challengeId);
 
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
-                        challengeId, memberId)
+                challengeId, memberId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
                         .addContext(ErrorContextKeys.MEMBER_ID, memberId)
@@ -146,19 +147,16 @@ public class ChallengeDailyGuideService {
 
         // day1일 때만 체크리스트 자동 완료 처리
         if (dayIndex == 1) {
-            // READ 투두 자동 생성 (뉴스레터 1개 읽기)
-            challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
-            // COMMENT 투두 생성 (한 줄 코멘트 작성)
-            challengeTodoService.insertCommentDone(participant, today);
+            // MINDSET 투두 생성 (마인드셋 댓글 작성)
+            challengeTodoService.insertMindsetDone(participant, today);
 
             // 이미 완료되지 않았으면 progress 처리
-            // day1에 두 투두(READ, COMMENT)가 모두 생성되므로 바로 완료 처리
+            // day1은 MINDSET 투두 하나만 존재하므로 바로 완료 처리
             if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
                 challengeTodoService.completeDailyTodo(participant, today);
 
-                // 팀 progress 업데이트
                 if (participant.getChallengeTeamId() != null) {
-                    var challengeTeam = challengeTeamService.getChallengeTeamByParticipant(participant);
+                    ChallengeTeam challengeTeam = challengeTeamService.getChallengeTeamByParticipant(participant);
                     challengeTeamService.updateTeamProgress(challengeTeam);
                 }
             }
@@ -173,8 +171,7 @@ public class ChallengeDailyGuideService {
         MemberDailyCommentResponse response = challengeDailyGuideCommentRepository.findMyComment(
                 challengeId,
                 dayIndex,
-                memberId
-        );
+                memberId);
         return response != null ? response : new MemberDailyCommentResponse(null);
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.challenge.service;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeGrade;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.dto.ChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.response.CertificationInfoResponse;
@@ -43,6 +45,7 @@ public class ChallengeProgressService {
     private final ChallengeDailyResultRepository challengeDailyResultRepository;
     private final ChallengeTeamRepository challengeTeamRepository;
     private final MemberRepository memberRepository;
+    private final Clock clock;
 
     @Transactional
     public void proceedDailySurvivalCheck(Challenge challenge, LocalDate yesterday) {
@@ -57,13 +60,10 @@ public class ChallengeProgressService {
     }
 
     public MemberChallengeProgressResponse getMemberProgress(Long id, Member member) {
+        Challenge challenge = getChallenge(id);
         validateParticipation(id, member);
 
-        List<ChallengeProgressFlat> progressList = challengeParticipantRepository.findMemberProgress(
-                id,
-                member.getId(),
-                LocalDate.now()
-        );
+        List<ChallengeProgressFlat> progressList = getDailyProgress(challenge, member);
         validateMemberProgressDataIntegrity(id, member, progressList);
 
         return MemberChallengeProgressResponse.of(member, progressList);
@@ -148,6 +148,27 @@ public class ChallengeProgressService {
         }
     }
 
+    private List<ChallengeProgressFlat> getDailyProgress(Challenge challenge, Member member) {
+        List<ChallengeProgressFlat> progressList = challengeParticipantRepository.findMemberProgress(
+                challenge.getId(),
+                member.getId(),
+                LocalDate.now(clock)
+        );
+
+        if (isFirstDay(challenge)) {
+            return progressList.stream()
+                    .filter(progress -> progress.todoType() == ChallengeTodoType.MINDSET)
+                    .toList();
+        }
+        return progressList.stream()
+                .filter(progress -> progress.todoType() != ChallengeTodoType.MINDSET)
+                .toList();
+    }
+
+    private boolean isFirstDay(Challenge challenge) {
+        return challenge.getStartDate().isEqual(LocalDate.now(clock));
+    }
+
     private void validateMemberProgressDataIntegrity(Long id, Member member, List<ChallengeProgressFlat> progressList) {
         if (progressList.isEmpty()) {
             throw new CServerErrorException(ErrorDetail.INTERNAL_SERVER_ERROR)
@@ -175,8 +196,8 @@ public class ChallengeProgressService {
         }
     }
 
-    private static void validateChallengeEnded(Challenge challenge) {
-        if (!challenge.isEnded(LocalDate.now())) {
+    private void validateChallengeEnded(Challenge challenge) {
+        if (!challenge.isEnded(LocalDate.now(clock))) {
             throw new CIllegalArgumentException(ErrorDetail.PRECONDITION_FAILED)
                     .addContext(ErrorContextKeys.OPERATION, "getCertificationInfo")
                     .addContext(ErrorContextKeys.DETAIL, "진행 중인 챌린지는 수료증을 조회할 수 없습니다");

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
@@ -58,6 +58,32 @@ public class ChallengeTodoService {
     }
 
     @Transactional
+    public void insertMindsetDone(ChallengeParticipant participant, LocalDate today) {
+        ChallengeTodo challengeTodo = challengeTodoRepository
+                .findByChallengeIdAndTodoType(participant.getChallengeId(), ChallengeTodoType.MINDSET)
+                .orElseThrow(() -> new CServerErrorException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, participant.getChallengeId())
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "ChallengeTodo")
+                        .addContext(ErrorContextKeys.OPERATION, "findByChallengeIdAndTodoType"));
+
+        // 중복 체크
+        if (challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(), today, challengeTodo.getId())) {
+            log.debug("Mindset todo already exists for participantId={}, date={}, todoId={}",
+                    participant.getId(), today, challengeTodo.getId());
+            return;
+        }
+
+        ChallengeDailyTodo dailyTodo = ChallengeDailyTodo.builder()
+                .participantId(participant.getId())
+                .todoDate(today)
+                .challengeTodoId(challengeTodo.getId())
+                .build();
+
+        challengeDailyTodoRepository.save(dailyTodo);
+    }
+
+    @Transactional
     public void completeDailyTodo(ChallengeParticipant participant, LocalDate today){
         challengeDailyResultRepository.save(
                 ChallengeDailyResult.builder()

--- a/backend/bom-bom-server/src/main/resources/db/migration/V21.0.3__modify_challenge_todo_type_enum.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V21.0.3__modify_challenge_todo_type_enum.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge_todo
+MODIFY COLUMN todo_type VARCHAR(20) NOT NULL;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -21,6 +21,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.domain.DailyGuideType;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyGuideCommentRepository;
@@ -84,6 +85,7 @@ class ChallengeDailyGuideServiceTest {
     private LocalDate today;
     private ChallengeTodo readTodo;
     private ChallengeTodo commentTodo;
+    private ChallengeTodo mindsetTodo;
 
     @BeforeEach
     void setUp() {
@@ -109,9 +111,7 @@ class ChallengeDailyGuideServiceTest {
                 "테스트 챌린지",
                 today.minusDays(5),
                 today.plusDays(5),
-                10
-                )
-        );
+                10));
 
         participant = challengeParticipantRepository.save(
                 TestFixture.createChallengeParticipant(
@@ -121,9 +121,10 @@ class ChallengeDailyGuideServiceTest {
                 )
         );
 
-        // READ, COMMENT 투두 생성
+        // READ, COMMENT, MINDSET 투두 생성
         readTodo = challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ));
         commentTodo = challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.COMMENT));
+        mindsetTodo = challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.MINDSET));
 
         int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
         guide = challengeDailyGuideRepository.save(
@@ -467,7 +468,7 @@ class ChallengeDailyGuideServiceTest {
     }
 
     @Test
-    void day1에_코멘트_작성시_READ와_COMMENT_체크리스트_자동_완료() {
+    void day1에_코멘트_작성시_MINDSET_체크리스트_자동_완료() {
         // given - day1 가이드 생성
         ChallengeDailyGuide day1Guide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
@@ -501,15 +502,28 @@ class ChallengeDailyGuideServiceTest {
         List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
         assertThat(comments).hasSize(1);
 
-        // then - READ 투두 생성 확인
+        // then - READ/COMMENT 투두는 생성되지 않음
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), weekday, readTodo.getId());
-        assertThat(readTodoExists).isTrue();
+                participant.getId(),
+                weekday,
+                readTodo.getId()
+        );
+        assertThat(readTodoExists).isFalse();
 
-        // then - COMMENT 투두 생성 확인
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), weekday, commentTodo.getId());
-        assertThat(commentTodoExists).isTrue();
+                participant.getId(),
+                weekday,
+                commentTodo.getId()
+        );
+        assertThat(commentTodoExists).isFalse();
+
+        // then - MINDSET 투두 생성 확인
+        boolean mindsetTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(),
+                weekday,
+                mindsetTodo.getId()
+        );
+        assertThat(mindsetTodoExists).isTrue();
 
         // then - progress 처리 확인: ChallengeDailyResult 생성 확인
         boolean dailyResultExists = challengeDailyResultRepository.existsByParticipantIdAndDate(
@@ -551,17 +565,31 @@ class ChallengeDailyGuideServiceTest {
 
         // then - READ 투두 생성 안 됨 (아직 아티클을 읽지 않았으므로)
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), today, readTodo.getId());
+                participant.getId(),
+                today,
+                readTodo.getId()
+        );
         assertThat(readTodoExists).isFalse();
 
         // then - COMMENT 투두 생성 안 됨 (day1이 아니므로)
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), today, commentTodo.getId());
+                participant.getId(),
+                today,
+                commentTodo.getId()
+        );
         assertThat(commentTodoExists).isFalse();
+
+        // then - MINDSET 투두 생성 안 됨 (day1이 아니므로)
+        boolean mindsetTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                participant.getId(),
+                today,
+                mindsetTodo.getId()
+        );
+        assertThat(mindsetTodoExists).isFalse();
     }
 
     @Test
-    void day1에_이미_READ_todo가_있어도_중복_생성_안함() {
+    void day1에_이미_MINDSET_todo가_있어도_중복_생성_안함() {
         // given - day1 가이드 생성
         ChallengeDailyGuide day1Guide = challengeDailyGuideRepository.save(
                 TestFixture.createChallengeDailyGuide(
@@ -581,12 +609,12 @@ class ChallengeDailyGuideServiceTest {
         }
         final LocalDate weekday = tempWeekday;
 
-        // 이미 READ 투두 생성
+        // 이미 MINDSET 투두 생성
         challengeDailyTodoRepository.save(
                 TestFixture.createChallengeDailyTodo(
                         participant.getId(),
                         weekday,
-                        readTodo.getId()
+                        mindsetTodo.getId()
                 )
         );
 
@@ -601,73 +629,13 @@ class ChallengeDailyGuideServiceTest {
                 weekday
         );
 
-        // then - READ 투두는 1개만 존재 (중복 생성 안 됨)
-        List<ChallengeDailyTodo> readTodos = challengeDailyTodoRepository.findAll().stream()
+        // then - MINDSET 투두는 1개만 존재 (중복 생성 안 됨)
+        List<ChallengeDailyTodo> mindsetTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
-                .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
+                .filter(todo -> todo.getChallengeTodoId().equals(mindsetTodo.getId()))
                 .filter(todo -> todo.getTodoDate().equals(weekday))
                 .toList();
-        assertThat(readTodos).hasSize(1);
-
-        // then - COMMENT 투두 생성 확인
-        boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), weekday, commentTodo.getId());
-        assertThat(commentTodoExists).isTrue();
-    }
-
-    @Test
-    void day1에_이미_COMMENT_todo가_있어도_중복_생성_안함() {
-        // given - day1 가이드 생성
-        ChallengeDailyGuide day1Guide = challengeDailyGuideRepository.save(
-                TestFixture.createChallengeDailyGuide(
-                        challenge.getId(),
-                        1,
-                        DailyGuideType.COMMENT,
-                        "https://example.com/day01.webp",
-                        "첫날 가이드",
-                        true
-                )
-        );
-
-        // 평일 날짜 사용 (주말에는 updateChallengeDailyTodo가 동작하지 않음)
-        LocalDate tempWeekday = today;
-        while (tempWeekday.getDayOfWeek() == DayOfWeek.SATURDAY || tempWeekday.getDayOfWeek() == DayOfWeek.SUNDAY) {
-            tempWeekday = tempWeekday.plusDays(1);
-        }
-        final LocalDate weekday = tempWeekday;
-
-        // 이미 COMMENT 투두 생성
-        challengeDailyTodoRepository.save(
-                TestFixture.createChallengeDailyTodo(
-                        participant.getId(),
-                        weekday,
-                        commentTodo.getId()
-                )
-        );
-
-        DailyGuideCommentRequest request = new DailyGuideCommentRequest("첫날 코멘트");
-
-        // when
-        challengeDailyGuideService.createDailyGuideComment(
-                challenge.getId(),
-                1,
-                member.getId(),
-                request,
-                weekday
-        );
-
-        // then - COMMENT 투두는 1개만 존재 (중복 생성 안 됨)
-        List<ChallengeDailyTodo> commentTodos = challengeDailyTodoRepository.findAll().stream()
-                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
-                .filter(todo -> todo.getChallengeTodoId().equals(commentTodo.getId()))
-                .filter(todo -> todo.getTodoDate().equals(weekday))
-                .toList();
-        assertThat(commentTodos).hasSize(1);
-
-        // then - READ 투두 생성 확인
-        boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(), weekday, readTodo.getId());
-        assertThat(readTodoExists).isTrue();
+        assertThat(mindsetTodos).hasSize(1);
     }
 
     @Test
@@ -701,8 +669,12 @@ class ChallengeDailyGuideServiceTest {
         Pageable pageable = PageRequest.of(0, 20);
 
         // when
-        Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
-                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), member.getId(), pageable);
+        Page<DailyGuideCommentResponse> response = challengeDailyGuideService.getTotalComments(
+                challenge.getId(),
+                guide.getDayIndex(),
+                member.getId(),
+                pageable
+        );
 
         // then
         assertSoftly(softly -> {
@@ -743,8 +715,12 @@ class ChallengeDailyGuideServiceTest {
         Pageable pageable = PageRequest.of(0, 1);
 
         // when
-        Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
-                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), member.getId(), pageable);
+        Page<DailyGuideCommentResponse> response = challengeDailyGuideService.getTotalComments(
+                challenge.getId(),
+                guide.getDayIndex(),
+                member.getId(),
+                pageable
+        );
 
         // then
         assertSoftly(softly -> {
@@ -817,8 +793,12 @@ class ChallengeDailyGuideServiceTest {
         Pageable pageable = PageRequest.of(0, 20);
 
         // when
-        Page<me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse> response =
-                challengeDailyGuideService.getTotalComments(challenge.getId(), guide.getDayIndex(), member.getId(), pageable);
+        Page<DailyGuideCommentResponse> response = challengeDailyGuideService.getTotalComments(
+                challenge.getId(),
+                guide.getDayIndex(),
+                member.getId(),
+                pageable
+        );
 
         // then
         assertSoftly(softly -> {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -502,20 +502,21 @@ class ChallengeDailyGuideServiceTest {
         List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
         assertThat(comments).hasSize(1);
 
-        // then - READ/COMMENT 투두는 생성되지 않음
+        // then - READ 투두 생성 및 완료 확인
         boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(),
                 weekday,
                 readTodo.getId()
         );
-        assertThat(readTodoExists).isFalse();
+        assertThat(readTodoExists).isTrue();
 
+        // then - COMMENT 투두 생성 및 완료 확인
         boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
                 participant.getId(),
                 weekday,
                 commentTodo.getId()
         );
-        assertThat(commentTodoExists).isFalse();
+        assertThat(commentTodoExists).isTrue();
 
         // then - MINDSET 투두 생성 확인
         boolean mindsetTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
@@ -740,8 +741,7 @@ class ChallengeDailyGuideServiceTest {
                 999L,
                 guide.getDayIndex(),
                 member.getId(),
-                pageable
-        )).isInstanceOf(CIllegalArgumentException.class);
+                pageable)).isInstanceOf(CIllegalArgumentException.class);
     }
 
     @Test
@@ -755,8 +755,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 invalidDayIndex,
                 member.getId(),
-                pageable
-        )).isInstanceOf(CIllegalArgumentException.class);
+                pageable)).isInstanceOf(CIllegalArgumentException.class);
     }
 
     @Test

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -39,6 +39,7 @@ import me.bombom.support.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 class ChallengeProgressServiceTest {
@@ -66,6 +67,9 @@ class ChallengeProgressServiceTest {
 
     @Autowired
     private ChallengeDailyResultRepository challengeDailyResultRepository;
+
+    @MockitoBean
+    private java.time.Clock clock;
 
     private Member member;
     private Challenge challenge;
@@ -108,6 +112,13 @@ class ChallengeProgressServiceTest {
                 LocalDate.now(),
                 readTodo.getId());
         challengeDailyTodoRepository.save(dailyTodo);
+
+        // Mock Clock behavior
+        // Default: LocalDate.now(clock) returns today
+        java.time.Instant instant = java.time.Instant.now();
+        java.time.ZoneId zoneId = java.time.ZoneId.systemDefault();
+        org.mockito.BDDMockito.given(clock.instant()).willReturn(instant);
+        org.mockito.BDDMockito.given(clock.getZone()).willReturn(zoneId);
     }
 
     @Test
@@ -577,5 +588,83 @@ class ChallengeProgressServiceTest {
             softly.assertThat(response.medal()).isEqualTo(ChallengeGrade.SILVER);
             softly.assertThat(response.medalCondition()).isEqualTo(90);
         });
+    }
+
+    @Test
+    void 챌린지_1일차에는_MINDSET_투두만_조회된다() {
+        // given
+        LocalDate today = LocalDate.now();
+        Challenge day1Challenge = challengeRepository.save(TestFixture.createChallenge(
+                "Day 1 Challenge",
+                today,
+                today.plusDays(9),
+                10));
+
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipant(
+                day1Challenge.getId(),
+                member.getId(),
+                0));
+
+        // Todos: MINDSET, READ, COMMENT 모두 생성
+        challengeTodoRepository
+                .save(TestFixture.createChallengeTodo(day1Challenge.getId(),
+                        ChallengeTodoType.MINDSET));
+        challengeTodoRepository
+                .save(TestFixture.createChallengeTodo(day1Challenge.getId(), ChallengeTodoType.READ));
+        challengeTodoRepository
+                .save(TestFixture.createChallengeTodo(day1Challenge.getId(),
+                        ChallengeTodoType.COMMENT));
+
+        // when
+        MemberChallengeProgressResponse response = challengeProgressService
+                .getMemberProgress(day1Challenge.getId(), member);
+
+        // then
+        assertThat(response.todayTodos()).hasSize(1);
+        assertThat(response.todayTodos().getFirst().challengeTodoType()).isEqualTo(ChallengeTodoType.MINDSET);
+    }
+
+    @Test
+    void 챌린지_2일차_이후에는_READ_COMMENT_투두만_조회된다() {
+        // given
+        // LocalDate.now()가 주말일 경우를 대비하여, 시작일을 충분히 과거로 설정하여
+        // 현재 날짜가 챌린지 2일차 이후의 평일이 되도록 보장
+        LocalDate realToday = LocalDate.now();
+        // 시작일을 현재 날짜로부터 3일 전으로 설정.
+        // 이렇게 하면 realToday가 월요일이든, 화요일이든, 수요일이든, 목요일이든, 금요일이든
+        // 챌린지 시작일로부터 최소 2일 이상의 평일이 지났음을 보장할 수 있다.
+        // (예: realToday가 수요일이면 시작일은 일요일. 월, 화 2일 경과)
+        // (예: realToday가 월요일이면 시작일은 금요일. 금, 월 2일 경과)
+        LocalDate safeStartDate = realToday.minusDays(3);
+
+        Challenge day2ChallengeFixed = challengeRepository.save(TestFixture.createChallenge(
+                "Day 2 Challenge",
+                safeStartDate,
+                safeStartDate.plusDays(9),
+                10));
+
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipant(
+                day2ChallengeFixed.getId(),
+                member.getId(),
+                1)); // completedDays를 1로 설정하여 2일차로 가정
+
+        // Todos: MINDSET, READ, COMMENT 모두 생성
+        challengeTodoRepository.save(
+                TestFixture.createChallengeTodo(day2ChallengeFixed.getId(), ChallengeTodoType.MINDSET));
+        challengeTodoRepository.save(
+                TestFixture.createChallengeTodo(day2ChallengeFixed.getId(), ChallengeTodoType.READ));
+        challengeTodoRepository.save(
+                TestFixture.createChallengeTodo(day2ChallengeFixed.getId(), ChallengeTodoType.COMMENT));
+
+        // when
+        MemberChallengeProgressResponse response = challengeProgressService
+                .getMemberProgress(day2ChallengeFixed.getId(), member);
+
+        // then
+        assertThat(response.todayTodos()).hasSize(2);
+        assertThat(response.todayTodos()).extracting("challengeTodoType")
+                .containsExactlyInAnyOrder(ChallengeTodoType.READ, ChallengeTodoType.COMMENT);
+        assertThat(response.todayTodos()).extracting("challengeTodoType")
+                .doesNotContain(ChallengeTodoType.MINDSET);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -4,8 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.UUID;
 import me.bombom.api.v1.TestFixture;
@@ -69,7 +73,7 @@ class ChallengeProgressServiceTest {
     private ChallengeDailyResultRepository challengeDailyResultRepository;
 
     @MockitoBean
-    private java.time.Clock clock;
+    private Clock clock;
 
     private Member member;
     private Challenge challenge;
@@ -115,10 +119,10 @@ class ChallengeProgressServiceTest {
 
         // Mock Clock behavior
         // Default: LocalDate.now(clock) returns today
-        java.time.Instant instant = java.time.Instant.now();
-        java.time.ZoneId zoneId = java.time.ZoneId.systemDefault();
-        org.mockito.BDDMockito.given(clock.instant()).willReturn(instant);
-        org.mockito.BDDMockito.given(clock.getZone()).willReturn(zoneId);
+        Instant instant = java.time.Instant.now();
+        ZoneId zoneId = java.time.ZoneId.systemDefault();
+        given(clock.instant()).willReturn(instant);
+        given(clock.getZone()).willReturn(zoneId);
     }
 
     @Test


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 투두 타입에 `MINDSET`(각오/다짐)을 추가하고, **챌린지 1일차에는 `READ`와 `COMMENT`, `MINDSET` 투두 모두 생성되도록 로직을 변경했습니다. 하지만 노출은 `MINDSET`만 됩니다.**
또한 1일차 가이드에 댓글(다짐)을 작성하면 해당 투두가 자동으로 완료되도록 구현했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존에는 1일차에도 아티클 읽기/댓글 달기 투두가 생성되었으나, 챌린지 시작 첫날에는 사용자가 다짐을 작성하고 마음가짐을 다잡는 것에 집중하도록 투두를 다르게 표시하기 위해서, 1일차의 투두 구성을 별도로 분리할 필요가 있었습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
1. Domain: ChallengeTodoType에 `MINDSET` 열거형을 추가했습니다.
2. Service:
- `ChallengeProgressService`: `getDailyProgress` 메서드에서 챌린지 1일차인 경우 `MINDSET` 타입만 반환하고, 2일차 이후부터는 
`MINDSET`을 제외한 나머지(`READ`, `COMMENT`)만 반환하도록 필터링 로직을 추가했습니다.
- `ChallengeDailyGuideService`:1일차 가이드에 댓글(다짐) 작성 시 `ChallengeTodoService.insertMindsetDone`을 호출하여 `READ`, `COMMENT` , `MINDSET` 투두 모두를 생성 및 완료 처리하도록 변경했습니다. 1일차에는 `MINDSET`만 생성되도록 하려했으나, 오늘이 챌린지 1일차이므로 MINDSET 타입만 만들 경우 이미 각오를 작성을 완료한 참가자에게 문제가 있을 거라 판단했습니다. 그래서 해당 로직에는 추후 삭제를 위해 TODO 주석을 달아두었습니다.
3. Tests:
- ChallengeDailyGuideServiceTest: 1일차 댓글 작성 시 `MINDSET` 투두 완료 검증, 2일차 이후 로직 검증 테스트를 추가 및 수정했습니다.
- ChallengeProgressServiceTest: 날짜별 투두 필터링이 정상적으로 동작하는지 검증하는 테스트를 추가했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
