### PR TITLE
[BOM-947] feat: 알림 설정 API 구현

### DIFF
--- a/backend/fcm-server/src/main/java/news/bombom/notification/config/NotificationCategoryConverter.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/config/NotificationCategoryConverter.java
@@ -1,0 +1,14 @@
+package news.bombom.notification.config;
+
+import news.bombom.notification.domain.NotificationCategory;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class NotificationCategoryConverter implements Converter<String, NotificationCategory> {
+
+    @Override
+    public NotificationCategory convert(String source) {
+        return NotificationCategory.valueOf(source.toUpperCase());
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/controller/NotificationController.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/controller/NotificationController.java
@@ -1,23 +1,17 @@
-package news.bombom.notification.controller.v1;
+package news.bombom.notification.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
-import news.bombom.notification.domain.NotificationCategory;
-import news.bombom.notification.dto.request.NotificationCategorySettingRequest;
 import news.bombom.notification.dto.request.NotificationSendRequest;
 import news.bombom.notification.dto.request.NotificationSettingRequest;
 import news.bombom.notification.dto.request.NotificationTokenRequest;
-import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
 import news.bombom.notification.service.NotificationService;
-import news.bombom.notification.service.NotificationSettingService;
 import news.bombom.notification.service.NotificationTokenService;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -34,7 +28,6 @@ public class NotificationController {
 
     private final NotificationTokenService notificationTokenService;
     private final NotificationService notificationService;
-    private final NotificationSettingService notificationSettingService;
 
     @PostMapping("/tokens")
     @ResponseStatus(HttpStatus.CREATED)
@@ -50,10 +43,11 @@ public class NotificationController {
 
     @PutMapping("/tokens/{memberId}/{deviceUuid}/settings")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateNotificationSettings(
+    public void updateDeviceNotificationSettings(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
             @PathVariable @NotBlank String deviceUuid,
-            @Valid @RequestBody NotificationSettingRequest request) {
+            @Valid @RequestBody NotificationSettingRequest request
+    ) {
         notificationTokenService.updateNotificationSetting(memberId, deviceUuid, request.enabled());
     }
 
@@ -71,30 +65,5 @@ public class NotificationController {
     @ResponseStatus(HttpStatus.OK)
     public void sendNotification(@Valid @RequestBody NotificationSendRequest request) {
         notificationService.sendNotification(request.token(), request.title(), request.body(), request.articleId());
-    }
-
-    @GetMapping("/{memberId}/settings")
-    public List<NotificationCategorySettingResponse> getCategorySettings(
-            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId
-    ) {
-        return notificationSettingService.getCategorySettings(memberId);
-    }
-
-    @GetMapping("/{memberId}/settings/{category}")
-    public NotificationCategorySettingResponse getCategorySetting(
-            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
-            @PathVariable NotificationCategory category
-    ) {
-        return notificationSettingService.getCategorySetting(memberId, category);
-    }
-
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    @PatchMapping("/{memberId}/settings/{category}")
-    public void updateNotificationCategorySetting(
-            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
-            @PathVariable NotificationCategory category,
-            @Valid @RequestBody NotificationCategorySettingRequest request
-    ) {
-        notificationSettingService.updateCategorySetting(memberId, category, request.enabled());
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/controller/NotificationController.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/controller/NotificationController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import news.bombom.notification.dto.request.NotificationSendRequest;
 import news.bombom.notification.dto.request.NotificationSettingRequest;
 import news.bombom.notification.dto.request.NotificationTokenRequest;
+import news.bombom.notification.service.NotificationProcessingService;
 import news.bombom.notification.service.NotificationService;
 import news.bombom.notification.service.NotificationTokenService;
 import org.springframework.http.HttpStatus;
@@ -27,18 +28,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class NotificationController {
 
     private final NotificationTokenService notificationTokenService;
+    private final NotificationProcessingService notificationProcessingService;
     private final NotificationService notificationService;
 
     @PostMapping("/tokens")
     @ResponseStatus(HttpStatus.CREATED)
-    public void registerNotificationToken(@Valid @RequestBody NotificationTokenRequest request) {
-        notificationTokenService.registerFcmToken(request.memberId(), request.deviceUuid(), request.token());
+    public void registerToken(@Valid @RequestBody NotificationTokenRequest request) {
+        notificationProcessingService.registerToken(request.memberId(), request.deviceUuid(), request.token());
     }
 
     @PutMapping("/tokens")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void upsertNotificationToken(@Valid @RequestBody NotificationTokenRequest request) {
-        notificationTokenService.upsertFcmToken(request.memberId(), request.deviceUuid(), request.token());
+    public void updateToken(@Valid @RequestBody NotificationTokenRequest request) {
+        notificationProcessingService.upsertToken(request.memberId(), request.deviceUuid(), request.token());
     }
 
     @PutMapping("/tokens/{memberId}/{deviceUuid}/settings")
@@ -46,8 +48,7 @@ public class NotificationController {
     public void updateDeviceNotificationSettings(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
             @PathVariable @NotBlank String deviceUuid,
-            @Valid @RequestBody NotificationSettingRequest request
-    ) {
+            @Valid @RequestBody NotificationSettingRequest request) {
         notificationTokenService.updateNotificationSetting(memberId, deviceUuid, request.enabled());
     }
 

--- a/backend/fcm-server/src/main/java/news/bombom/notification/controller/NotificationSettingController.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/controller/NotificationSettingController.java
@@ -1,0 +1,53 @@
+package news.bombom.notification.controller;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.request.NotificationCategorySettingRequest;
+import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
+import news.bombom.notification.service.NotificationSettingService;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/notifications")
+public class NotificationSettingController {
+
+    private final NotificationSettingService notificationSettingService;
+
+    @GetMapping("/{memberId}/settings")
+    public List<NotificationCategorySettingResponse> getCategorySettings(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId
+    ) {
+        return notificationSettingService.getCategorySettings(memberId);
+    }
+
+    @GetMapping("/{memberId}/settings/{category}")
+    public NotificationCategorySettingResponse getCategorySetting(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
+            @PathVariable NotificationCategory category
+    ) {
+        return notificationSettingService.getCategorySetting(memberId, category);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/{memberId}/settings/{category}")
+    public void updateNotificationCategorySetting(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
+            @PathVariable NotificationCategory category,
+            @Valid @RequestBody NotificationCategorySettingRequest request
+    ) {
+        notificationSettingService.updateCategorySetting(memberId, category, request.enabled());
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/controller/v1/NotificationController.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/controller/v1/NotificationController.java
@@ -3,15 +3,21 @@ package news.bombom.notification.controller.v1;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.request.NotificationCategorySettingRequest;
 import news.bombom.notification.dto.request.NotificationSendRequest;
 import news.bombom.notification.dto.request.NotificationSettingRequest;
 import news.bombom.notification.dto.request.NotificationTokenRequest;
+import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
 import news.bombom.notification.service.NotificationService;
+import news.bombom.notification.service.NotificationSettingService;
 import news.bombom.notification.service.NotificationTokenService;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -28,6 +34,7 @@ public class NotificationController {
 
     private final NotificationTokenService notificationTokenService;
     private final NotificationService notificationService;
+    private final NotificationSettingService notificationSettingService;
 
     @PostMapping("/tokens")
     @ResponseStatus(HttpStatus.CREATED)
@@ -46,16 +53,14 @@ public class NotificationController {
     public void updateNotificationSettings(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
             @PathVariable @NotBlank String deviceUuid,
-            @Valid @RequestBody NotificationSettingRequest request
-    ) {
+            @Valid @RequestBody NotificationSettingRequest request) {
         notificationTokenService.updateNotificationSetting(memberId, deviceUuid, request.enabled());
     }
 
     @GetMapping("/tokens/{memberId}/{deviceUuid}/settings/status")
     public boolean getNotificationSettingsStatus(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
-            @PathVariable @NotBlank String deviceUuid
-    ) {
+            @PathVariable @NotBlank String deviceUuid) {
         return notificationTokenService.getNotificationEnabled(memberId, deviceUuid);
     }
 
@@ -66,5 +71,30 @@ public class NotificationController {
     @ResponseStatus(HttpStatus.OK)
     public void sendNotification(@Valid @RequestBody NotificationSendRequest request) {
         notificationService.sendNotification(request.token(), request.title(), request.body(), request.articleId());
+    }
+
+    @GetMapping("/{memberId}/settings")
+    public List<NotificationCategorySettingResponse> getCategorySettings(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId
+    ) {
+        return notificationSettingService.getCategorySettings(memberId);
+    }
+
+    @GetMapping("/{memberId}/settings/{category}")
+    public boolean getCategorySetting(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
+            @PathVariable NotificationCategory category
+    ) {
+        return notificationSettingService.getCategorySetting(memberId, category);
+    }
+
+    @PatchMapping("/{memberId}/settings/{category}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void updateNotificationCategorySetting(
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
+            @PathVariable NotificationCategory category,
+            @Valid @RequestBody NotificationCategorySettingRequest request
+    ) {
+        notificationSettingService.updateCategorySetting(memberId, category, request.enabled());
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/controller/v1/NotificationController.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/controller/v1/NotificationController.java
@@ -81,7 +81,7 @@ public class NotificationController {
     }
 
     @GetMapping("/{memberId}/settings/{category}")
-    public boolean getCategorySetting(
+    public NotificationCategorySettingResponse getCategorySetting(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
             @PathVariable NotificationCategory category
     ) {

--- a/backend/fcm-server/src/main/java/news/bombom/notification/controller/v1/NotificationController.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/controller/v1/NotificationController.java
@@ -88,8 +88,8 @@ public class NotificationController {
         return notificationSettingService.getCategorySetting(memberId, category);
     }
 
-    @PatchMapping("/{memberId}/settings/{category}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping("/{memberId}/settings/{category}")
     public void updateNotificationCategorySetting(
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long memberId,
             @PathVariable NotificationCategory category,

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
@@ -35,14 +35,6 @@ public class MemberNotificationSetting extends BaseEntity {
         this.eventEnabled = eventEnabled;
     }
 
-    public void updateArticleEnabled(boolean enabled) {
-        this.articleEnabled = enabled;
-    }
-
-    public void updateEventEnabled(boolean enabled) {
-        this.eventEnabled = enabled;
-    }
-
     public void updateCategory(NotificationCategory category, boolean enabled) {
         switch (category) {
             case ARTICLE -> this.articleEnabled = enabled;

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
@@ -1,8 +1,6 @@
 package news.bombom.notification.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,39 +11,37 @@ import news.bombom.notification.common.BaseEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "uk_member_category", columnNames = {"memberId", "category"})
+})
 public class MemberNotificationSetting extends BaseEntity {
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
     @Column(nullable = false)
     private Long memberId;
 
-    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
-    private boolean articleEnabled = true;
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NotificationCategory category;
 
-    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
-    private boolean eventEnabled = false;
+    @Column(nullable = false)
+    private boolean isEnabled;
 
     @Builder
     public MemberNotificationSetting(
             @NonNull Long memberId,
-            boolean articleEnabled,
-            boolean eventEnabled) {
+            @NonNull NotificationCategory category,
+            boolean isEnabled
+    ) {
         this.memberId = memberId;
-        this.articleEnabled = articleEnabled;
-        this.eventEnabled = eventEnabled;
+        this.category = category;
+        this.isEnabled = isEnabled;
     }
 
-    public void updateCategory(NotificationCategory category, boolean enabled) {
-        switch (category) {
-            case ARTICLE -> this.articleEnabled = enabled;
-            case EVENT -> this.eventEnabled = enabled;
-        }
-    }
-
-    public boolean isEnabled(NotificationCategory category) {
-        return switch (category) {
-            case ARTICLE -> articleEnabled;
-            case EVENT -> eventEnabled;
-        };
+    public void updateEnabled(boolean isEnabled) {
+        this.isEnabled = isEnabled;
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
@@ -29,8 +29,7 @@ public class MemberNotificationSetting extends BaseEntity {
     public MemberNotificationSetting(
             @NonNull Long memberId,
             boolean articleEnabled,
-            boolean eventEnabled
-    ) {
+            boolean eventEnabled) {
         this.memberId = memberId;
         this.articleEnabled = articleEnabled;
         this.eventEnabled = eventEnabled;
@@ -42,6 +41,13 @@ public class MemberNotificationSetting extends BaseEntity {
 
     public void updateEventEnabled(boolean enabled) {
         this.eventEnabled = enabled;
+    }
+
+    public void updateCategory(NotificationCategory category, boolean enabled) {
+        switch (category) {
+            case ARTICLE -> this.articleEnabled = enabled;
+            case EVENT -> this.eventEnabled = enabled;
+        }
     }
 
     public boolean isEnabledFor(NotificationCategory category) {

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
@@ -1,0 +1,53 @@
+package news.bombom.notification.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombom.notification.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberNotificationSetting extends BaseEntity {
+
+    @Id
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private boolean articleEnabled = true;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean eventEnabled = false;
+
+    @Builder
+    public MemberNotificationSetting(
+            @NonNull Long memberId,
+            boolean articleEnabled,
+            boolean eventEnabled
+    ) {
+        this.memberId = memberId;
+        this.articleEnabled = articleEnabled;
+        this.eventEnabled = eventEnabled;
+    }
+
+    public void updateArticleEnabled(boolean enabled) {
+        this.articleEnabled = enabled;
+    }
+
+    public void updateEventEnabled(boolean enabled) {
+        this.eventEnabled = enabled;
+    }
+
+    public boolean isEnabledFor(NotificationCategory category) {
+        return switch (category) {
+            case ARTICLE -> articleEnabled;
+            case EVENT -> eventEnabled;
+        };
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/MemberNotificationSetting.java
@@ -42,7 +42,7 @@ public class MemberNotificationSetting extends BaseEntity {
         }
     }
 
-    public boolean isEnabledFor(NotificationCategory category) {
+    public boolean isEnabled(NotificationCategory category) {
         return switch (category) {
             case ARTICLE -> articleEnabled;
             case EVENT -> eventEnabled;

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
@@ -1,11 +1,15 @@
 package news.bombom.notification.domain;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public enum NotificationCategory {
 
-    ARTICLE,
-    EVENT,
+    ARTICLE(true),
+    EVENT(false),
     ;
+
+    private final boolean defaultSetting;
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
@@ -1,0 +1,11 @@
+package news.bombom.notification.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum NotificationCategory {
+
+    ARTICLE,
+    EVENT,
+    ;
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
@@ -1,9 +1,7 @@
 package news.bombom.notification.domain;
 
-import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-@Getter
 @RequiredArgsConstructor
 public enum NotificationCategory {
 
@@ -12,4 +10,8 @@ public enum NotificationCategory {
     ;
 
     private final boolean defaultSetting;
+
+    public boolean getDefaultSetting() {
+        return defaultSetting;
+    }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/dto/request/NotificationCategorySettingRequest.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/dto/request/NotificationCategorySettingRequest.java
@@ -1,0 +1,7 @@
+package news.bombom.notification.dto.request;
+
+public record NotificationCategorySettingRequest(
+
+        boolean enabled
+) {
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
@@ -8,7 +8,8 @@ import news.bombom.notification.domain.NotificationCategory;
 public record NotificationCategorySettingResponse(
 
         @NotNull NotificationCategory category,
-        boolean enabled) {
+        boolean enabled
+) {
 
     public static List<NotificationCategorySettingResponse> from(List<MemberNotificationSetting> settings) {
         return settings.stream()

--- a/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
@@ -8,13 +8,12 @@ import news.bombom.notification.domain.NotificationCategory;
 
 public record NotificationCategorySettingResponse(
 
-        @NotNull
-        NotificationCategory category,
+        @NotNull NotificationCategory category,
         boolean enabled
 ) {
 
     public static NotificationCategorySettingResponse from(MemberNotificationSetting setting, NotificationCategory category) {
-        return new NotificationCategorySettingResponse(category, setting.isEnabledFor(category));
+        return new NotificationCategorySettingResponse(category, setting.isEnabled(category));
     }
 
     public static List<NotificationCategorySettingResponse> from(MemberNotificationSetting setting) {

--- a/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
@@ -1,0 +1,13 @@
+package news.bombom.notification.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+import news.bombom.notification.domain.NotificationCategory;
+
+public record NotificationCategorySettingResponse(
+
+        @NotNull
+        NotificationCategory category,
+
+        boolean enabled
+) {
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
@@ -1,13 +1,25 @@
 package news.bombom.notification.dto.response;
 
 import jakarta.validation.constraints.NotNull;
+import java.util.Arrays;
+import java.util.List;
+import news.bombom.notification.domain.MemberNotificationSetting;
 import news.bombom.notification.domain.NotificationCategory;
 
 public record NotificationCategorySettingResponse(
 
         @NotNull
         NotificationCategory category,
-
         boolean enabled
 ) {
+
+    public static NotificationCategorySettingResponse from(MemberNotificationSetting setting, NotificationCategory category) {
+        return new NotificationCategorySettingResponse(category, setting.isEnabledFor(category));
+    }
+
+    public static List<NotificationCategorySettingResponse> from(MemberNotificationSetting setting) {
+        return Arrays.stream(NotificationCategory.values())
+                .map(category -> from(setting, category))
+                .toList();
+    }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
@@ -1,7 +1,6 @@
 package news.bombom.notification.dto.response;
 
 import jakarta.validation.constraints.NotNull;
-import java.util.Arrays;
 import java.util.List;
 import news.bombom.notification.domain.MemberNotificationSetting;
 import news.bombom.notification.domain.NotificationCategory;
@@ -12,13 +11,13 @@ public record NotificationCategorySettingResponse(
         boolean enabled
 ) {
 
-    public static NotificationCategorySettingResponse from(MemberNotificationSetting setting, NotificationCategory category) {
-        return new NotificationCategorySettingResponse(category, setting.isEnabled(category));
+    public static List<NotificationCategorySettingResponse> from(List<MemberNotificationSetting> settings) {
+        return settings.stream()
+                .map(NotificationCategorySettingResponse::from)
+                .toList();
     }
 
-    public static List<NotificationCategorySettingResponse> from(MemberNotificationSetting setting) {
-        return Arrays.stream(NotificationCategory.values())
-                .map(category -> from(setting, category))
-                .toList();
+    public static NotificationCategorySettingResponse from(MemberNotificationSetting setting) {
+        return new NotificationCategorySettingResponse(setting.getCategory(), setting.isEnabled());
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/dto/response/NotificationCategorySettingResponse.java
@@ -8,8 +8,7 @@ import news.bombom.notification.domain.NotificationCategory;
 public record NotificationCategorySettingResponse(
 
         @NotNull NotificationCategory category,
-        boolean enabled
-) {
+        boolean enabled) {
 
     public static List<NotificationCategorySettingResponse> from(List<MemberNotificationSetting> settings) {
         return settings.stream()

--- a/backend/fcm-server/src/main/java/news/bombom/notification/repository/MemberNotificationSettingRepository.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/repository/MemberNotificationSettingRepository.java
@@ -1,10 +1,16 @@
 package news.bombom.notification.repository;
 
+import java.util.List;
 import java.util.Optional;
 import news.bombom.notification.domain.MemberNotificationSetting;
+import news.bombom.notification.domain.NotificationCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberNotificationSettingRepository extends JpaRepository<MemberNotificationSetting, Long> {
 
-    Optional<MemberNotificationSetting> findByMemberId(Long memberId);
+    List<MemberNotificationSetting> findAllByMemberId(Long memberId);
+
+    Optional<MemberNotificationSetting> findByMemberIdAndCategory(Long memberId, NotificationCategory category);
+
+    boolean existsByMemberIdAndCategory(Long memberId, NotificationCategory category);
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/repository/MemberNotificationSettingRepository.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/repository/MemberNotificationSettingRepository.java
@@ -1,0 +1,10 @@
+package news.bombom.notification.repository;
+
+import java.util.Optional;
+import news.bombom.notification.domain.MemberNotificationSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberNotificationSettingRepository extends JpaRepository<MemberNotificationSetting, Long> {
+
+    Optional<MemberNotificationSetting> findByMemberId(Long memberId);
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/scheduler/NotificationScheduler.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/scheduler/NotificationScheduler.java
@@ -40,7 +40,7 @@ public class NotificationScheduler {
                     continue;
                 }
 
-                notificationProcessingService.processNotification(notification);
+                notificationProcessingService.processArticleArrivedNotification(notification);
             } catch (Exception e) {
                 log.error("알림 처리 중 오류 발생: notificationId={}", notification.getId(), e);
             }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationProcessingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationProcessingService.java
@@ -39,4 +39,16 @@ public class NotificationProcessingService {
         NotificationResultResponse result = notificationSender.sendToAllDevices(notification, fcmTokens);
         statusUpdater.updateStatus(notification, result);
     }
+
+    @Transactional
+    public void registerToken(Long memberId, String deviceUuid, String fcmToken) {
+        notificationTokenService.registerToken(memberId, deviceUuid, fcmToken);
+        notificationSettingService.ensureMemberNotificationSetting(memberId);
+    }
+
+    @Transactional
+    public void upsertToken(Long memberId, String deviceUuid, String fcmToken) {
+        notificationTokenService.upsertToken(memberId, deviceUuid, fcmToken);
+        notificationSettingService.ensureMemberNotificationSetting(memberId);
+    }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationProcessingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationProcessingService.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombom.notification.domain.ArticleArrivalNotification;
 import news.bombom.notification.domain.MemberFcmToken;
+import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.dto.response.NotificationResultResponse;
-import news.bombom.notification.service.NotificationTokenService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +22,10 @@ public class NotificationProcessingService {
 
     @Transactional
     public void processNotification(ArticleArrivalNotification notification) {
-        List<MemberFcmToken> fcmTokens = notificationTokenService.resolveTokens(notification.getMemberId());
-        
+        List<MemberFcmToken> fcmTokens = notificationTokenService.resolveTokens(
+                notification.getMemberId(),
+                NotificationCategory.ARTICLE
+        );
         if (fcmTokens.isEmpty()) {
             statusUpdater.markAsFailed(notification, "FCM 토큰 없음");
             return;

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationProcessingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationProcessingService.java
@@ -19,13 +19,18 @@ public class NotificationProcessingService {
     private final NotificationTokenService notificationTokenService;
     private final NotificationSenderService notificationSender;
     private final NotificationStatusService statusUpdater;
+    private final NotificationSettingService notificationSettingService;
 
     @Transactional
     public void processArticleArrivedNotification(ArticleArrivalNotification notification) {
-        List<MemberFcmToken> fcmTokens = notificationTokenService.resolveTokens(
-                notification.getMemberId(),
-                NotificationCategory.ARTICLE
-        );
+        Long memberId = notification.getMemberId();
+        NotificationCategory category = NotificationCategory.ARTICLE;
+        if (!notificationSettingService.isEnabled(memberId, category)) {
+            log.info("알림 수신 동의하지 않음: memberId={}, category={}", memberId, category);
+            return;
+        }
+
+        List<MemberFcmToken> fcmTokens = notificationTokenService.resolveTokens(memberId);
         if (fcmTokens.isEmpty()) {
             statusUpdater.markAsFailed(notification, "FCM 토큰 없음");
             return;

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationProcessingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationProcessingService.java
@@ -21,7 +21,7 @@ public class NotificationProcessingService {
     private final NotificationStatusService statusUpdater;
 
     @Transactional
-    public void processNotification(ArticleArrivalNotification notification) {
+    public void processArticleArrivedNotification(ArticleArrivalNotification notification) {
         List<MemberFcmToken> fcmTokens = notificationTokenService.resolveTokens(
                 notification.getMemberId(),
                 NotificationCategory.ARTICLE

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationService.java
@@ -54,8 +54,7 @@ public class NotificationService {
     /**
      * 여러 토큰으로 일괄 알림 전송 (비즈니스 로직 포함)
      */
-    public Map<String, NotificationResult> sendBulkNotification(List<String> tokens, String title, String body,
-                                                                String articleId) {
+    public Map<String, NotificationResult> sendBulkNotification(List<String> tokens, String title, String body, String articleId) {
         if (tokens == null || tokens.isEmpty()) {
             throw new IllegalArgumentException("전송할 토큰 목록이 비어있습니다.");
         }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -53,7 +53,7 @@ public class NotificationSettingService {
 
     public boolean isEnabled(Long memberId, NotificationCategory category) {
         return settingRepository.findByMemberId(memberId)
-                .map(setting -> setting.isEnabledFor(category))
+                .map(setting -> setting.isEnabled(category))
                 .orElse(true);
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -1,0 +1,55 @@
+package news.bombom.notification.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import news.bombom.notification.domain.MemberNotificationSetting;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
+import news.bombom.notification.repository.MemberNotificationSettingRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationSettingService {
+
+    private final MemberNotificationSettingRepository settingRepository;
+
+    @Transactional
+    public void updateCategorySetting(Long memberId, NotificationCategory category, boolean enabled) {
+        MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
+                .orElseGet(() -> createAndSaveDefaultSetting(memberId));
+
+        setting.updateCategory(category, enabled);
+    }
+
+    public List<NotificationCategorySettingResponse> getCategorySettings(Long memberId) {
+        MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
+                .orElseGet(() -> createDefaultSetting(memberId));
+
+        return List.of(
+                new NotificationCategorySettingResponse(NotificationCategory.ARTICLE, setting.isArticleEnabled()),
+                new NotificationCategorySettingResponse(NotificationCategory.EVENT, setting.isEventEnabled()));
+    }
+
+    public boolean getCategorySetting(Long memberId, NotificationCategory category) {
+        MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
+                .orElseGet(() -> createDefaultSetting(memberId));
+
+        return setting.isEnabledFor(category);
+    }
+
+    private MemberNotificationSetting createAndSaveDefaultSetting(Long memberId) {
+        MemberNotificationSetting setting = createDefaultSetting(memberId);
+        return settingRepository.save(setting);
+    }
+
+    private MemberNotificationSetting createDefaultSetting(Long memberId) {
+        return MemberNotificationSetting.builder()
+                .memberId(memberId)
+                .articleEnabled(true)
+                .eventEnabled(false)
+                .build();
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -27,17 +27,13 @@ public class NotificationSettingService {
     public List<NotificationCategorySettingResponse> getCategorySettings(Long memberId) {
         MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
                 .orElseGet(() -> createDefaultSetting(memberId));
-
-        return List.of(
-                new NotificationCategorySettingResponse(NotificationCategory.ARTICLE, setting.isArticleEnabled()),
-                new NotificationCategorySettingResponse(NotificationCategory.EVENT, setting.isEventEnabled()));
+        return NotificationCategorySettingResponse.from(setting);
     }
 
-    public boolean getCategorySetting(Long memberId, NotificationCategory category) {
+    public NotificationCategorySettingResponse getCategorySetting(Long memberId, NotificationCategory category) {
         MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
                 .orElseGet(() -> createDefaultSetting(memberId));
-
-        return setting.isEnabledFor(category);
+        return NotificationCategorySettingResponse.from(setting, category);
     }
 
     private MemberNotificationSetting createAndSaveDefaultSetting(Long memberId) {

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -19,13 +19,23 @@ public class NotificationSettingService {
     @Transactional
     public MemberNotificationSetting ensureMemberNotificationSetting(Long memberId) {
         return settingRepository.findByMemberId(memberId)
-                .orElseGet(() -> createAndSaveDefaultSetting(memberId));
+                .orElseGet(() -> createDefaultSetting(memberId));
+    }
+
+    @Transactional
+    public MemberNotificationSetting createDefaultSetting(Long memberId) {
+        MemberNotificationSetting memberNotificationSetting = MemberNotificationSetting.builder()
+                .memberId(memberId)
+                .articleEnabled(true)
+                .eventEnabled(false)
+                .build();
+        return settingRepository.save(memberNotificationSetting);
     }
 
     @Transactional
     public void updateCategorySetting(Long memberId, NotificationCategory category, boolean enabled) {
         MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
-                .orElseGet(() -> createAndSaveDefaultSetting(memberId));
+                .orElseGet(() -> createDefaultSetting(memberId));
         setting.updateCategory(category, enabled);
     }
 
@@ -39,18 +49,5 @@ public class NotificationSettingService {
         MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
                 .orElseGet(() -> createDefaultSetting(memberId));
         return NotificationCategorySettingResponse.from(setting, category);
-    }
-
-    private MemberNotificationSetting createAndSaveDefaultSetting(Long memberId) {
-        MemberNotificationSetting setting = createDefaultSetting(memberId);
-        return settingRepository.save(setting);
-    }
-
-    private MemberNotificationSetting createDefaultSetting(Long memberId) {
-        return MemberNotificationSetting.builder()
-                .memberId(memberId)
-                .articleEnabled(true)
-                .eventEnabled(false)
-                .build();
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -1,5 +1,6 @@
 package news.bombom.notification.service;
 
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import news.bombom.notification.domain.MemberNotificationSetting;
@@ -17,43 +18,53 @@ public class NotificationSettingService {
     private final MemberNotificationSettingRepository settingRepository;
 
     @Transactional
-    public MemberNotificationSetting ensureMemberNotificationSetting(Long memberId) {
-        return settingRepository.findByMemberId(memberId)
-                .orElseGet(() -> createDefaultSetting(memberId));
-    }
-
-    @Transactional
-    public MemberNotificationSetting createDefaultSetting(Long memberId) {
-        MemberNotificationSetting memberNotificationSetting = MemberNotificationSetting.builder()
-                .memberId(memberId)
-                .articleEnabled(true)
-                .eventEnabled(false)
-                .build();
-        return settingRepository.save(memberNotificationSetting);
+    public void ensureMemberNotificationSetting(Long memberId) {
+        Arrays.stream(NotificationCategory.values())
+                .forEach(category -> ensureCategorySetting(memberId, category));
     }
 
     @Transactional
     public void updateCategorySetting(Long memberId, NotificationCategory category, boolean enabled) {
-        MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
-                .orElseGet(() -> createDefaultSetting(memberId));
-        setting.updateCategory(category, enabled);
+        MemberNotificationSetting setting = settingRepository.findByMemberIdAndCategory(memberId, category)
+                .orElseGet(() -> MemberNotificationSetting.builder()
+                        .memberId(memberId)
+                        .category(category)
+                        .isEnabled(enabled)
+                        .build());
+
+        setting.updateEnabled(enabled);
+        settingRepository.save(setting);
     }
 
     public List<NotificationCategorySettingResponse> getCategorySettings(Long memberId) {
-        MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
-                .orElseGet(() -> createDefaultSetting(memberId));
-        return NotificationCategorySettingResponse.from(setting);
+        ensureMemberNotificationSetting(memberId);
+        List<MemberNotificationSetting> settings = settingRepository.findAllByMemberId(memberId);
+        return NotificationCategorySettingResponse.from(settings);
     }
 
     public NotificationCategorySettingResponse getCategorySetting(Long memberId, NotificationCategory category) {
-        MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
-                .orElseGet(() -> createDefaultSetting(memberId));
-        return NotificationCategorySettingResponse.from(setting, category);
+        MemberNotificationSetting setting = settingRepository.findByMemberIdAndCategory(memberId, category)
+                .orElseGet(() -> {
+                    ensureCategorySetting(memberId, category);
+                    return settingRepository.findByMemberIdAndCategory(memberId, category).orElseThrow();
+                });
+        return NotificationCategorySettingResponse.from(setting);
     }
 
     public boolean isEnabled(Long memberId, NotificationCategory category) {
-        return settingRepository.findByMemberId(memberId)
-                .map(setting -> setting.isEnabled(category))
-                .orElse(true);
+        return settingRepository.findByMemberIdAndCategory(memberId, category)
+                .map(MemberNotificationSetting::isEnabled)
+                .orElse(category.isDefaultSetting());
+    }
+
+    private void ensureCategorySetting(Long memberId, NotificationCategory category) {
+        if (!settingRepository.existsByMemberIdAndCategory(memberId, category)) {
+            MemberNotificationSetting setting = MemberNotificationSetting.builder()
+                    .memberId(memberId)
+                    .category(category)
+                    .isEnabled(category.isDefaultSetting())
+                    .build();
+            settingRepository.save(setting);
+        }
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -20,7 +20,6 @@ public class NotificationSettingService {
     public void updateCategorySetting(Long memberId, NotificationCategory category, boolean enabled) {
         MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
                 .orElseGet(() -> createAndSaveDefaultSetting(memberId));
-
         setting.updateCategory(category, enabled);
     }
 

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -61,14 +61,14 @@ public class NotificationSettingService {
     public boolean isEnabled(Long memberId, NotificationCategory category) {
         return settingRepository.findByMemberIdAndCategory(memberId, category)
                 .map(MemberNotificationSetting::isEnabled)
-                .orElse(category.isDefaultSetting());
+                .orElse(category.getDefaultSetting());
     }
 
     private MemberNotificationSetting createDefaultSetting(Long memberId, NotificationCategory category) {
         return MemberNotificationSetting.builder()
                 .memberId(memberId)
                 .category(category)
-                .isEnabled(category.isDefaultSetting())
+                .isEnabled(category.getDefaultSetting())
                 .build();
     }
 

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -1,7 +1,9 @@
 package news.bombom.notification.service;
 
-import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import news.bombom.notification.domain.MemberNotificationSetting;
 import news.bombom.notification.domain.NotificationCategory;
@@ -11,43 +13,48 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class NotificationSettingService {
 
     private final MemberNotificationSettingRepository settingRepository;
 
     @Transactional
-    public void ensureMemberNotificationSetting(Long memberId) {
-        Arrays.stream(NotificationCategory.values())
-                .forEach(category -> ensureCategorySetting(memberId, category));
+    public List<MemberNotificationSetting> ensureMemberNotificationSetting(Long memberId) {
+        List<MemberNotificationSetting> settings = new ArrayList<>(settingRepository.findAllByMemberId(memberId));
+        Set<NotificationCategory> missingCategories = getMissingCategories(settings);
+
+        if (missingCategories.isEmpty()) {
+            return settings;
+        }
+
+        List<MemberNotificationSetting> newSettings = missingCategories.stream()
+                .map(category -> createDefaultSetting(memberId, category))
+                .toList();
+
+        settings.addAll(settingRepository.saveAll(newSettings));
+        return settings;
     }
 
     @Transactional
     public void updateCategorySetting(Long memberId, NotificationCategory category, boolean enabled) {
         MemberNotificationSetting setting = settingRepository.findByMemberIdAndCategory(memberId, category)
-                .orElseGet(() -> MemberNotificationSetting.builder()
-                        .memberId(memberId)
-                        .category(category)
-                        .isEnabled(enabled)
-                        .build());
+                .orElseGet(() -> createDefaultSetting(memberId, category));
 
         setting.updateEnabled(enabled);
         settingRepository.save(setting);
     }
 
+    @Transactional
     public List<NotificationCategorySettingResponse> getCategorySettings(Long memberId) {
-        ensureMemberNotificationSetting(memberId);
-        List<MemberNotificationSetting> settings = settingRepository.findAllByMemberId(memberId);
+        List<MemberNotificationSetting> settings = ensureMemberNotificationSetting(memberId);
         return NotificationCategorySettingResponse.from(settings);
     }
 
+    @Transactional
     public NotificationCategorySettingResponse getCategorySetting(Long memberId, NotificationCategory category) {
         MemberNotificationSetting setting = settingRepository.findByMemberIdAndCategory(memberId, category)
-                .orElseGet(() -> {
-                    ensureCategorySetting(memberId, category);
-                    return settingRepository.findByMemberIdAndCategory(memberId, category).orElseThrow();
-                });
+                .orElseGet(() -> settingRepository.save(createDefaultSetting(memberId, category)));
         return NotificationCategorySettingResponse.from(setting);
     }
 
@@ -57,14 +64,17 @@ public class NotificationSettingService {
                 .orElse(category.isDefaultSetting());
     }
 
-    private void ensureCategorySetting(Long memberId, NotificationCategory category) {
-        if (!settingRepository.existsByMemberIdAndCategory(memberId, category)) {
-            MemberNotificationSetting setting = MemberNotificationSetting.builder()
-                    .memberId(memberId)
-                    .category(category)
-                    .isEnabled(category.isDefaultSetting())
-                    .build();
-            settingRepository.save(setting);
-        }
+    private MemberNotificationSetting createDefaultSetting(Long memberId, NotificationCategory category) {
+        return MemberNotificationSetting.builder()
+                .memberId(memberId)
+                .category(category)
+                .isEnabled(category.isDefaultSetting())
+                .build();
+    }
+
+    private Set<NotificationCategory> getMissingCategories(List<MemberNotificationSetting> existing) {
+        Set<NotificationCategory> missing = EnumSet.allOf(NotificationCategory.class);
+        existing.forEach(setting -> missing.remove(setting.getCategory()));
+        return missing;
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -50,4 +50,10 @@ public class NotificationSettingService {
                 .orElseGet(() -> createDefaultSetting(memberId));
         return NotificationCategorySettingResponse.from(setting, category);
     }
+
+    public boolean isEnabled(Long memberId, NotificationCategory category) {
+        return settingRepository.findByMemberId(memberId)
+                .map(setting -> setting.isEnabledFor(category))
+                .orElse(true);
+    }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -17,6 +17,12 @@ public class NotificationSettingService {
     private final MemberNotificationSettingRepository settingRepository;
 
     @Transactional
+    public MemberNotificationSetting ensureMemberNotificationSetting(Long memberId) {
+        return settingRepository.findByMemberId(memberId)
+                .orElseGet(() -> createAndSaveDefaultSetting(memberId));
+    }
+
+    @Transactional
     public void updateCategorySetting(Long memberId, NotificationCategory category, boolean enabled) {
         MemberNotificationSetting setting = settingRepository.findByMemberId(memberId)
                 .orElseGet(() -> createAndSaveDefaultSetting(memberId));

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
@@ -10,7 +10,6 @@ import news.bombom.notification.domain.MemberFcmToken;
 import news.bombom.notification.domain.MemberNotificationSetting;
 import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.repository.MemberFcmTokenRepository;
-import news.bombom.notification.repository.MemberNotificationSettingRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationTokenService {
 
     private final MemberFcmTokenRepository fcmTokenRepository;
-    private final MemberNotificationSettingRepository notificationSettingRepository;
+    private final NotificationSettingService notificationSettingService;
 
     /**
      * 알림 토큰 등록
@@ -94,9 +93,7 @@ public class NotificationTokenService {
      * 회원의 알림 토큰 조회 (카테고리별 필터링)
      */
     public List<MemberFcmToken> resolveTokens(Long memberId, NotificationCategory category) {
-        MemberNotificationSetting setting = notificationSettingRepository.findByMemberId(memberId)
-                .orElseGet(() -> createDefaultSetting(memberId));
-
+        MemberNotificationSetting setting = notificationSettingService.ensureMemberNotificationSetting(memberId);
         if (!setting.isEnabledFor(category)) {
             log.info("알림 수신 동의하지 않음: memberId={}, category={}", memberId, category);
             return Collections.emptyList();
@@ -124,13 +121,5 @@ public class NotificationTokenService {
                     );
                 });
         return memberFcmToken.isNotificationEnabled();
-    }
-
-    private MemberNotificationSetting createDefaultSetting(Long memberId) {
-        return MemberNotificationSetting.builder()
-                .memberId(memberId)
-                .articleEnabled(true)
-                .eventEnabled(false)
-                .build();
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
@@ -1,12 +1,16 @@
 package news.bombom.notification.service;
 
 import jakarta.persistence.EntityNotFoundException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombom.notification.domain.MemberFcmToken;
+import news.bombom.notification.domain.MemberNotificationSetting;
+import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.repository.MemberFcmTokenRepository;
+import news.bombom.notification.repository.MemberNotificationSettingRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationTokenService {
 
     private final MemberFcmTokenRepository fcmTokenRepository;
+    private final MemberNotificationSettingRepository notificationSettingRepository;
 
     /**
      * 알림 토큰 등록
@@ -86,9 +91,17 @@ public class NotificationTokenService {
     }
 
     /**
-     * 회원의 알림 토큰 조회
+     * 회원의 알림 토큰 조회 (카테고리별 필터링)
      */
-    public List<MemberFcmToken> resolveTokens(Long memberId) {
+    public List<MemberFcmToken> resolveTokens(Long memberId, NotificationCategory category) {
+        MemberNotificationSetting setting = notificationSettingRepository.findByMemberId(memberId)
+                .orElseGet(() -> createDefaultSetting(memberId));
+
+        if (!setting.isEnabledFor(category)) {
+            log.info("알림 수신 동의하지 않음: memberId={}, category={}", memberId, category);
+            return Collections.emptyList();
+        }
+
         List<MemberFcmToken> fcmTokens = fcmTokenRepository.findByMemberId(memberId);
 
         if (fcmTokens.isEmpty()) {
@@ -111,5 +124,13 @@ public class NotificationTokenService {
                     );
                 });
         return memberFcmToken.isNotificationEnabled();
+    }
+
+    private MemberNotificationSetting createDefaultSetting(Long memberId) {
+        return MemberNotificationSetting.builder()
+                .memberId(memberId)
+                .articleEnabled(true)
+                .eventEnabled(false)
+                .build();
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombom.notification.domain.MemberFcmToken;
-import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.repository.MemberFcmTokenRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,13 +17,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationTokenService {
 
     private final MemberFcmTokenRepository fcmTokenRepository;
-    private final NotificationSettingService notificationSettingService;
 
     /**
      * 알림 토큰 등록
      */
     @Transactional
-    public void registerFcmToken(Long memberId, String deviceUuid, String fcmToken) {
+    public void registerToken(Long memberId, String deviceUuid, String fcmToken) {
         fcmTokenRepository.deleteByDeviceUuid(deviceUuid);
 
         MemberFcmToken token = MemberFcmToken.builder()
@@ -34,7 +32,6 @@ public class NotificationTokenService {
                 .isNotificationEnabled(true)
                 .build();
         fcmTokenRepository.save(token);
-        notificationSettingService.createDefaultSetting(memberId);
         log.info("알림 토큰 등록 완료: memberId={}, deviceUuid={}", memberId, deviceUuid);
     }
 
@@ -42,9 +39,8 @@ public class NotificationTokenService {
      * 알림 토큰 업데이트 또는 등록
      */
     @Transactional
-    public void upsertFcmToken(Long memberId, String deviceUuid, String fcmToken) {
-        Optional<MemberFcmToken> fcmTokenOptional = fcmTokenRepository.findByMemberIdAndDeviceUuid(memberId,
-                deviceUuid);
+    public void upsertToken(Long memberId, String deviceUuid, String fcmToken) {
+        Optional<MemberFcmToken> fcmTokenOptional = fcmTokenRepository.findByMemberIdAndDeviceUuid(memberId, deviceUuid);
 
         if (fcmTokenOptional.isPresent()) {
             MemberFcmToken token = fcmTokenOptional.get();

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
@@ -36,6 +36,7 @@ public class NotificationTokenService {
                 .isNotificationEnabled(true)
                 .build();
         fcmTokenRepository.save(token);
+        notificationSettingService.createDefaultSetting(memberId);
         log.info("알림 토큰 등록 완료: memberId={}, deviceUuid={}", memberId, deviceUuid);
     }
 

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
@@ -1,13 +1,11 @@
 package news.bombom.notification.service;
 
 import jakarta.persistence.EntityNotFoundException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombom.notification.domain.MemberFcmToken;
-import news.bombom.notification.domain.MemberNotificationSetting;
 import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.repository.MemberFcmTokenRepository;
 import org.springframework.stereotype.Service;
@@ -91,15 +89,9 @@ public class NotificationTokenService {
     }
 
     /**
-     * 회원의 알림 토큰 조회 (카테고리별 필터링)
+     * 회원의 알림 토큰 조회
      */
-    public List<MemberFcmToken> resolveTokens(Long memberId, NotificationCategory category) {
-        MemberNotificationSetting setting = notificationSettingService.ensureMemberNotificationSetting(memberId);
-        if (!setting.isEnabledFor(category)) {
-            log.info("알림 수신 동의하지 않음: memberId={}, category={}", memberId, category);
-            return Collections.emptyList();
-        }
-
+    public List<MemberFcmToken> resolveTokens(Long memberId) {
         List<MemberFcmToken> fcmTokens = fcmTokenRepository.findByMemberId(memberId);
 
         if (fcmTokens.isEmpty()) {
@@ -117,9 +109,7 @@ public class NotificationTokenService {
                             String.format(
                                     "memberId=%d, deviceUuid=%s 에 해당하는 FCM 토큰이 존재하지 않습니다.",
                                     memberId,
-                                    deviceUuid
-                            )
-                    );
+                                    deviceUuid));
                 });
         return memberFcmToken.isNotificationEnabled();
     }

--- a/backend/fcm-server/src/test/java/news/bombom/notification/controller/NotificationSettingControllerTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/controller/NotificationSettingControllerTest.java
@@ -1,0 +1,81 @@
+package news.bombom.notification.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.request.NotificationCategorySettingRequest;
+import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
+import news.bombom.notification.service.NotificationSettingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(NotificationSettingController.class)
+@DisplayName("알림 설정 컨트롤러 테스트")
+class NotificationSettingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NotificationSettingService notificationSettingService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMappingContext;
+
+    @MockitoBean
+    private AuditingHandler jpaAuditingHandler;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private final Long TEST_MEMBER_ID = 1L;
+
+    @Test
+    @DisplayName("사용자의 전체 알림 설정 조회 성공")
+    void getCategorySettings_Success() throws Exception {
+        // Given
+        List<NotificationCategorySettingResponse> responses = List.of(
+                new NotificationCategorySettingResponse(NotificationCategory.ARTICLE, true),
+                new NotificationCategorySettingResponse(NotificationCategory.EVENT, false));
+        when(notificationSettingService.getCategorySettings(TEST_MEMBER_ID)).thenReturn(responses);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/notifications/{memberId}/settings", TEST_MEMBER_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].category").value("ARTICLE"))
+                .andExpect(jsonPath("$[0].enabled").value(true));
+    }
+
+    @Test
+    @DisplayName("특정 카테고리 알림 설정 업데이트 성공")
+    void updateNotificationCategorySetting_Success() throws Exception {
+        // Given
+        NotificationCategorySettingRequest request = new NotificationCategorySettingRequest(false);
+        doNothing().when(notificationSettingService).updateCategorySetting(anyLong(), any(), anyBoolean());
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/notifications/{memberId}/settings/{category}",
+                TEST_MEMBER_ID, NotificationCategory.ARTICLE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/notification/controller/v1/NotificationControllerTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/controller/v1/NotificationControllerTest.java
@@ -1,10 +1,15 @@
 package news.bombom.notification.controller.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.request.NotificationCategorySettingRequest;
 import news.bombom.notification.dto.request.NotificationTokenRequest;
 import news.bombom.notification.dto.request.NotificationSettingRequest;
 import news.bombom.notification.dto.request.NotificationSendRequest;
 import news.bombom.notification.dto.NotificationResult;
+import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
+import news.bombom.notification.service.NotificationSettingService;
 import news.bombom.notification.service.NotificationTokenService;
 import news.bombom.notification.service.NotificationService;
 import org.junit.jupiter.api.DisplayName;
@@ -33,6 +38,9 @@ class NotificationControllerTest {
     private NotificationTokenService notificationTokenService;
 
     @MockitoBean
+    private NotificationSettingService notificationSettingService;
+
+    @MockitoBean
     private JpaMetamodelMappingContext jpaMappingContext;
 
     @MockitoBean
@@ -53,7 +61,6 @@ class NotificationControllerTest {
     void registerNotificationToken_Success() throws Exception {
         // Given
         NotificationTokenRequest request = new NotificationTokenRequest(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
-        
         doNothing().when(notificationTokenService).registerFcmToken(anyLong(), anyString(), anyString());
 
         // When & Then
@@ -85,7 +92,7 @@ class NotificationControllerTest {
     void upsertNotificationToken_Success() throws Exception {
         // Given
         NotificationTokenRequest request = new NotificationTokenRequest(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
-        
+
         doNothing().when(notificationTokenService).upsertFcmToken(anyLong(), anyString(), anyString());
 
         // When & Then
@@ -117,7 +124,7 @@ class NotificationControllerTest {
     void updateNotificationSettings_Success() throws Exception {
         // Given
         NotificationSettingRequest request = new NotificationSettingRequest(true);
-        
+
         doNothing().when(notificationTokenService).updateNotificationSetting(anyLong(), anyString(), anyBoolean());
 
         // When & Then
@@ -149,12 +156,12 @@ class NotificationControllerTest {
     void sendNotification_Success() throws Exception {
         // Given
         NotificationSendRequest request = new NotificationSendRequest(
-                TEST_FCM_TOKEN, 
-                "테스트 제목", 
-                "테스트 내용", 
+                TEST_FCM_TOKEN,
+                "테스트 제목",
+                "테스트 내용",
                 "test-article-123"
         );
-        
+
         NotificationResult successResult = NotificationResult.success("test-message-id");
         when(notificationService.sendNotification(anyString(), anyString(), anyString(), anyString())).thenReturn(successResult);
 
@@ -180,5 +187,96 @@ class NotificationControllerTest {
                 .andExpect(status().isBadRequest());
 
         verify(notificationService, never()).sendNotification(anyString(), anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("카테고리 설정 업데이트 성공 - 소문자")
+    void updateNotificationCategorySetting_Success_Lowercase() throws Exception {
+        // Given
+        NotificationCategorySettingRequest request = new NotificationCategorySettingRequest(true);
+        doNothing().when(notificationSettingService).updateCategorySetting(
+                anyLong(),
+                any(NotificationCategory.class),
+                anyBoolean()
+        );
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/notifications/{memberId}/settings/{category}", TEST_MEMBER_ID, "event")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+
+        verify(notificationSettingService, times(1)).updateCategorySetting(
+                TEST_MEMBER_ID,
+                NotificationCategory.EVENT,
+                true
+        );
+    }
+
+    @Test
+    @DisplayName("카테고리 설정 업데이트 성공 - 대문자")
+    void updateNotificationCategorySetting_Success_Uppercase() throws Exception {
+        // Given
+        NotificationCategorySettingRequest request = new NotificationCategorySettingRequest(false);
+        doNothing().when(notificationSettingService).updateCategorySetting(
+                anyLong(),
+                any(NotificationCategory.class),
+                anyBoolean()
+        );
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/notifications/{memberId}/settings/{category}", TEST_MEMBER_ID, "ARTICLE")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent());
+
+        verify(notificationSettingService, times(1)).updateCategorySetting(
+                TEST_MEMBER_ID,
+                NotificationCategory.ARTICLE,
+                false
+        );
+    }
+
+    @Test
+    @DisplayName("모든 카테고리 설정 조회 성공")
+    void getCategorySettings_Success() throws Exception {
+        // Given
+        List<NotificationCategorySettingResponse> responses = List.of(
+                new NotificationCategorySettingResponse(NotificationCategory.ARTICLE, true),
+                new NotificationCategorySettingResponse(NotificationCategory.EVENT, false)
+        );
+        when(notificationSettingService.getCategorySettings(anyLong())).thenReturn(responses);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/notifications/{memberId}/settings", TEST_MEMBER_ID))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].category").value("ARTICLE"))
+                .andExpect(jsonPath("$[0].enabled").value(true))
+                .andExpect(jsonPath("$[1].category").value("EVENT"))
+                .andExpect(jsonPath("$[1].enabled").value(false));
+
+        verify(notificationSettingService, times(1)).getCategorySettings(TEST_MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("특정 카테고리 설정 조회 성공")
+    void getCategorySetting_Success() throws Exception {
+        // Given
+        NotificationCategorySettingResponse response = new NotificationCategorySettingResponse(NotificationCategory.EVENT, true);
+        when(notificationSettingService.getCategorySetting(anyLong(), any(NotificationCategory.class)))
+                .thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/notifications/{memberId}/settings/{category}", TEST_MEMBER_ID, "event"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.category").value("EVENT"))
+                .andExpect(jsonPath("$.enabled").value(true));
+
+        verify(notificationSettingService, times(1)).getCategorySetting(
+                TEST_MEMBER_ID,
+                NotificationCategory.EVENT
+        );
     }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/notification/controller/v1/NotificationControllerTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/controller/v1/NotificationControllerTest.java
@@ -1,15 +1,12 @@
 package news.bombom.notification.controller.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
-import news.bombom.notification.domain.NotificationCategory;
-import news.bombom.notification.dto.request.NotificationCategorySettingRequest;
+import news.bombom.notification.controller.NotificationController;
 import news.bombom.notification.dto.request.NotificationTokenRequest;
 import news.bombom.notification.dto.request.NotificationSettingRequest;
 import news.bombom.notification.dto.request.NotificationSendRequest;
 import news.bombom.notification.dto.NotificationResult;
-import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
-import news.bombom.notification.service.NotificationSettingService;
+import news.bombom.notification.service.NotificationProcessingService;
 import news.bombom.notification.service.NotificationTokenService;
 import news.bombom.notification.service.NotificationService;
 import org.junit.jupiter.api.DisplayName;
@@ -38,7 +35,7 @@ class NotificationControllerTest {
     private NotificationTokenService notificationTokenService;
 
     @MockitoBean
-    private NotificationSettingService notificationSettingService;
+    private NotificationProcessingService notificationProcessingService;
 
     @MockitoBean
     private JpaMetamodelMappingContext jpaMappingContext;
@@ -58,10 +55,10 @@ class NotificationControllerTest {
 
     @Test
     @DisplayName("알림 토큰 등록 성공")
-    void registerNotificationToken_Success() throws Exception {
+    void registerToken_Success() throws Exception {
         // Given
         NotificationTokenRequest request = new NotificationTokenRequest(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
-        doNothing().when(notificationTokenService).registerFcmToken(anyLong(), anyString(), anyString());
+        doNothing().when(notificationProcessingService).registerToken(anyLong(), anyString(), anyString());
 
         // When & Then
         mockMvc.perform(post("/api/v1/notifications/tokens")
@@ -69,14 +66,15 @@ class NotificationControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated());
 
-        verify(notificationTokenService, times(1)).registerFcmToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
+        verify(notificationProcessingService, times(1)).registerToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
     }
 
     @Test
     @DisplayName("알림 토큰 등록 - 유효성 검증 실패")
-    void registerNotificationToken_ValidationFailure() throws Exception {
+    void registerToken_ValidationFailure() throws Exception {
         // Given - 잘못된 요청 (memberId가 null)
-        NotificationTokenRequest invalidRequest = new NotificationTokenRequest(null, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
+        NotificationTokenRequest invalidRequest = new NotificationTokenRequest(null, TEST_DEVICE_UUID,
+                TEST_FCM_TOKEN);
 
         // When & Then
         mockMvc.perform(post("/api/v1/notifications/tokens")
@@ -84,16 +82,15 @@ class NotificationControllerTest {
                         .content(objectMapper.writeValueAsString(invalidRequest)))
                 .andExpect(status().isBadRequest());
 
-        verify(notificationTokenService, never()).registerFcmToken(anyLong(), anyString(), anyString());
+        verify(notificationProcessingService, never()).registerToken(anyLong(), anyString(), anyString());
     }
 
     @Test
-    @DisplayName("알림 토큰 업서트 성공")
-    void upsertNotificationToken_Success() throws Exception {
+    @DisplayName("알림 토큰 업데이트 성공")
+    void updateToken_Success() throws Exception {
         // Given
         NotificationTokenRequest request = new NotificationTokenRequest(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
-
-        doNothing().when(notificationTokenService).upsertFcmToken(anyLong(), anyString(), anyString());
+        doNothing().when(notificationProcessingService).upsertToken(anyLong(), anyString(), anyString());
 
         // When & Then
         mockMvc.perform(put("/api/v1/notifications/tokens")
@@ -101,31 +98,16 @@ class NotificationControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNoContent());
 
-        verify(notificationTokenService, times(1)).upsertFcmToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
+        verify(notificationProcessingService, times(1)).upsertToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
     }
 
     @Test
-    @DisplayName("알림 토큰 업서트 - 유효성 검증 실패")
-    void upsertNotificationToken_ValidationFailure() throws Exception {
-        // Given - 잘못된 요청 (fcmToken이 빈 문자열)
-        NotificationTokenRequest invalidRequest = new NotificationTokenRequest(TEST_MEMBER_ID, TEST_DEVICE_UUID, "");
-
-        // When & Then
-        mockMvc.perform(put("/api/v1/notifications/tokens")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidRequest)))
-                .andExpect(status().isBadRequest());
-
-        verify(notificationTokenService, never()).upsertFcmToken(anyLong(), anyString(), anyString());
-    }
-
-    @Test
-    @DisplayName("알림 설정 업데이트 성공")
-    void updateNotificationSettings_Success() throws Exception {
+    @DisplayName("기기별 알림 설정 업데이트 성공")
+    void updateDeviceNotificationSettings_Success() throws Exception {
         // Given
         NotificationSettingRequest request = new NotificationSettingRequest(true);
-
-        doNothing().when(notificationTokenService).updateNotificationSetting(anyLong(), anyString(), anyBoolean());
+        doNothing().when(notificationTokenService).updateNotificationSetting(anyLong(), anyString(),
+                anyBoolean());
 
         // When & Then
         mockMvc.perform(put("/api/v1/notifications/tokens/{memberId}/{deviceUuid}/settings", TEST_MEMBER_ID, TEST_DEVICE_UUID)
@@ -134,21 +116,6 @@ class NotificationControllerTest {
                 .andExpect(status().isNoContent());
 
         verify(notificationTokenService, times(1)).updateNotificationSetting(TEST_MEMBER_ID, TEST_DEVICE_UUID, true);
-    }
-
-    @Test
-    @DisplayName("알림 설정 업데이트 - 잘못된 JSON")
-    void updateNotificationSettings_InvalidJson() throws Exception {
-        // Given - 잘못된 JSON
-        String invalidJson = "{ invalid json }";
-
-        // When & Then
-        mockMvc.perform(put("/api/v1/notifications/tokens/{memberId}/{deviceUuid}/settings", TEST_MEMBER_ID, TEST_DEVICE_UUID)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(invalidJson))
-                .andExpect(status().isBadRequest());
-
-        verify(notificationTokenService, never()).updateNotificationSetting(anyLong(), anyString(), anyBoolean());
     }
 
     @Test
@@ -163,7 +130,8 @@ class NotificationControllerTest {
         );
 
         NotificationResult successResult = NotificationResult.success("test-message-id");
-        when(notificationService.sendNotification(anyString(), anyString(), anyString(), anyString())).thenReturn(successResult);
+        when(notificationService.sendNotification(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(successResult);
 
         // When & Then
         mockMvc.perform(post("/api/v1/notifications/send")
@@ -172,111 +140,5 @@ class NotificationControllerTest {
                 .andExpect(status().isOk());
 
         verify(notificationService, times(1)).sendNotification(TEST_FCM_TOKEN, "테스트 제목", "테스트 내용", "test-article-123");
-    }
-
-    @Test
-    @DisplayName("알림 직접 발송 - 유효성 검증 실패")
-    void sendNotification_ValidationFailure() throws Exception {
-        // Given - 잘못된 요청 (토큰이 빈 문자열)
-        NotificationSendRequest invalidRequest = new NotificationSendRequest("", "테스트 제목", "테스트 내용", "test-article-123");
-
-        // When & Then
-        mockMvc.perform(post("/api/v1/notifications/send")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(invalidRequest)))
-                .andExpect(status().isBadRequest());
-
-        verify(notificationService, never()).sendNotification(anyString(), anyString(), anyString(), anyString());
-    }
-
-    @Test
-    @DisplayName("카테고리 설정 업데이트 성공 - 소문자")
-    void updateNotificationCategorySetting_Success_Lowercase() throws Exception {
-        // Given
-        NotificationCategorySettingRequest request = new NotificationCategorySettingRequest(true);
-        doNothing().when(notificationSettingService).updateCategorySetting(
-                anyLong(),
-                any(NotificationCategory.class),
-                anyBoolean()
-        );
-
-        // When & Then
-        mockMvc.perform(patch("/api/v1/notifications/{memberId}/settings/{category}", TEST_MEMBER_ID, "event")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isNoContent());
-
-        verify(notificationSettingService, times(1)).updateCategorySetting(
-                TEST_MEMBER_ID,
-                NotificationCategory.EVENT,
-                true
-        );
-    }
-
-    @Test
-    @DisplayName("카테고리 설정 업데이트 성공 - 대문자")
-    void updateNotificationCategorySetting_Success_Uppercase() throws Exception {
-        // Given
-        NotificationCategorySettingRequest request = new NotificationCategorySettingRequest(false);
-        doNothing().when(notificationSettingService).updateCategorySetting(
-                anyLong(),
-                any(NotificationCategory.class),
-                anyBoolean()
-        );
-
-        // When & Then
-        mockMvc.perform(patch("/api/v1/notifications/{memberId}/settings/{category}", TEST_MEMBER_ID, "ARTICLE")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isNoContent());
-
-        verify(notificationSettingService, times(1)).updateCategorySetting(
-                TEST_MEMBER_ID,
-                NotificationCategory.ARTICLE,
-                false
-        );
-    }
-
-    @Test
-    @DisplayName("모든 카테고리 설정 조회 성공")
-    void getCategorySettings_Success() throws Exception {
-        // Given
-        List<NotificationCategorySettingResponse> responses = List.of(
-                new NotificationCategorySettingResponse(NotificationCategory.ARTICLE, true),
-                new NotificationCategorySettingResponse(NotificationCategory.EVENT, false)
-        );
-        when(notificationSettingService.getCategorySettings(anyLong())).thenReturn(responses);
-
-        // When & Then
-        mockMvc.perform(get("/api/v1/notifications/{memberId}/settings", TEST_MEMBER_ID))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$.length()").value(2))
-                .andExpect(jsonPath("$[0].category").value("ARTICLE"))
-                .andExpect(jsonPath("$[0].enabled").value(true))
-                .andExpect(jsonPath("$[1].category").value("EVENT"))
-                .andExpect(jsonPath("$[1].enabled").value(false));
-
-        verify(notificationSettingService, times(1)).getCategorySettings(TEST_MEMBER_ID);
-    }
-
-    @Test
-    @DisplayName("특정 카테고리 설정 조회 성공")
-    void getCategorySetting_Success() throws Exception {
-        // Given
-        NotificationCategorySettingResponse response = new NotificationCategorySettingResponse(NotificationCategory.EVENT, true);
-        when(notificationSettingService.getCategorySetting(anyLong(), any(NotificationCategory.class)))
-                .thenReturn(response);
-
-        // When & Then
-        mockMvc.perform(get("/api/v1/notifications/{memberId}/settings/{category}", TEST_MEMBER_ID, "event"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.category").value("EVENT"))
-                .andExpect(jsonPath("$.enabled").value(true));
-
-        verify(notificationSettingService, times(1)).getCategorySetting(
-                TEST_MEMBER_ID,
-                NotificationCategory.EVENT
-        );
     }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationProcessingServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationProcessingServiceTest.java
@@ -1,0 +1,152 @@
+package news.bombom.notification.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import news.bombom.notification.domain.ArticleArrivalNotification;
+import news.bombom.notification.domain.MemberFcmToken;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.response.NotificationResultResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("알림 처리 서비스 테스트")
+class NotificationProcessingServiceTest {
+
+    @Mock
+    private NotificationTokenService notificationTokenService;
+
+    @Mock
+    private NotificationSenderService notificationSender;
+
+    @Mock
+    private NotificationStatusService statusUpdater;
+
+    @Mock
+    private NotificationSettingService notificationSettingService;
+
+    @InjectMocks
+    private NotificationProcessingService notificationProcessingService;
+
+    private final Long TEST_MEMBER_ID = 1L;
+
+    @Test
+    @DisplayName("아티클 알림 설정이 비활성화되어 있으면 전송하지 않고 로그를 남긴다")
+    void processArticleArrivedNotification_SettingsDisabled_DoesNotSend() {
+        // Given
+        ArticleArrivalNotification notification = createNotification();
+        when(notificationSettingService.isEnabled(TEST_MEMBER_ID, NotificationCategory.ARTICLE))
+                .thenReturn(false);
+
+        // When
+        notificationProcessingService.processArticleArrivedNotification(notification);
+
+        // Then
+        verify(notificationSettingService, times(1)).isEnabled(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
+        verify(notificationTokenService, never()).resolveTokens(anyLong());
+        verify(notificationSender, never()).sendToAllDevices(any(), anyList());
+        verify(statusUpdater, never()).updateStatus(any(), any());
+    }
+
+    @Test
+    @DisplayName("아티클 알림 설정이 활성화되어 있고 토큰이 있으면 전송한다")
+    void processArticleArrivedNotification_SettingsEnabledAndTokensExist_SendsNotification() {
+        // Given
+        ArticleArrivalNotification notification = createNotification();
+        List<MemberFcmToken> tokens = List.of(MemberFcmToken.builder()
+                .memberId(TEST_MEMBER_ID)
+                .deviceUuid("test-device")
+                .fcmToken("test-token")
+                .isNotificationEnabled(true)
+                .build());
+
+        when(notificationSettingService.isEnabled(TEST_MEMBER_ID, NotificationCategory.ARTICLE))
+                .thenReturn(true);
+        when(notificationTokenService.resolveTokens(TEST_MEMBER_ID))
+                .thenReturn(tokens);
+        when(notificationSender.sendToAllDevices(eq(notification), anyList()))
+                .thenReturn(new NotificationResultResponse(1, 0, 0, ""));
+
+        // When
+        notificationProcessingService.processArticleArrivedNotification(notification);
+
+        // Then
+        verify(notificationSettingService, times(1)).isEnabled(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
+        verify(notificationTokenService, times(1)).resolveTokens(TEST_MEMBER_ID);
+        verify(notificationSender, times(1)).sendToAllDevices(eq(notification), anyList());
+        verify(statusUpdater, times(1)).updateStatus(eq(notification), any());
+    }
+
+    @Test
+    @DisplayName("아티클 알림 설정은 활성화되어 있으나 토큰이 없으면 실패 처리한다")
+    void processArticleArrivedNotification_SettingsEnabledButNoTokens_MarksAsFailed() {
+        // Given
+        ArticleArrivalNotification notification = createNotification();
+
+        when(notificationSettingService.isEnabled(TEST_MEMBER_ID, NotificationCategory.ARTICLE))
+                .thenReturn(true);
+        when(notificationTokenService.resolveTokens(TEST_MEMBER_ID))
+                .thenReturn(Collections.emptyList());
+
+        // When
+        notificationProcessingService.processArticleArrivedNotification(notification);
+
+        // Then
+        verify(notificationSettingService, times(1)).isEnabled(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
+        verify(statusUpdater, times(1)).markAsFailed(eq(notification), anyString());
+        verify(notificationSender, never()).sendToAllDevices(any(), anyList());
+    }
+
+    @Test
+    @DisplayName("알림 토큰 등록 시 토큰 저장과 설정 서비스가 모두 호출된다")
+    void registerToken_CallsBothServices() {
+        // Given
+        String deviceUuid = "device-123";
+        String token = "token-123";
+
+        // When
+        notificationProcessingService.registerToken(TEST_MEMBER_ID, deviceUuid, token);
+
+        // Then
+        verify(notificationTokenService, times(1)).registerToken(TEST_MEMBER_ID, deviceUuid, token);
+        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("알림 토큰 업데이트 시 토큰 처리와 설정 서비스가 모두 호출된다")
+    void upsertToken_CallsBothServices() {
+        // Given
+        String deviceUuid = "device-123";
+        String token = "token-123";
+
+        // When
+        notificationProcessingService.upsertToken(TEST_MEMBER_ID, deviceUuid, token);
+
+        // Then
+        verify(notificationTokenService, times(1)).upsertToken(TEST_MEMBER_ID, deviceUuid, token);
+        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
+    }
+
+    private ArticleArrivalNotification createNotification() {
+        return ArticleArrivalNotification.builder()
+                .memberId(TEST_MEMBER_ID)
+                .articleId(123L)
+                .articleTitle("테스트 제목")
+                .newsletterName("테스트 뉴스레터")
+                .build();
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
@@ -1,0 +1,146 @@
+package news.bombom.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import news.bombom.notification.domain.MemberNotificationSetting;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
+import news.bombom.notification.repository.MemberNotificationSettingRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationSettingServiceTest {
+
+        @Mock
+        private MemberNotificationSettingRepository settingRepository;
+
+        @InjectMocks
+        private NotificationSettingService notificationSettingService;
+
+        private final Long TEST_MEMBER_ID = 1L;
+
+        @Test
+        @DisplayName("카테고리 설정 업데이트 - 기존 설정 존재")
+        void updateCategorySetting_ExistingSetting_Success() {
+                // Given
+                MemberNotificationSetting setting = createSetting(true, false);
+                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                                .thenReturn(Optional.of(setting));
+
+                // When
+                notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
+
+                // Then
+                assertThat(setting.isEventEnabled()).isTrue();
+        }
+
+        @Test
+        @DisplayName("카테고리 설정 업데이트 - 설정 없음, 새로 생성")
+        void updateCategorySetting_NoSetting_CreateNew() {
+                // Given
+                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                                .thenReturn(Optional.empty());
+                when(settingRepository.save(any(MemberNotificationSetting.class)))
+                                .thenAnswer(invocation -> invocation.getArgument(0));
+
+                // When
+                notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
+
+                // Then
+                verify(settingRepository).save(any(MemberNotificationSetting.class));
+        }
+
+        @Test
+        @DisplayName("모든 카테고리 설정 조회")
+        void getCategorySettings_ReturnsAllSettings() {
+                // Given
+                MemberNotificationSetting setting = createSetting(true, false);
+                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                                .thenReturn(Optional.of(setting));
+
+                // When
+                List<NotificationCategorySettingResponse> result = notificationSettingService
+                                .getCategorySettings(TEST_MEMBER_ID);
+
+                // Then
+                SoftAssertions.assertSoftly(softly -> {
+                        softly.assertThat(result).hasSize(2);
+                        softly.assertThat(result).extracting(NotificationCategorySettingResponse::category)
+                                        .containsExactlyInAnyOrder(NotificationCategory.ARTICLE,
+                                                        NotificationCategory.EVENT);
+                        softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.ARTICLE)
+                                        .extracting(NotificationCategorySettingResponse::enabled)
+                                        .containsExactly(true);
+                        softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.EVENT)
+                                        .extracting(NotificationCategorySettingResponse::enabled)
+                                        .containsExactly(false);
+                });
+        }
+
+        @Test
+        @DisplayName("특정 카테고리 설정 조회")
+        void getCategorySetting_ReturnsSpecificSetting() {
+                // Given
+                MemberNotificationSetting setting = createSetting(true, false);
+                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                                .thenReturn(Optional.of(setting));
+
+                // When
+                NotificationCategorySettingResponse articleResponse = notificationSettingService.getCategorySetting(
+                                TEST_MEMBER_ID,
+                                NotificationCategory.ARTICLE);
+                NotificationCategorySettingResponse eventResponse = notificationSettingService.getCategorySetting(
+                                TEST_MEMBER_ID,
+                                NotificationCategory.EVENT);
+
+                // Then
+                SoftAssertions.assertSoftly(softly -> {
+                        softly.assertThat(articleResponse.category()).isEqualTo(NotificationCategory.ARTICLE);
+                        softly.assertThat(articleResponse.enabled()).isTrue();
+                        softly.assertThat(eventResponse.category()).isEqualTo(NotificationCategory.EVENT);
+                        softly.assertThat(eventResponse.enabled()).isFalse();
+                });
+        }
+
+        @Test
+        @DisplayName("설정 없을 때 기본값 반환")
+        void getCategorySettings_NoSetting_ReturnsDefaults() {
+                // Given
+                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                                .thenReturn(Optional.empty());
+
+                // When
+                List<NotificationCategorySettingResponse> result = notificationSettingService
+                                .getCategorySettings(TEST_MEMBER_ID);
+
+                // Then
+                SoftAssertions.assertSoftly(softly -> {
+                        softly.assertThat(result).hasSize(2);
+                        softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.ARTICLE)
+                                        .extracting(NotificationCategorySettingResponse::enabled)
+                                        .containsExactly(true);
+                        softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.EVENT)
+                                        .extracting(NotificationCategorySettingResponse::enabled)
+                                        .containsExactly(false);
+                });
+        }
+
+        private MemberNotificationSetting createSetting(boolean articleEnabled, boolean eventEnabled) {
+                return MemberNotificationSetting.builder()
+                                .memberId(TEST_MEMBER_ID)
+                                .articleEnabled(articleEnabled)
+                                .eventEnabled(eventEnabled)
+                                .build();
+        }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
@@ -1,9 +1,7 @@
 package news.bombom.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -33,18 +31,16 @@ class NotificationSettingServiceTest {
     private final Long TEST_MEMBER_ID = 1L;
 
     @Test
-    @DisplayName("회원 알림 설정 보장 - 모든 카테고리에 대해 행이 없으면 각각 생성한다")
+    @DisplayName("회원 알림 설정 보장 - 모든 카테고리에 대해 행이 없으면 한꺼번에 생성한다")
     void ensureMemberNotificationSetting_NoSettings_CreatesAll() {
         // given
-        when(settingRepository.existsByMemberIdAndCategory(eq(TEST_MEMBER_ID), any(NotificationCategory.class)))
-                .thenReturn(false);
+        when(settingRepository.findAllByMemberId(TEST_MEMBER_ID)).thenReturn(List.of());
 
         // when
         notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID);
 
         // then
-        int categoryCount = NotificationCategory.values().length;
-        verify(settingRepository, times(categoryCount)).save(any(MemberNotificationSetting.class));
+        verify(settingRepository, times(1)).saveAll(anyList());
     }
 
     @Test
@@ -78,7 +74,7 @@ class NotificationSettingServiceTest {
 
         // Then
         assertThat(result).hasSize(2);
-        verify(settingRepository, atLeastOnce()).existsByMemberIdAndCategory(eq(TEST_MEMBER_ID), any());
+        verify(settingRepository, times(1)).findAllByMemberId(TEST_MEMBER_ID);
     }
 
     @Test
@@ -92,7 +88,7 @@ class NotificationSettingServiceTest {
         boolean result = notificationSettingService.isEnabled(TEST_MEMBER_ID, NotificationCategory.EVENT);
 
         // Then
-        assertThat(result).isEqualTo(NotificationCategory.EVENT.isDefaultSetting());
+        assertThat(result).isEqualTo(NotificationCategory.EVENT.getDefaultSetting());
     }
 
     private MemberNotificationSetting createSetting(NotificationCategory category, boolean isEnabled) {

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
@@ -2,6 +2,7 @@ package news.bombom.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,125 +23,163 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class NotificationSettingServiceTest {
 
-        @Mock
-        private MemberNotificationSettingRepository settingRepository;
+    @Mock
+    private MemberNotificationSettingRepository settingRepository;
 
-        @InjectMocks
-        private NotificationSettingService notificationSettingService;
+    @InjectMocks
+    private NotificationSettingService notificationSettingService;
 
-        private final Long TEST_MEMBER_ID = 1L;
+    private final Long TEST_MEMBER_ID = 1L;
 
-        @Test
-        @DisplayName("카테고리 설정 업데이트 - 기존 설정 존재")
-        void updateCategorySetting_ExistingSetting_Success() {
-                // Given
-                MemberNotificationSetting setting = createSetting(true, false);
-                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                                .thenReturn(Optional.of(setting));
+    @Test
+    @DisplayName("회원 알림 설정 보장 - 기존 설정 존재")
+    void ensureMemberNotificationSetting_ExistingSetting_ReturnsExisting() {
+        // given
+        MemberNotificationSetting existingSetting = createSetting(true, true);
+        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.of(existingSetting));
 
-                // When
-                notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
+        // when
+        MemberNotificationSetting result = notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID);
 
-                // Then
-                assertThat(setting.isEventEnabled()).isTrue();
-        }
+        // then
+        assertThat(result).isEqualTo(existingSetting);
+        verify(settingRepository, never()).save(any());
+    }
 
-        @Test
-        @DisplayName("카테고리 설정 업데이트 - 설정 없음, 새로 생성")
-        void updateCategorySetting_NoSetting_CreateNew() {
-                // Given
-                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                                .thenReturn(Optional.empty());
-                when(settingRepository.save(any(MemberNotificationSetting.class)))
-                                .thenAnswer(invocation -> invocation.getArgument(0));
+    @Test
+    @DisplayName("회원 알림 설정 보장 - 설정 없음, 기본값 생성 및 저장")
+    void ensureMemberNotificationSetting_NoSetting_CreateAndReturn() {
+        // given
+        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.empty());
+        when(settingRepository.save(any(MemberNotificationSetting.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
 
-                // When
-                notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
+        // when
+        MemberNotificationSetting result = notificationSettingService
+                .ensureMemberNotificationSetting(TEST_MEMBER_ID);
 
-                // Then
-                verify(settingRepository).save(any(MemberNotificationSetting.class));
-        }
+        // then
+        assertThat(result.getMemberId()).isEqualTo(TEST_MEMBER_ID);
+        assertThat(result.isArticleEnabled()).isTrue();
+        assertThat(result.isEventEnabled()).isFalse();
+        verify(settingRepository).save(any(MemberNotificationSetting.class));
+    }
 
-        @Test
-        @DisplayName("모든 카테고리 설정 조회")
-        void getCategorySettings_ReturnsAllSettings() {
-                // Given
-                MemberNotificationSetting setting = createSetting(true, false);
-                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                                .thenReturn(Optional.of(setting));
+    @Test
+    @DisplayName("카테고리 설정 업데이트 - 기존 설정 존재")
+    void updateCategorySetting_ExistingSetting_Success() {
+        // Given
+        MemberNotificationSetting setting = createSetting(true, false);
+        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.of(setting));
 
-                // When
-                List<NotificationCategorySettingResponse> result = notificationSettingService
-                                .getCategorySettings(TEST_MEMBER_ID);
+        // When
+        notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
 
-                // Then
-                SoftAssertions.assertSoftly(softly -> {
-                        softly.assertThat(result).hasSize(2);
-                        softly.assertThat(result).extracting(NotificationCategorySettingResponse::category)
-                                        .containsExactlyInAnyOrder(NotificationCategory.ARTICLE,
-                                                        NotificationCategory.EVENT);
-                        softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.ARTICLE)
-                                        .extracting(NotificationCategorySettingResponse::enabled)
-                                        .containsExactly(true);
-                        softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.EVENT)
-                                        .extracting(NotificationCategorySettingResponse::enabled)
-                                        .containsExactly(false);
-                });
-        }
+        // Then
+        assertThat(setting.isEventEnabled()).isTrue();
+    }
 
-        @Test
-        @DisplayName("특정 카테고리 설정 조회")
-        void getCategorySetting_ReturnsSpecificSetting() {
-                // Given
-                MemberNotificationSetting setting = createSetting(true, false);
-                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                                .thenReturn(Optional.of(setting));
+    @Test
+    @DisplayName("카테고리 설정 업데이트 - 설정 없음, 새로 생성")
+    void updateCategorySetting_NoSetting_CreateNew() {
+        // Given
+        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.empty());
+        when(settingRepository.save(any(MemberNotificationSetting.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
 
-                // When
-                NotificationCategorySettingResponse articleResponse = notificationSettingService.getCategorySetting(
-                                TEST_MEMBER_ID,
-                                NotificationCategory.ARTICLE);
-                NotificationCategorySettingResponse eventResponse = notificationSettingService.getCategorySetting(
-                                TEST_MEMBER_ID,
-                                NotificationCategory.EVENT);
+        // When
+        notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
 
-                // Then
-                SoftAssertions.assertSoftly(softly -> {
-                        softly.assertThat(articleResponse.category()).isEqualTo(NotificationCategory.ARTICLE);
-                        softly.assertThat(articleResponse.enabled()).isTrue();
-                        softly.assertThat(eventResponse.category()).isEqualTo(NotificationCategory.EVENT);
-                        softly.assertThat(eventResponse.enabled()).isFalse();
-                });
-        }
+        // Then
+        verify(settingRepository).save(any(MemberNotificationSetting.class));
+    }
 
-        @Test
-        @DisplayName("설정 없을 때 기본값 반환")
-        void getCategorySettings_NoSetting_ReturnsDefaults() {
-                // Given
-                when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                                .thenReturn(Optional.empty());
+    @Test
+    @DisplayName("모든 카테고리 설정 조회")
+    void getCategorySettings_ReturnsAllSettings() {
+        // Given
+        MemberNotificationSetting setting = createSetting(true, false);
+        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.of(setting));
 
-                // When
-                List<NotificationCategorySettingResponse> result = notificationSettingService
-                                .getCategorySettings(TEST_MEMBER_ID);
+        // When
+        List<NotificationCategorySettingResponse> result = notificationSettingService
+                .getCategorySettings(TEST_MEMBER_ID);
 
-                // Then
-                SoftAssertions.assertSoftly(softly -> {
-                        softly.assertThat(result).hasSize(2);
-                        softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.ARTICLE)
-                                        .extracting(NotificationCategorySettingResponse::enabled)
-                                        .containsExactly(true);
-                        softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.EVENT)
-                                        .extracting(NotificationCategorySettingResponse::enabled)
-                                        .containsExactly(false);
-                });
-        }
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(2);
+            softly.assertThat(result).extracting(NotificationCategorySettingResponse::category)
+                    .containsExactlyInAnyOrder(NotificationCategory.ARTICLE,
+                            NotificationCategory.EVENT);
+            softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.ARTICLE)
+                    .extracting(NotificationCategorySettingResponse::enabled)
+                    .containsExactly(true);
+            softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.EVENT)
+                    .extracting(NotificationCategorySettingResponse::enabled)
+                    .containsExactly(false);
+        });
+    }
 
-        private MemberNotificationSetting createSetting(boolean articleEnabled, boolean eventEnabled) {
-                return MemberNotificationSetting.builder()
-                                .memberId(TEST_MEMBER_ID)
-                                .articleEnabled(articleEnabled)
-                                .eventEnabled(eventEnabled)
-                                .build();
-        }
+    @Test
+    @DisplayName("특정 카테고리 설정 조회")
+    void getCategorySetting_ReturnsSpecificSetting() {
+        // Given
+        MemberNotificationSetting setting = createSetting(true, false);
+        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.of(setting));
+
+        // When
+        NotificationCategorySettingResponse articleResponse = notificationSettingService.getCategorySetting(
+                TEST_MEMBER_ID,
+                NotificationCategory.ARTICLE);
+        NotificationCategorySettingResponse eventResponse = notificationSettingService.getCategorySetting(
+                TEST_MEMBER_ID,
+                NotificationCategory.EVENT);
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(articleResponse.category()).isEqualTo(NotificationCategory.ARTICLE);
+            softly.assertThat(articleResponse.enabled()).isTrue();
+            softly.assertThat(eventResponse.category()).isEqualTo(NotificationCategory.EVENT);
+            softly.assertThat(eventResponse.enabled()).isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("설정 없을 때 기본값 반환")
+    void getCategorySettings_NoSetting_ReturnsDefaults() {
+        // Given
+        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.empty());
+        when(settingRepository.save(any(MemberNotificationSetting.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        // When
+        List<NotificationCategorySettingResponse> result = notificationSettingService
+                .getCategorySettings(TEST_MEMBER_ID);
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(2);
+            softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.ARTICLE)
+                    .extracting(NotificationCategorySettingResponse::enabled)
+                    .containsExactly(true);
+            softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.EVENT)
+                    .extracting(NotificationCategorySettingResponse::enabled)
+                    .containsExactly(false);
+        });
+    }
+
+    private MemberNotificationSetting createSetting(boolean articleEnabled, boolean eventEnabled) {
+        return MemberNotificationSetting.builder()
+                .memberId(TEST_MEMBER_ID)
+                .articleEnabled(articleEnabled)
+                .eventEnabled(eventEnabled)
+                .build();
+    }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
@@ -2,7 +2,9 @@ package news.bombom.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.never;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -12,7 +14,6 @@ import news.bombom.notification.domain.MemberNotificationSetting;
 import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.dto.response.NotificationCategorySettingResponse;
 import news.bombom.notification.repository.MemberNotificationSettingRepository;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,154 +33,73 @@ class NotificationSettingServiceTest {
     private final Long TEST_MEMBER_ID = 1L;
 
     @Test
-    @DisplayName("회원 알림 설정 보장 - 기존 설정 존재")
-    void ensureMemberNotificationSetting_ExistingSetting_ReturnsExisting() {
+    @DisplayName("회원 알림 설정 보장 - 모든 카테고리에 대해 행이 없으면 각각 생성한다")
+    void ensureMemberNotificationSetting_NoSettings_CreatesAll() {
         // given
-        MemberNotificationSetting existingSetting = createSetting(true, true);
-        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.of(existingSetting));
+        when(settingRepository.existsByMemberIdAndCategory(eq(TEST_MEMBER_ID), any(NotificationCategory.class)))
+                .thenReturn(false);
 
         // when
-        MemberNotificationSetting result = notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID);
+        notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID);
 
         // then
-        assertThat(result).isEqualTo(existingSetting);
-        verify(settingRepository, never()).save(any());
+        int categoryCount = NotificationCategory.values().length;
+        verify(settingRepository, times(categoryCount)).save(any(MemberNotificationSetting.class));
     }
 
     @Test
-    @DisplayName("회원 알림 설정 보장 - 설정 없음, 기본값 생성 및 저장")
-    void ensureMemberNotificationSetting_NoSetting_CreateAndReturn() {
-        // given
-        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.empty());
-        when(settingRepository.save(any(MemberNotificationSetting.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        // when
-        MemberNotificationSetting result = notificationSettingService
-                .ensureMemberNotificationSetting(TEST_MEMBER_ID);
-
-        // then
-        assertThat(result.getMemberId()).isEqualTo(TEST_MEMBER_ID);
-        assertThat(result.isArticleEnabled()).isTrue();
-        assertThat(result.isEventEnabled()).isFalse();
-        verify(settingRepository).save(any(MemberNotificationSetting.class));
-    }
-
-    @Test
-    @DisplayName("카테고리 설정 업데이트 - 기존 설정 존재")
-    void updateCategorySetting_ExistingSetting_Success() {
+    @DisplayName("카테고리 설정 업데이트 - 기존 설정 존재 시 해당 행만 업데이트")
+    void updateCategorySetting_ExistingSetting_UpdatesIt() {
         // Given
-        MemberNotificationSetting setting = createSetting(true, false);
-        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+        MemberNotificationSetting setting = createSetting(NotificationCategory.ARTICLE, true);
+        when(settingRepository.findByMemberIdAndCategory(TEST_MEMBER_ID, NotificationCategory.ARTICLE))
                 .thenReturn(Optional.of(setting));
 
         // When
-        notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
+        notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.ARTICLE, false);
 
         // Then
-        assertThat(setting.isEventEnabled()).isTrue();
+        assertThat(setting.isEnabled()).isFalse();
+        verify(settingRepository).save(setting);
     }
 
     @Test
-    @DisplayName("카테고리 설정 업데이트 - 설정 없음, 새로 생성")
-    void updateCategorySetting_NoSetting_CreateNew() {
+    @DisplayName("모든 카테고리 설정 조회 - 조회 시 설정을 보장(ensure)한다")
+    void getCategorySettings_EnsuresAndReturnsAll() {
         // Given
-        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.empty());
-        when(settingRepository.save(any(MemberNotificationSetting.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
-
-        // When
-        notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
-
-        // Then
-        verify(settingRepository).save(any(MemberNotificationSetting.class));
-    }
-
-    @Test
-    @DisplayName("모든 카테고리 설정 조회")
-    void getCategorySettings_ReturnsAllSettings() {
-        // Given
-        MemberNotificationSetting setting = createSetting(true, false);
-        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.of(setting));
+        List<MemberNotificationSetting> settings = List.of(
+                createSetting(NotificationCategory.ARTICLE, true),
+                createSetting(NotificationCategory.EVENT, false));
+        when(settingRepository.findAllByMemberId(TEST_MEMBER_ID)).thenReturn(settings);
 
         // When
         List<NotificationCategorySettingResponse> result = notificationSettingService
                 .getCategorySettings(TEST_MEMBER_ID);
 
         // Then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(result).hasSize(2);
-            softly.assertThat(result).extracting(NotificationCategorySettingResponse::category)
-                    .containsExactlyInAnyOrder(NotificationCategory.ARTICLE,
-                            NotificationCategory.EVENT);
-            softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.ARTICLE)
-                    .extracting(NotificationCategorySettingResponse::enabled)
-                    .containsExactly(true);
-            softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.EVENT)
-                    .extracting(NotificationCategorySettingResponse::enabled)
-                    .containsExactly(false);
-        });
+        assertThat(result).hasSize(2);
+        verify(settingRepository, atLeastOnce()).existsByMemberIdAndCategory(eq(TEST_MEMBER_ID), any());
     }
 
     @Test
-    @DisplayName("특정 카테고리 설정 조회")
-    void getCategorySetting_ReturnsSpecificSetting() {
+    @DisplayName("설정 활성화 여부 확인 - 설정 행이 없으면 기본값을 반환한다")
+    void isEnabled_NoSetting_ReturnsDefault() {
         // Given
-        MemberNotificationSetting setting = createSetting(true, false);
-        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.of(setting));
-
-        // When
-        NotificationCategorySettingResponse articleResponse = notificationSettingService.getCategorySetting(
-                TEST_MEMBER_ID,
-                NotificationCategory.ARTICLE);
-        NotificationCategorySettingResponse eventResponse = notificationSettingService.getCategorySetting(
-                TEST_MEMBER_ID,
-                NotificationCategory.EVENT);
-
-        // Then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(articleResponse.category()).isEqualTo(NotificationCategory.ARTICLE);
-            softly.assertThat(articleResponse.enabled()).isTrue();
-            softly.assertThat(eventResponse.category()).isEqualTo(NotificationCategory.EVENT);
-            softly.assertThat(eventResponse.enabled()).isFalse();
-        });
-    }
-
-    @Test
-    @DisplayName("설정 없을 때 기본값 반환")
-    void getCategorySettings_NoSetting_ReturnsDefaults() {
-        // Given
-        when(settingRepository.findByMemberId(TEST_MEMBER_ID))
+        when(settingRepository.findByMemberIdAndCategory(TEST_MEMBER_ID, NotificationCategory.EVENT))
                 .thenReturn(Optional.empty());
-        when(settingRepository.save(any(MemberNotificationSetting.class)))
-                .thenAnswer(invocation -> invocation.getArgument(0));
 
         // When
-        List<NotificationCategorySettingResponse> result = notificationSettingService
-                .getCategorySettings(TEST_MEMBER_ID);
+        boolean result = notificationSettingService.isEnabled(TEST_MEMBER_ID, NotificationCategory.EVENT);
 
         // Then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(result).hasSize(2);
-            softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.ARTICLE)
-                    .extracting(NotificationCategorySettingResponse::enabled)
-                    .containsExactly(true);
-            softly.assertThat(result).filteredOn(r -> r.category() == NotificationCategory.EVENT)
-                    .extracting(NotificationCategorySettingResponse::enabled)
-                    .containsExactly(false);
-        });
+        assertThat(result).isEqualTo(NotificationCategory.EVENT.isDefaultSetting());
     }
 
-    private MemberNotificationSetting createSetting(boolean articleEnabled, boolean eventEnabled) {
+    private MemberNotificationSetting createSetting(NotificationCategory category, boolean isEnabled) {
         return MemberNotificationSetting.builder()
                 .memberId(TEST_MEMBER_ID)
-                .articleEnabled(articleEnabled)
-                .eventEnabled(eventEnabled)
+                .category(category)
+                .isEnabled(isEnabled)
                 .build();
     }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationTokenServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationTokenServiceTest.java
@@ -1,5 +1,6 @@
 package news.bombom.notification.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -9,9 +10,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import news.bombom.notification.domain.MemberFcmToken;
+import news.bombom.notification.domain.MemberNotificationSetting;
+import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.repository.MemberFcmTokenRepository;
+import news.bombom.notification.repository.MemberNotificationSettingRepository;
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +31,9 @@ class NotificationTokenServiceTest {
 
     @Mock
     private MemberFcmTokenRepository fcmTokenRepository;
+
+    @Mock
+    private MemberNotificationSettingRepository notificationSettingRepository;
 
     @InjectMocks
     private NotificationTokenService notificationTokenService;
@@ -125,6 +134,137 @@ class NotificationTokenServiceTest {
 
         // Then
         verify(fcmTokenRepository, times(1)).deleteByMemberIdAndDeviceUuid(TEST_MEMBER_ID, TEST_DEVICE_UUID);
+    }
+
+    @Test
+    @DisplayName("아티클 알림 활성화 시 토큰 목록 반환")
+    void resolveTokens_ArticleEnabled_ReturnsTokens() {
+        // Given
+        MemberNotificationSetting setting = createSetting(true, false);
+        MemberFcmToken token = createTestToken();
+
+        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.of(setting));
+        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(List.of(token));
+
+        // When
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
+                TEST_MEMBER_ID,
+                NotificationCategory.ARTICLE
+        );
+
+        // Then
+        SoftAssertions.assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result.getFirst().getFcmToken()).isEqualTo(TEST_FCM_TOKEN);
+        });
+    }
+
+    @Test
+    @DisplayName("기사 알림 비활성화 시 빈 목록 반환")
+    void resolveTokens_ArticleDisabled_ReturnsEmpty() {
+        // Given
+        MemberNotificationSetting setting = createSetting(false, false);
+
+        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.of(setting));
+
+        // When
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
+                TEST_MEMBER_ID,
+                NotificationCategory.ARTICLE
+        );
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("이벤트 알림 활성화 시 토큰 목록 반환")
+    void resolveTokens_EventEnabled_ReturnsTokens() {
+        // Given
+        MemberNotificationSetting setting = createSetting(true, true);
+        MemberFcmToken token = createTestToken();
+
+        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.of(setting));
+        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(List.of(token));
+
+        // When
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
+                TEST_MEMBER_ID,
+                NotificationCategory.EVENT
+        );
+
+        // Then
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("이벤트 알림 비활성화 시 빈 목록 반환")
+    void resolveTokens_EventDisabled_ReturnsEmpty() {
+        // Given
+        MemberNotificationSetting setting = createSetting(true, false);
+
+        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.of(setting));
+
+        // When
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
+                TEST_MEMBER_ID,
+                NotificationCategory.EVENT
+        );
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("설정이 없는 경우 기본값 사용 - 기사 알림 활성화")
+    void resolveTokens_NoSetting_ArticleEnabledByDefault() {
+        // Given
+        MemberFcmToken token = createTestToken();
+
+        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.empty());
+        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(List.of(token));
+
+        // When
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
+                TEST_MEMBER_ID,
+                NotificationCategory.ARTICLE
+        );
+
+        // Then
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("설정이 없는 경우 기본값 사용 - 이벤트 알림 비활성화")
+    void resolveTokens_NoSetting_EventDisabledByDefault() {
+        // Given
+        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
+                .thenReturn(Optional.empty());
+
+        // When
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
+                TEST_MEMBER_ID,
+                NotificationCategory.EVENT
+        );
+
+        // Then
+        assertThat(result).isEmpty();
+    }
+
+    private MemberNotificationSetting createSetting(boolean articleEnabled, boolean eventEnabled) {
+        return MemberNotificationSetting.builder()
+                .memberId(TEST_MEMBER_ID)
+                .articleEnabled(articleEnabled)
+                .eventEnabled(eventEnabled)
+                .build();
     }
 
     private MemberFcmToken createTestToken() {

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationTokenServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationTokenServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,8 +13,6 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Optional;
 import news.bombom.notification.domain.MemberFcmToken;
-import news.bombom.notification.domain.MemberNotificationSetting;
-import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.repository.MemberFcmTokenRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,9 +28,6 @@ class NotificationTokenServiceTest {
     @Mock
     private MemberFcmTokenRepository fcmTokenRepository;
 
-    @Mock
-    private NotificationSettingService notificationSettingService;
-
     @InjectMocks
     private NotificationTokenService notificationTokenService;
 
@@ -43,33 +37,30 @@ class NotificationTokenServiceTest {
     private final String NEW_FCM_TOKEN = "new-fcm-token-67890";
 
     @Test
-    @DisplayName("FCM 토큰 등록 성공")
-    void registerFcmToken_Success() {
+    @DisplayName("토큰 등록 성공")
+    void registerToken_Success() {
         // Given
         doNothing().when(fcmTokenRepository).deleteByDeviceUuid(anyString());
         when(fcmTokenRepository.save(any(MemberFcmToken.class))).thenReturn(createTestToken());
-        when(notificationSettingService.createDefaultSetting(anyLong()))
-                .thenReturn(mock(MemberNotificationSetting.class));
 
         // When
-        notificationTokenService.registerFcmToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
+        notificationTokenService.registerToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
 
         // Then
         verify(fcmTokenRepository, times(1)).deleteByDeviceUuid(TEST_DEVICE_UUID);
         verify(fcmTokenRepository, times(1)).save(any(MemberFcmToken.class));
-        verify(notificationSettingService, times(1)).createDefaultSetting(TEST_MEMBER_ID);
     }
 
     @Test
-    @DisplayName("FCM 토큰 업서트 성공 - 기존 토큰 존재")
-    void upsertFcmToken_Success_ExistingToken() {
+    @DisplayName("토큰 업데이트 성공 - 기존 토큰 존재")
+    void upsertToken_Success_ExistingToken() {
         // Given
         MemberFcmToken existingToken = mock(MemberFcmToken.class);
         when(fcmTokenRepository.findByMemberIdAndDeviceUuid(TEST_MEMBER_ID, TEST_DEVICE_UUID))
                 .thenReturn(Optional.of(existingToken));
 
         // When
-        notificationTokenService.upsertFcmToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, NEW_FCM_TOKEN);
+        notificationTokenService.upsertToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, NEW_FCM_TOKEN);
 
         // Then
         verify(fcmTokenRepository, times(1)).findByMemberIdAndDeviceUuid(TEST_MEMBER_ID, TEST_DEVICE_UUID);
@@ -77,8 +68,8 @@ class NotificationTokenServiceTest {
     }
 
     @Test
-    @DisplayName("FCM 토큰 업서트 성공 - 기존 토큰 없음")
-    void upsertFcmToken_Success_NoExistingToken() {
+    @DisplayName("토큰 업데이트 성공 - 기존 토큰 없음")
+    void upsertToken_Success_NoExistingToken() {
         // Given
         when(fcmTokenRepository.findByMemberIdAndDeviceUuid(TEST_MEMBER_ID, TEST_DEVICE_UUID))
                 .thenReturn(Optional.empty());
@@ -87,7 +78,7 @@ class NotificationTokenServiceTest {
                 .thenReturn(createTestToken());
 
         // When
-        notificationTokenService.upsertFcmToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
+        notificationTokenService.upsertToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
 
         // Then
         verify(fcmTokenRepository, times(1)).findByMemberIdAndDeviceUuid(TEST_MEMBER_ID, TEST_DEVICE_UUID);
@@ -140,117 +131,31 @@ class NotificationTokenServiceTest {
     }
 
     @Test
-    @DisplayName("아티클 알림 설정이 켜져있으면 토큰 리스트 반환")
-    void resolveTokens_ArticleEnabled_ReturnsTokens() {
+    @DisplayName("회원의 토큰 리스트 반환")
+    void resolveTokens_ReturnsTokens() {
         // Given
-        MemberNotificationSetting setting = createSetting(true, false);
-        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID)).thenReturn(setting);
         when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID)).thenReturn(List.of(createTestToken()));
 
         // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID);
 
         // Then
         assertThat(result).hasSize(1);
-        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
-    }
-
-    @Test
-    @DisplayName("카테고리 알림이 비활성화되어 있으면 빈 목록 반환")
-    void resolveTokens_CategoryDisabled_ReturnsEmpty() {
-        // Given
-        MemberNotificationSetting setting = createSetting(false, false);
-        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
-                .thenReturn(setting);
-
-        // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
-
-        // Then
-        assertThat(result).isEmpty();
-        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
-        verify(fcmTokenRepository, never()).findByMemberId(anyLong());
-    }
-
-    @Test
-    @DisplayName("이벤트 알림 활성화 시 토큰 목록 반환")
-    void resolveTokens_EventEnabled_ReturnsTokens() {
-        // Given
-        MemberNotificationSetting setting = createSetting(true, true);
-        MemberFcmToken token = createTestToken();
-
-        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
-                .thenReturn(setting);
-        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(List.of(token));
-
-        // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.EVENT);
-
-        // Then
-        assertThat(result).hasSize(1);
-        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
         verify(fcmTokenRepository, times(1)).findByMemberId(TEST_MEMBER_ID);
     }
 
     @Test
-    @DisplayName("이벤트 알림 비활성화 시 빈 목록 반환")
-    void resolveTokens_EventDisabled_ReturnsEmpty() {
+    @DisplayName("토큰이 없으면 빈 목록 반환")
+    void resolveTokens_NoTokens_ReturnsEmpty() {
         // Given
-        MemberNotificationSetting setting = createSetting(true, false);
-
-        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
-                .thenReturn(setting);
+        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID)).thenReturn(List.of());
 
         // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.EVENT);
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID);
 
         // Then
         assertThat(result).isEmpty();
-        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
-        verify(fcmTokenRepository, never()).findByMemberId(anyLong());
-    }
-
-    @Test
-    @DisplayName("설정이 없는 경우 기본값 사용 - 기사 알림 활성화")
-    void resolveTokens_NoSetting_ArticleEnabledByDefault() {
-        // Given
-        MemberFcmToken token = createTestToken();
-        MemberNotificationSetting defaultSetting = createSetting(true, false);
-
-        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
-                .thenReturn(defaultSetting);
-        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(List.of(token));
-
-        // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
-
-        // Then
-        assertThat(result).hasSize(1);
-    }
-
-    @Test
-    @DisplayName("설정이 없는 경우 기본값 사용 - 이벤트 알림 비활성화")
-    void resolveTokens_NoSetting_EventDisabledByDefault() {
-        // Given
-        MemberNotificationSetting defaultSetting = createSetting(true, false);
-        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
-                .thenReturn(defaultSetting);
-
-        // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.EVENT);
-
-        // Then
-        assertThat(result).isEmpty();
-    }
-
-    private MemberNotificationSetting createSetting(boolean articleEnabled, boolean eventEnabled) {
-        return MemberNotificationSetting.builder()
-                .memberId(TEST_MEMBER_ID)
-                .articleEnabled(articleEnabled)
-                .eventEnabled(eventEnabled)
-                .build();
+        verify(fcmTokenRepository, times(1)).findByMemberId(TEST_MEMBER_ID);
     }
 
     private MemberFcmToken createTestToken() {

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationTokenServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationTokenServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -16,8 +17,6 @@ import news.bombom.notification.domain.MemberFcmToken;
 import news.bombom.notification.domain.MemberNotificationSetting;
 import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.repository.MemberFcmTokenRepository;
-import news.bombom.notification.repository.MemberNotificationSettingRepository;
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -33,7 +32,7 @@ class NotificationTokenServiceTest {
     private MemberFcmTokenRepository fcmTokenRepository;
 
     @Mock
-    private MemberNotificationSettingRepository notificationSettingRepository;
+    private NotificationSettingService notificationSettingService;
 
     @InjectMocks
     private NotificationTokenService notificationTokenService;
@@ -49,6 +48,8 @@ class NotificationTokenServiceTest {
         // Given
         doNothing().when(fcmTokenRepository).deleteByDeviceUuid(anyString());
         when(fcmTokenRepository.save(any(MemberFcmToken.class))).thenReturn(createTestToken());
+        when(notificationSettingService.createDefaultSetting(anyLong()))
+                .thenReturn(mock(MemberNotificationSetting.class));
 
         // When
         notificationTokenService.registerFcmToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
@@ -56,6 +57,7 @@ class NotificationTokenServiceTest {
         // Then
         verify(fcmTokenRepository, times(1)).deleteByDeviceUuid(TEST_DEVICE_UUID);
         verify(fcmTokenRepository, times(1)).save(any(MemberFcmToken.class));
+        verify(notificationSettingService, times(1)).createDefaultSetting(TEST_MEMBER_ID);
     }
 
     @Test
@@ -81,7 +83,8 @@ class NotificationTokenServiceTest {
         when(fcmTokenRepository.findByMemberIdAndDeviceUuid(TEST_MEMBER_ID, TEST_DEVICE_UUID))
                 .thenReturn(Optional.empty());
         doNothing().when(fcmTokenRepository).deleteByDeviceUuid(anyString());
-        when(fcmTokenRepository.save(any(MemberFcmToken.class))).thenReturn(createTestToken());
+        when(fcmTokenRepository.save(any(MemberFcmToken.class)))
+                .thenReturn(createTestToken());
 
         // When
         notificationTokenService.upsertFcmToken(TEST_MEMBER_ID, TEST_DEVICE_UUID, TEST_FCM_TOKEN);
@@ -137,47 +140,36 @@ class NotificationTokenServiceTest {
     }
 
     @Test
-    @DisplayName("아티클 알림 활성화 시 토큰 목록 반환")
+    @DisplayName("아티클 알림 설정이 켜져있으면 토큰 리스트 반환")
     void resolveTokens_ArticleEnabled_ReturnsTokens() {
         // Given
         MemberNotificationSetting setting = createSetting(true, false);
-        MemberFcmToken token = createTestToken();
-
-        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.of(setting));
-        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(List.of(token));
+        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID)).thenReturn(setting);
+        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID)).thenReturn(List.of(createTestToken()));
 
         // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
-                TEST_MEMBER_ID,
-                NotificationCategory.ARTICLE
-        );
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
 
         // Then
-        SoftAssertions.assertSoftly(softly -> {
-            softly.assertThat(result).hasSize(1);
-            softly.assertThat(result.getFirst().getFcmToken()).isEqualTo(TEST_FCM_TOKEN);
-        });
+        assertThat(result).hasSize(1);
+        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
     }
 
     @Test
-    @DisplayName("기사 알림 비활성화 시 빈 목록 반환")
-    void resolveTokens_ArticleDisabled_ReturnsEmpty() {
+    @DisplayName("카테고리 알림이 비활성화되어 있으면 빈 목록 반환")
+    void resolveTokens_CategoryDisabled_ReturnsEmpty() {
         // Given
         MemberNotificationSetting setting = createSetting(false, false);
-
-        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.of(setting));
+        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
+                .thenReturn(setting);
 
         // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
-                TEST_MEMBER_ID,
-                NotificationCategory.ARTICLE
-        );
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
 
         // Then
         assertThat(result).isEmpty();
+        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
+        verify(fcmTokenRepository, never()).findByMemberId(anyLong());
     }
 
     @Test
@@ -187,19 +179,18 @@ class NotificationTokenServiceTest {
         MemberNotificationSetting setting = createSetting(true, true);
         MemberFcmToken token = createTestToken();
 
-        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.of(setting));
+        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
+                .thenReturn(setting);
         when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID))
                 .thenReturn(List.of(token));
 
         // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
-                TEST_MEMBER_ID,
-                NotificationCategory.EVENT
-        );
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.EVENT);
 
         // Then
         assertThat(result).hasSize(1);
+        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
+        verify(fcmTokenRepository, times(1)).findByMemberId(TEST_MEMBER_ID);
     }
 
     @Test
@@ -208,17 +199,16 @@ class NotificationTokenServiceTest {
         // Given
         MemberNotificationSetting setting = createSetting(true, false);
 
-        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.of(setting));
+        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
+                .thenReturn(setting);
 
         // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
-                TEST_MEMBER_ID,
-                NotificationCategory.EVENT
-        );
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.EVENT);
 
         // Then
         assertThat(result).isEmpty();
+        verify(notificationSettingService, times(1)).ensureMemberNotificationSetting(TEST_MEMBER_ID);
+        verify(fcmTokenRepository, never()).findByMemberId(anyLong());
     }
 
     @Test
@@ -226,17 +216,15 @@ class NotificationTokenServiceTest {
     void resolveTokens_NoSetting_ArticleEnabledByDefault() {
         // Given
         MemberFcmToken token = createTestToken();
+        MemberNotificationSetting defaultSetting = createSetting(true, false);
 
-        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.empty());
+        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
+                .thenReturn(defaultSetting);
         when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID))
                 .thenReturn(List.of(token));
 
         // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
-                TEST_MEMBER_ID,
-                NotificationCategory.ARTICLE
-        );
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
 
         // Then
         assertThat(result).hasSize(1);
@@ -246,14 +234,12 @@ class NotificationTokenServiceTest {
     @DisplayName("설정이 없는 경우 기본값 사용 - 이벤트 알림 비활성화")
     void resolveTokens_NoSetting_EventDisabledByDefault() {
         // Given
-        when(notificationSettingRepository.findByMemberId(TEST_MEMBER_ID))
-                .thenReturn(Optional.empty());
+        MemberNotificationSetting defaultSetting = createSetting(true, false);
+        when(notificationSettingService.ensureMemberNotificationSetting(TEST_MEMBER_ID))
+                .thenReturn(defaultSetting);
 
         // When
-        List<MemberFcmToken> result = notificationTokenService.resolveTokens(
-                TEST_MEMBER_ID,
-                NotificationCategory.EVENT
-        );
+        List<MemberFcmToken> result = notificationTokenService.resolveTokens(TEST_MEMBER_ID, NotificationCategory.EVENT);
 
         // Then
         assertThat(result).isEmpty();


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
이벤트 알림 설정 API를 구현했습니다.
- 알림 설정 모두 조회
- 알림 설정 단일 조회
- 알림 설정 변경 

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
서비스 성장에 따라 '아티클 알림', '이벤트 알림' 등 카테고리별로 정교한 수신 동의 관리가 필요해졌습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
1. 최대한 기존 코드의 변경을 줄이면서 확장성을 확보하고자 했습니다.
- 기존 `MemberFcmToken.isNotificationEnabled`는 현재 아티클 알림만 존재하여 사실상 아티클 동의 여부처럼 사용되고 있었습니다. 하지만 이 테이블은 `memberId`와 `deviceUuid`를 가지므로, 같은 사용자라도 디바이스마다 설정이 달라질 수 있는 '기기별 설정' 영역입니다.
- 따라서 기존 필드는 기기별 푸시 수신 여부(시스템 권한 등)를 제어하는 용도로 남겨두어 기존 로직의 영향도를 최소화했습니다.

2. 사용자 중심의 알림 설정 엔티티(`MemberNotificationSetting`) 생성
- 디바이스와 무관하게 사용자 계정 자체에 귀속되는 알림 선호도를 관리하기 위해 `MemberNotificationSetting`을 새로 만들었습니다.
- 이를 통해 서비스가 확장되더라도(아티클, 이벤트 등 카테고리 추가) 사용자가 어떤 기기를 사용하든 동일한 알림 환경을 경험할 수 있도록 설계했습니다.


### 정리
**➡️ 현재는 알림 종류가 적어 기기별 설정이 큰 부담이 아닐 수 있으나, 향후 알림 유형이 다양해질 경우 사용자가 모든 기기에서 설정을 개별적으로 관리해야 하는 번거로움이 발생할 것이라 생각했습니다. 관리 피로도를 낮추고 사용자에게 일관된 동의 경험을 제공하기 위해, 디바이스 중심이 아닌 사용자 계정 중심의 통합 설정 구조가 더 적합하다고 판단했습니다.**

- `MemberFcmToken.isNotificationEnabled`: "이 핸드폰으로 알림을 보낼 수 있는가?" 
- `MemberNotificationSetting`: "이 사용자는 아티클/이벤트 알림을 받기를 원하는가?"



## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

HOW 부분에 대한 리뷰해주시면 감사드리겠습니다.