### PR TITLE
[BOM-953] feat: reCapcha API 구현

### DIFF
--- a/backend/fcm-server/build.gradle.kts
+++ b/backend/fcm-server/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     // fcm
     implementation("com.google.firebase:firebase-admin:9.2.0")
 
+    // swagger
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.15")
+
     // lombok
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")

--- a/backend/fcm-server/src/main/java/news/bombom/NotificationServerApplication.java
+++ b/backend/fcm-server/src/main/java/news/bombom/NotificationServerApplication.java
@@ -1,4 +1,4 @@
-package news.bombom.notification;
+package news.bombom;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/client/GoogleRecaptchaClient.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/client/GoogleRecaptchaClient.java
@@ -1,0 +1,47 @@
+package news.bombom.captcha.client;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.captcha.config.RecaptchaProperties;
+import news.bombom.captcha.dto.response.GoogleRecaptchaResponse;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleRecaptchaClient {
+
+    private final RecaptchaProperties recaptchaProperties;
+    private final RestTemplate restTemplate;
+
+    public GoogleRecaptchaResponse verify(String gRecaptchaResponse, String remoteIp) {
+        try {
+            MultiValueMap<String, String> params = buildRequestParams(gRecaptchaResponse, remoteIp);
+            HttpEntity<MultiValueMap<String, String>> request = buildRequest(params);
+            return restTemplate.postForObject(recaptchaProperties.getVerifyUrl(), request, GoogleRecaptchaResponse.class);
+        } catch (Exception e) {
+            log.error("Google reCAPTCHA API 호출 실패: {}", e.getMessage(), e);
+            throw new RecaptchaApiException("Google reCAPTCHA API 호출 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    private MultiValueMap<String, String> buildRequestParams(String gRecaptchaResponse, String remoteIp) {
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("secret", recaptchaProperties.getSecretKey());
+        params.add("response", gRecaptchaResponse);
+        params.add("remoteip", remoteIp);
+        return params;
+    }
+
+    private HttpEntity<MultiValueMap<String, String>> buildRequest(MultiValueMap<String, String> params) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        return new HttpEntity<>(params, headers);
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/client/GoogleRecaptchaClient.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/client/GoogleRecaptchaClient.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 
 @Slf4j
@@ -35,7 +36,9 @@ public class GoogleRecaptchaClient {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("secret", recaptchaProperties.getSecretKey());
         params.add("response", gRecaptchaResponse);
-        params.add("remoteip", remoteIp);
+        if (StringUtils.hasText(remoteIp)) {
+            params.add("remoteip", remoteIp);
+        }
         return params;
     }
 

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/client/GoogleRecaptchaClient.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/client/GoogleRecaptchaClient.java
@@ -4,14 +4,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombom.captcha.config.RecaptchaProperties;
 import news.bombom.captcha.dto.response.GoogleRecaptchaResponse;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 
 @Slf4j
 @Component
@@ -19,32 +17,36 @@ import org.springframework.web.client.RestTemplate;
 public class GoogleRecaptchaClient {
 
     private final RecaptchaProperties recaptchaProperties;
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
 
     public GoogleRecaptchaResponse verify(String gRecaptchaResponse, String remoteIp) {
         try {
             MultiValueMap<String, String> params = buildRequestParams(gRecaptchaResponse, remoteIp);
-            HttpEntity<MultiValueMap<String, String>> request = buildRequest(params);
-            return restTemplate.postForObject(recaptchaProperties.getVerifyUrl(), request, GoogleRecaptchaResponse.class);
+
+            return restClient.post()
+                    .uri(recaptchaProperties.getVerifyUrl())
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(params)
+                    .retrieve()
+                    .body(GoogleRecaptchaResponse.class);
         } catch (Exception e) {
             log.error("Google reCAPTCHA API 호출 실패: {}", e.getMessage(), e);
             throw new RecaptchaApiException("Google reCAPTCHA API 호출 중 오류가 발생했습니다.", e);
         }
     }
 
+    /**
+     * API 요청 파라미터 생성
+     */
     private MultiValueMap<String, String> buildRequestParams(String gRecaptchaResponse, String remoteIp) {
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("secret", recaptchaProperties.getSecretKey());
         params.add("response", gRecaptchaResponse);
+        // remoteip는 선택적 파라미터 (유효한 값이 있는 경우만 추가)
         if (StringUtils.hasText(remoteIp)) {
             params.add("remoteip", remoteIp);
         }
         return params;
     }
-
-    private HttpEntity<MultiValueMap<String, String>> buildRequest(MultiValueMap<String, String> params) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-        return new HttpEntity<>(params, headers);
-    }
 }
+

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/client/RecaptchaApiException.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/client/RecaptchaApiException.java
@@ -1,0 +1,12 @@
+package news.bombom.captcha.client;
+
+public class RecaptchaApiException extends RuntimeException {
+
+    public RecaptchaApiException(String message) {
+        super(message);
+    }
+
+    public RecaptchaApiException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/config/RecaptchaProperties.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/config/RecaptchaProperties.java
@@ -1,5 +1,6 @@
 package news.bombom.captcha.config;
 
+import java.time.Duration;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -13,5 +14,19 @@ public class RecaptchaProperties {
 
     private String secretKey;
     private String verifyUrl = "https://www.google.com/recaptcha/api/siteverify";
+    
+    /**
+     * reCAPTCHA 토큰 유효 시간 (초)
+     */
     private long maxAgeSeconds = 120;
+    
+    /**
+     * Google API 연결 타임아웃
+     */
+    private Duration connectTimeout = Duration.ofSeconds(3);
+    
+    /**
+     * Google API 응답 읽기 타임아웃
+     */
+    private Duration readTimeout = Duration.ofSeconds(5);
 }

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/config/RecaptchaProperties.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/config/RecaptchaProperties.java
@@ -1,0 +1,17 @@
+package news.bombom.captcha.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "recaptcha")
+public class RecaptchaProperties {
+
+    private String secretKey;
+    private String verifyUrl = "https://www.google.com/recaptcha/api/siteverify";
+    private long maxAgeSeconds = 120;
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/config/RestClientConfig.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/config/RestClientConfig.java
@@ -1,28 +1,27 @@
 package news.bombom.captcha.config;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 @RequiredArgsConstructor
-public class RestTemplateConfig {
+public class RestClientConfig {
 
     private final RecaptchaProperties recaptchaProperties;
 
     /**
-     * reCAPTCHA 검증용 RestTemplate 타임아웃 설정은 application.yml에서 조정 가능
+     * reCAPTCHA 검증용 RestClient 타임아웃 설정은 application.yml에서 조정 가능
      */
     @Bean
-    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+    public RestClient restClient(RestClient.Builder builder) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
         requestFactory.setConnectTimeout(recaptchaProperties.getConnectTimeout());
         requestFactory.setReadTimeout(recaptchaProperties.getReadTimeout());
 
-        return builder.requestFactory(() -> requestFactory)
+        return builder.requestFactory(requestFactory)
                 .build();
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/config/RestTemplateConfig.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/config/RestTemplateConfig.java
@@ -1,6 +1,6 @@
 package news.bombom.captcha.config;
 
-import java.time.Duration;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,16 +8,21 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
+@RequiredArgsConstructor
 public class RestTemplateConfig {
 
+    private final RecaptchaProperties recaptchaProperties;
+
+    /**
+     * reCAPTCHA 검증용 RestTemplate 타임아웃 설정은 application.yml에서 조정 가능
+     */
     @Bean
     public RestTemplate restTemplate(RestTemplateBuilder builder) {
         SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
-        requestFactory.setConnectTimeout(Duration.ofSeconds(3));
-        requestFactory.setReadTimeout(Duration.ofSeconds(5));
-        
-        return builder
-                .requestFactory(() -> requestFactory)
+        requestFactory.setConnectTimeout(recaptchaProperties.getConnectTimeout());
+        requestFactory.setReadTimeout(recaptchaProperties.getReadTimeout());
+
+        return builder.requestFactory(() -> requestFactory)
                 .build();
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/config/RestTemplateConfig.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/config/RestTemplateConfig.java
@@ -1,0 +1,23 @@
+package news.bombom.captcha.config;
+
+import java.time.Duration;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(3));
+        requestFactory.setReadTimeout(Duration.ofSeconds(5));
+        
+        return builder
+                .requestFactory(() -> requestFactory)
+                .build();
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/controller/CaptchaController.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/controller/CaptchaController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/captcha")
+@RequestMapping("/api/v1/notifications/captcha")
 public class CaptchaController implements CaptchaControllerApi {
 
     private final CaptchaService captchaService;

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/controller/CaptchaController.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/controller/CaptchaController.java
@@ -1,0 +1,30 @@
+package news.bombom.captcha.controller;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.captcha.dto.request.CaptchaVerifyRequest;
+import news.bombom.captcha.dto.response.CaptchaVerifyResponse;
+import news.bombom.captcha.service.CaptchaService;
+import news.bombom.captcha.util.ClientIpResolver;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/captcha")
+public class CaptchaController implements CaptchaControllerApi {
+
+    private final CaptchaService captchaService;
+
+    @Override
+    @PostMapping
+    public CaptchaVerifyResponse verify(@Valid @RequestBody CaptchaVerifyRequest request, HttpServletRequest httpRequest) {
+        String clientIp = ClientIpResolver.getClientIp(httpRequest);
+        return captchaService.verify(request.gRecaptchaResponse(), clientIp);
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/controller/CaptchaControllerApi.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/controller/CaptchaControllerApi.java
@@ -1,0 +1,32 @@
+package news.bombom.captcha.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import news.bombom.captcha.dto.request.CaptchaVerifyRequest;
+import news.bombom.captcha.dto.response.CaptchaVerifyResponse;
+
+@Tag(name = "Captcha", description = "reCAPTCHA 검증 API")
+public interface CaptchaControllerApi {
+
+    @Operation(
+            summary = "reCAPTCHA 검증",
+            description = "reCAPTCHA v2 토큰을 검증합니다. 토큰은 2분 이내에만 유효합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "캡차 검증 완료 (성공 여부는 응답의 isSuccess 필드 참고)",
+                    content = @Content(schema = @Schema(implementation = CaptchaVerifyResponse.class))
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "잘못된 요청 (토큰 누락)"
+            )
+    })
+    CaptchaVerifyResponse verify(CaptchaVerifyRequest request, HttpServletRequest httpRequest);
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/dto/request/CaptchaVerifyRequest.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/dto/request/CaptchaVerifyRequest.java
@@ -1,6 +1,5 @@
 package news.bombom.captcha.dto.request;
 
-import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record CaptchaVerifyRequest(

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/dto/request/CaptchaVerifyRequest.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/dto/request/CaptchaVerifyRequest.java
@@ -1,0 +1,11 @@
+package news.bombom.captcha.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+public record CaptchaVerifyRequest(
+
+        @NotBlank
+        String gRecaptchaResponse
+) {
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/dto/response/CaptchaVerifyResponse.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/dto/response/CaptchaVerifyResponse.java
@@ -1,0 +1,22 @@
+package news.bombom.captcha.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+
+public record CaptchaVerifyResponse(
+
+        @Schema(description = "검증 성공 여부", requiredMode = RequiredMode.REQUIRED)
+        boolean isSuccess,
+        
+        @Schema(description = "메시지", requiredMode = RequiredMode.REQUIRED)
+        String message
+) {
+
+    public static CaptchaVerifyResponse success() {
+        return new CaptchaVerifyResponse(true, "캡차 검증 성공");
+    }
+
+    public static CaptchaVerifyResponse fail(String message) {
+        return new CaptchaVerifyResponse(false, message);
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/dto/response/GoogleRecaptchaResponse.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/dto/response/GoogleRecaptchaResponse.java
@@ -1,0 +1,23 @@
+package news.bombom.captcha.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class GoogleRecaptchaResponse {
+
+    private boolean success;
+
+    @JsonProperty("challenge_ts")
+    private String challengeTs;
+
+    private String hostname;
+
+    @JsonProperty("error-codes")
+    private List<String> errorCodes;
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/service/CaptchaService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/service/CaptchaService.java
@@ -1,0 +1,75 @@
+package news.bombom.captcha.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.captcha.client.GoogleRecaptchaClient;
+import news.bombom.captcha.config.RecaptchaProperties;
+import news.bombom.captcha.dto.response.CaptchaVerifyResponse;
+import news.bombom.captcha.dto.response.GoogleRecaptchaResponse;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CaptchaService {
+
+    private final GoogleRecaptchaClient googleRecaptchaClient;
+    private final RecaptchaProperties recaptchaProperties;
+
+    public CaptchaVerifyResponse verify(String gRecaptchaResponse, String remoteIp) {
+        try {
+            GoogleRecaptchaResponse response = googleRecaptchaClient.verify(gRecaptchaResponse, remoteIp);
+
+            if (response == null) {
+                log.error("reCAPTCHA 검증 실패: 응답이 null입니다.");
+                return CaptchaVerifyResponse.fail("캡차 검증 중 오류가 발생했습니다.");
+            }
+
+            if (!response.isSuccess()) {
+                log.warn("reCAPTCHA 검증 실패 - error-codes: {}", response.getErrorCodes());
+                return CaptchaVerifyResponse.fail("캡차 검증에 실패했습니다.");
+            }
+
+            // 2분 만료 검증
+            if (!validateNotExpired(response.getChallengeTs())) {
+                log.warn("reCAPTCHA 검증 실패 - 토큰이 만료되었습니다. challenge_ts: {}", 
+                        response.getChallengeTs());
+                return CaptchaVerifyResponse.fail("캡차 토큰이 만료되었습니다.");
+            }
+
+            log.info("reCAPTCHA 검증 성공 - challenge_ts: {}, hostname: {}, remoteIp: {}",
+                    response.getChallengeTs(), response.getHostname(), remoteIp);
+            return CaptchaVerifyResponse.success();
+        } catch (Exception e) {
+            log.error("reCAPTCHA 검증 중 오류 발생: {}", e.getMessage(), e);
+            return CaptchaVerifyResponse.fail("캡차 검증 중 오류가 발생했습니다.");
+        }
+    }
+
+    /**
+     * challenge_ts 검증 (2분 이내인지 확인)
+     */
+    private boolean validateNotExpired(String challengeTs) {
+        if (challengeTs == null || challengeTs.isEmpty()) {
+            log.warn("challenge_ts가 null이거나 비어있습니다.");
+            return false;
+        }
+
+        try {
+            Instant challengeTime = Instant.parse(challengeTs);
+            Instant now = Instant.now();
+            long secondsDiff = Duration.between(challengeTime, now).getSeconds();
+
+            log.debug("challenge_ts: {}, 현재 시간: {}, 차이: {}초", 
+                    challengeTs, now, secondsDiff);
+
+            return secondsDiff >= 0 && secondsDiff <= recaptchaProperties.getMaxAgeSeconds();
+        } catch (DateTimeParseException e) {
+            log.error("challenge_ts 파싱 실패: {}", challengeTs, e);
+            return false;
+        }
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/service/CaptchaService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/service/CaptchaService.java
@@ -35,8 +35,7 @@ public class CaptchaService {
 
             // 2분 만료 검증
             if (!validateNotExpired(response.getChallengeTs())) {
-                log.warn("reCAPTCHA 검증 실패 - 토큰이 만료되었습니다. challenge_ts: {}", 
-                        response.getChallengeTs());
+                log.warn("reCAPTCHA 검증 실패 - 토큰이 만료되었습니다. challenge_ts: {}", response.getChallengeTs());
                 return CaptchaVerifyResponse.fail("캡차 토큰이 만료되었습니다.");
             }
 
@@ -63,10 +62,19 @@ public class CaptchaService {
             Instant now = Instant.now();
             long secondsDiff = Duration.between(challengeTime, now).getSeconds();
 
-            log.debug("challenge_ts: {}, 현재 시간: {}, 차이: {}초", 
-                    challengeTs, now, secondsDiff);
+            // 미래 시간 체크
+            if (secondsDiff < 0) {
+                log.warn("challenge_ts가 미래 시간입니다. challenge_ts: {}, 현재: {}", challengeTime, now);
+                return false;
+            }
 
-            return secondsDiff >= 0 && secondsDiff <= recaptchaProperties.getMaxAgeSeconds();
+            // 2분 이내인지 체크
+            if (secondsDiff > recaptchaProperties.getMaxAgeSeconds()) {
+                log.debug("토큰이 만료되었습니다. 경과 시간: {}초, 최대 허용: {}초", secondsDiff, recaptchaProperties.getMaxAgeSeconds());
+                return false;
+            }
+
+            return true;
         } catch (DateTimeParseException e) {
             log.error("challenge_ts 파싱 실패: {}", challengeTs, e);
             return false;

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/util/ClientIpResolver.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/util/ClientIpResolver.java
@@ -1,0 +1,54 @@
+package news.bombom.captcha.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * 클라이언트 IP 주소 추출 유틸리티
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ClientIpResolver {
+
+    private static final String[] IP_HEADER_CANDIDATES = {
+            "X-Forwarded-For",
+            "Proxy-Client-IP",
+            "WL-Proxy-Client-IP",
+            "HTTP_CLIENT_IP",
+            "HTTP_X_FORWARDED_FOR"
+    };
+
+    private static final String UNKNOWN = "unknown";
+
+    public static String getClientIp(HttpServletRequest request) {
+        if (request == null) {
+            return "0.0.0.0";
+        }
+
+        String ip = null;
+
+        // 헤더에서 IP 추출 시도
+        for (String header : IP_HEADER_CANDIDATES) {
+            ip = request.getHeader(header);
+            if (isValidIp(ip)) {
+                break;
+            }
+        }
+
+        // 헤더에서 찾지 못한 경우 RemoteAddr 사용
+        if (!isValidIp(ip)) {
+            ip = request.getRemoteAddr();
+        }
+
+        // X-Forwarded-For에 여러 IP가 있는 경우 첫 번째 IP 사용 (원본 클라이언트 IP)
+        if (ip != null && ip.contains(",")) {
+            ip = ip.split(",")[0].trim();
+        }
+
+        return ip;
+    }
+
+    private static boolean isValidIp(String ip) {
+        return ip != null && !ip.isEmpty() && !UNKNOWN.equalsIgnoreCase(ip);
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/captcha/util/ClientIpResolver.java
+++ b/backend/fcm-server/src/main/java/news/bombom/captcha/util/ClientIpResolver.java
@@ -21,31 +21,26 @@ public final class ClientIpResolver {
     private static final String UNKNOWN = "unknown";
 
     public static String getClientIp(HttpServletRequest request) {
-        if (request == null) {
-            return "0.0.0.0";
-        }
-
-        String ip = null;
-
-        // 헤더에서 IP 추출 시도
+        // 헤더에서 IP 찾기
         for (String header : IP_HEADER_CANDIDATES) {
-            ip = request.getHeader(header);
+            String ip = request.getHeader(header);
             if (isValidIp(ip)) {
-                break;
+                return extractFirstIp(ip);
             }
         }
 
-        // 헤더에서 찾지 못한 경우 RemoteAddr 사용
-        if (!isValidIp(ip)) {
-            ip = request.getRemoteAddr();
-        }
+        // 헤더에 없으면 RemoteAddr 사용
+        return extractFirstIp(request.getRemoteAddr());
+    }
 
-        // X-Forwarded-For에 여러 IP가 있는 경우 첫 번째 IP 사용 (원본 클라이언트 IP)
-        if (ip != null && ip.contains(",")) {
-            ip = ip.split(",")[0].trim();
+    /**
+     * 여러 IP가 콤마로 구분된 경우 첫 번째 IP만 추출 (X-Forwarded-For: "client-ip, proxy1-ip, proxy2-ip")
+     */
+    private static String extractFirstIp(String ip) {
+        if (ip == null || !ip.contains(",")) {
+            return ip;
         }
-
-        return ip;
+        return ip.split(",")[0].trim();
     }
 
     private static boolean isValidIp(String ip) {

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/client/GoogleRecaptchaClientTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/client/GoogleRecaptchaClientTest.java
@@ -197,4 +197,50 @@ class GoogleRecaptchaClientTest {
         assertThat(result).isNotNull();
         assertThat(result.isSuccess()).isFalse();
     }
+
+    @Test
+    @DisplayName("remoteIp가 null인 경우 remoteip 파라미터 제외")
+    void verify_null_remote_ip() {
+        // given
+        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
+        response.setSuccess(true);
+        response.setChallengeTs("2025-07-25T12:00:00Z");
+
+        when(restTemplate.postForObject(eq(VERIFY_URL), requestCaptor.capture(), eq(GoogleRecaptchaResponse.class)))
+                .thenReturn(response);
+
+        // when
+        googleRecaptchaClient.verify(TEST_TOKEN, null);
+
+        // then
+        HttpEntity<MultiValueMap<String, String>> capturedRequest = requestCaptor.getValue();
+        MultiValueMap<String, String> params = capturedRequest.getBody();
+
+        assertThat(params).isNotNull();
+        assertThat(params.getFirst("secret")).isEqualTo(TEST_SECRET_KEY);
+        assertThat(params.getFirst("response")).isEqualTo(TEST_TOKEN);
+        assertThat(params.getFirst("remoteip")).isNull(); // remoteip 파라미터가 없어야 함
+    }
+
+    @Test
+    @DisplayName("remoteIp가 빈 문자열인 경우 remoteip 파라미터 제외")
+    void verify_empty_remote_ip() {
+        // given
+        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
+        response.setSuccess(true);
+        response.setChallengeTs("2025-07-25T12:00:00Z");
+
+        when(restTemplate.postForObject(eq(VERIFY_URL), requestCaptor.capture(), eq(GoogleRecaptchaResponse.class)))
+                .thenReturn(response);
+
+        // when
+        googleRecaptchaClient.verify(TEST_TOKEN, "");
+
+        // then
+        HttpEntity<MultiValueMap<String, String>> capturedRequest = requestCaptor.getValue();
+        MultiValueMap<String, String> params = capturedRequest.getBody();
+
+        assertThat(params).isNotNull();
+        assertThat(params.getFirst("remoteip")).isNull(); // remoteip 파라미터가 없어야 함
+    }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/client/GoogleRecaptchaClientTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/client/GoogleRecaptchaClientTest.java
@@ -2,43 +2,32 @@ package news.bombom.captcha.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Duration;
 import java.util.List;
 import news.bombom.captcha.config.RecaptchaProperties;
 import news.bombom.captcha.dto.response.GoogleRecaptchaResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpEntity;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.boot.test.web.client.MockServerRestClientCustomizer;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
 
-@ExtendWith(MockitoExtension.class)
+@DisplayName("GoogleRecaptchaClient 테스트")
 class GoogleRecaptchaClientTest {
 
-    @Mock
-    private RecaptchaProperties recaptchaProperties;
-
-    @Mock
-    private RestTemplate restTemplate;
-
-    @InjectMocks
+    private MockRestServiceServer mockServer;
     private GoogleRecaptchaClient googleRecaptchaClient;
-
-    @Captor
-    private ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestCaptor;
+    private RecaptchaProperties recaptchaProperties;
+    private ObjectMapper objectMapper;
 
     private static final String TEST_TOKEN = "test-recaptcha-token";
     private static final String TEST_IP = "192.168.1.1";
@@ -47,26 +36,40 @@ class GoogleRecaptchaClientTest {
 
     @BeforeEach
     void setUp() {
-        when(recaptchaProperties.getSecretKey()).thenReturn(TEST_SECRET_KEY);
-        when(recaptchaProperties.getVerifyUrl()).thenReturn(VERIFY_URL);
+        recaptchaProperties = new RecaptchaProperties();
+        recaptchaProperties.setSecretKey(TEST_SECRET_KEY);
+        recaptchaProperties.setVerifyUrl(VERIFY_URL);
+        recaptchaProperties.setConnectTimeout(Duration.ofSeconds(3));
+        recaptchaProperties.setReadTimeout(Duration.ofSeconds(5));
+
+        // MockServerRestClientCustomizer 사용
+        MockServerRestClientCustomizer customizer = new MockServerRestClientCustomizer();
+        RestClient.Builder builder = RestClient.builder();
+        customizer.customize(builder);
+        
+        mockServer = customizer.getServer();
+        googleRecaptchaClient = new GoogleRecaptchaClient(recaptchaProperties, builder.build());
+        objectMapper = new ObjectMapper();
     }
 
     @Test
     @DisplayName("Google API 호출 성공")
-    void verify_success() {
+    void verify_success() throws Exception {
         // given
         GoogleRecaptchaResponse expectedResponse = new GoogleRecaptchaResponse();
         expectedResponse.setSuccess(true);
         expectedResponse.setChallengeTs("2025-07-25T12:00:00Z");
         expectedResponse.setHostname("example.com");
 
-        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
-                .thenReturn(expectedResponse);
+        mockServer.expect(requestTo(VERIFY_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
 
         // when
         GoogleRecaptchaResponse result = googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
 
         // then
+        mockServer.verify();
         assertThat(result).isNotNull();
         assertThat(result.isSuccess()).isTrue();
         assertThat(result.getChallengeTs()).isEqualTo("2025-07-25T12:00:00Z");
@@ -74,173 +77,77 @@ class GoogleRecaptchaClientTest {
     }
 
     @Test
-    @DisplayName("요청 파라미터가 올바르게 설정됨")
-    void verify_request_parameters() {
-        // given
-        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
-        response.setSuccess(true);
-
-        when(restTemplate.postForObject(eq(VERIFY_URL), requestCaptor.capture(), eq(GoogleRecaptchaResponse.class)))
-                .thenReturn(response);
-
-        // when
-        googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
-
-        // then
-        HttpEntity<MultiValueMap<String, String>> capturedRequest = requestCaptor.getValue();
-        MultiValueMap<String, String> params = capturedRequest.getBody();
-
-        assertThat(params).isNotNull();
-        assertThat(params.getFirst("secret")).isEqualTo(TEST_SECRET_KEY);
-        assertThat(params.getFirst("response")).isEqualTo(TEST_TOKEN);
-        assertThat(params.getFirst("remoteip")).isEqualTo(TEST_IP);
-    }
-
-    @Test
     @DisplayName("Google API가 실패 응답을 반환")
-    void verify_google_returns_failure() {
+    void verify_google_returns_failure() throws Exception {
         // given
         GoogleRecaptchaResponse expectedResponse = new GoogleRecaptchaResponse();
         expectedResponse.setSuccess(false);
         expectedResponse.setErrorCodes(List.of("invalid-input-response"));
 
-        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
-                .thenReturn(expectedResponse);
+        mockServer.expect(requestTo(VERIFY_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(objectMapper.writeValueAsString(expectedResponse), MediaType.APPLICATION_JSON));
 
         // when
         GoogleRecaptchaResponse result = googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
 
         // then
+        mockServer.verify();
         assertThat(result).isNotNull();
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.getErrorCodes()).containsExactly("invalid-input-response");
     }
 
     @Test
-    @DisplayName("네트워크 오류 시 RecaptchaApiException 발생")
-    void verify_network_error() {
+    @DisplayName("서버 오류 시 RecaptchaApiException 발생")
+    void verify_server_error() {
         // given
-        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
-                .thenThrow(new RestClientException("Network error"));
-
-        // when & then
-        assertThatThrownBy(() -> googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP))
-                .isInstanceOf(RecaptchaApiException.class)
-                .hasMessageContaining("Google reCAPTCHA API 호출 중 오류가 발생했습니다.")
-                .hasCauseInstanceOf(RestClientException.class);
-    }
-
-    @Test
-    @DisplayName("타임아웃 시 RecaptchaApiException 발생")
-    void verify_timeout() {
-        // given
-        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
-                .thenThrow(new RestClientException("Read timed out"));
+        mockServer.expect(requestTo(VERIFY_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withServerError());
 
         // when & then
         assertThatThrownBy(() -> googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP))
                 .isInstanceOf(RecaptchaApiException.class)
                 .hasMessageContaining("Google reCAPTCHA API 호출 중 오류가 발생했습니다.");
+
+        mockServer.verify();
     }
 
     @Test
-    @DisplayName("올바른 URL로 API 호출")
-    void verify_correct_url() {
-        // given
-        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
-        response.setSuccess(true);
-
-        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
-                .thenReturn(response);
-
-        // when
-        googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
-
-        // then
-        verify(restTemplate).postForObject(eq(VERIFY_URL), any(), eq(GoogleRecaptchaResponse.class));
-    }
-
-    @Test
-    @DisplayName("Content-Type이 application/x-www-form-urlencoded로 설정됨")
-    void verify_content_type() {
-        // given
-        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
-        response.setSuccess(true);
-
-        when(restTemplate.postForObject(anyString(), requestCaptor.capture(), eq(GoogleRecaptchaResponse.class)))
-                .thenReturn(response);
-
-        // when
-        googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
-
-        // then
-        HttpEntity<MultiValueMap<String, String>> capturedRequest = requestCaptor.getValue();
-        assertThat(capturedRequest.getHeaders().getContentType().toString())
-                .isEqualTo("application/x-www-form-urlencoded");
-    }
-
-    @Test
-    @DisplayName("빈 토큰으로도 API 호출 가능 (Google에서 검증 실패)")
-    void verify_empty_token() {
+    @DisplayName("빈 토큰으로도 API 호출 가능")
+    void verify_empty_token() throws Exception {
         // given
         GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
         response.setSuccess(false);
         response.setErrorCodes(List.of("missing-input-response"));
 
-        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
-                .thenReturn(response);
+        mockServer.expect(requestTo(VERIFY_URL))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess(objectMapper.writeValueAsString(response), MediaType.APPLICATION_JSON));
 
         // when
         GoogleRecaptchaResponse result = googleRecaptchaClient.verify("", TEST_IP);
 
         // then
+        mockServer.verify();
         assertThat(result).isNotNull();
         assertThat(result.isSuccess()).isFalse();
     }
 
     @Test
-    @DisplayName("remoteIp가 null인 경우 remoteip 파라미터 제외")
-    void verify_null_remote_ip() {
+    @DisplayName("RecaptchaApiException 생성자 테스트")
+    void recaptcha_api_exception() {
         // given
-        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
-        response.setSuccess(true);
-        response.setChallengeTs("2025-07-25T12:00:00Z");
-
-        when(restTemplate.postForObject(eq(VERIFY_URL), requestCaptor.capture(), eq(GoogleRecaptchaResponse.class)))
-                .thenReturn(response);
+        String message = "테스트 메시지";
+        Exception cause = new RuntimeException("원인");
 
         // when
-        googleRecaptchaClient.verify(TEST_TOKEN, null);
+        RecaptchaApiException exception = new RecaptchaApiException(message, cause);
 
         // then
-        HttpEntity<MultiValueMap<String, String>> capturedRequest = requestCaptor.getValue();
-        MultiValueMap<String, String> params = capturedRequest.getBody();
-
-        assertThat(params).isNotNull();
-        assertThat(params.getFirst("secret")).isEqualTo(TEST_SECRET_KEY);
-        assertThat(params.getFirst("response")).isEqualTo(TEST_TOKEN);
-        assertThat(params.getFirst("remoteip")).isNull(); // remoteip 파라미터가 없어야 함
-    }
-
-    @Test
-    @DisplayName("remoteIp가 빈 문자열인 경우 remoteip 파라미터 제외")
-    void verify_empty_remote_ip() {
-        // given
-        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
-        response.setSuccess(true);
-        response.setChallengeTs("2025-07-25T12:00:00Z");
-
-        when(restTemplate.postForObject(eq(VERIFY_URL), requestCaptor.capture(), eq(GoogleRecaptchaResponse.class)))
-                .thenReturn(response);
-
-        // when
-        googleRecaptchaClient.verify(TEST_TOKEN, "");
-
-        // then
-        HttpEntity<MultiValueMap<String, String>> capturedRequest = requestCaptor.getValue();
-        MultiValueMap<String, String> params = capturedRequest.getBody();
-
-        assertThat(params).isNotNull();
-        assertThat(params.getFirst("remoteip")).isNull(); // remoteip 파라미터가 없어야 함
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getCause()).isEqualTo(cause);
     }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/client/GoogleRecaptchaClientTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/client/GoogleRecaptchaClientTest.java
@@ -1,0 +1,200 @@
+package news.bombom.captcha.client;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import news.bombom.captcha.config.RecaptchaProperties;
+import news.bombom.captcha.dto.response.GoogleRecaptchaResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class GoogleRecaptchaClientTest {
+
+    @Mock
+    private RecaptchaProperties recaptchaProperties;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    @InjectMocks
+    private GoogleRecaptchaClient googleRecaptchaClient;
+
+    @Captor
+    private ArgumentCaptor<HttpEntity<MultiValueMap<String, String>>> requestCaptor;
+
+    private static final String TEST_TOKEN = "test-recaptcha-token";
+    private static final String TEST_IP = "192.168.1.1";
+    private static final String TEST_SECRET_KEY = "test-secret-key";
+    private static final String VERIFY_URL = "https://www.google.com/recaptcha/api/siteverify";
+
+    @BeforeEach
+    void setUp() {
+        when(recaptchaProperties.getSecretKey()).thenReturn(TEST_SECRET_KEY);
+        when(recaptchaProperties.getVerifyUrl()).thenReturn(VERIFY_URL);
+    }
+
+    @Test
+    @DisplayName("Google API 호출 성공")
+    void verify_success() {
+        // given
+        GoogleRecaptchaResponse expectedResponse = new GoogleRecaptchaResponse();
+        expectedResponse.setSuccess(true);
+        expectedResponse.setChallengeTs("2025-07-25T12:00:00Z");
+        expectedResponse.setHostname("example.com");
+
+        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
+                .thenReturn(expectedResponse);
+
+        // when
+        GoogleRecaptchaResponse result = googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.getChallengeTs()).isEqualTo("2025-07-25T12:00:00Z");
+        assertThat(result.getHostname()).isEqualTo("example.com");
+    }
+
+    @Test
+    @DisplayName("요청 파라미터가 올바르게 설정됨")
+    void verify_request_parameters() {
+        // given
+        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
+        response.setSuccess(true);
+
+        when(restTemplate.postForObject(eq(VERIFY_URL), requestCaptor.capture(), eq(GoogleRecaptchaResponse.class)))
+                .thenReturn(response);
+
+        // when
+        googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        HttpEntity<MultiValueMap<String, String>> capturedRequest = requestCaptor.getValue();
+        MultiValueMap<String, String> params = capturedRequest.getBody();
+
+        assertThat(params).isNotNull();
+        assertThat(params.getFirst("secret")).isEqualTo(TEST_SECRET_KEY);
+        assertThat(params.getFirst("response")).isEqualTo(TEST_TOKEN);
+        assertThat(params.getFirst("remoteip")).isEqualTo(TEST_IP);
+    }
+
+    @Test
+    @DisplayName("Google API가 실패 응답을 반환")
+    void verify_google_returns_failure() {
+        // given
+        GoogleRecaptchaResponse expectedResponse = new GoogleRecaptchaResponse();
+        expectedResponse.setSuccess(false);
+        expectedResponse.setErrorCodes(List.of("invalid-input-response"));
+
+        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
+                .thenReturn(expectedResponse);
+
+        // when
+        GoogleRecaptchaResponse result = googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.getErrorCodes()).containsExactly("invalid-input-response");
+    }
+
+    @Test
+    @DisplayName("네트워크 오류 시 RecaptchaApiException 발생")
+    void verify_network_error() {
+        // given
+        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
+                .thenThrow(new RestClientException("Network error"));
+
+        // when & then
+        assertThatThrownBy(() -> googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP))
+                .isInstanceOf(RecaptchaApiException.class)
+                .hasMessageContaining("Google reCAPTCHA API 호출 중 오류가 발생했습니다.")
+                .hasCauseInstanceOf(RestClientException.class);
+    }
+
+    @Test
+    @DisplayName("타임아웃 시 RecaptchaApiException 발생")
+    void verify_timeout() {
+        // given
+        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
+                .thenThrow(new RestClientException("Read timed out"));
+
+        // when & then
+        assertThatThrownBy(() -> googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP))
+                .isInstanceOf(RecaptchaApiException.class)
+                .hasMessageContaining("Google reCAPTCHA API 호출 중 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("올바른 URL로 API 호출")
+    void verify_correct_url() {
+        // given
+        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
+        response.setSuccess(true);
+
+        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
+                .thenReturn(response);
+
+        // when
+        googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        verify(restTemplate).postForObject(eq(VERIFY_URL), any(), eq(GoogleRecaptchaResponse.class));
+    }
+
+    @Test
+    @DisplayName("Content-Type이 application/x-www-form-urlencoded로 설정됨")
+    void verify_content_type() {
+        // given
+        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
+        response.setSuccess(true);
+
+        when(restTemplate.postForObject(anyString(), requestCaptor.capture(), eq(GoogleRecaptchaResponse.class)))
+                .thenReturn(response);
+
+        // when
+        googleRecaptchaClient.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        HttpEntity<MultiValueMap<String, String>> capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getHeaders().getContentType().toString())
+                .isEqualTo("application/x-www-form-urlencoded");
+    }
+
+    @Test
+    @DisplayName("빈 토큰으로도 API 호출 가능 (Google에서 검증 실패)")
+    void verify_empty_token() {
+        // given
+        GoogleRecaptchaResponse response = new GoogleRecaptchaResponse();
+        response.setSuccess(false);
+        response.setErrorCodes(List.of("missing-input-response"));
+
+        when(restTemplate.postForObject(anyString(), any(), eq(GoogleRecaptchaResponse.class)))
+                .thenReturn(response);
+
+        // when
+        GoogleRecaptchaResponse result = googleRecaptchaClient.verify("", TEST_IP);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.isSuccess()).isFalse();
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/controller/CaptchaControllerTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/controller/CaptchaControllerTest.java
@@ -1,0 +1,101 @@
+package news.bombom.captcha.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import news.bombom.captcha.dto.request.CaptchaVerifyRequest;
+import news.bombom.captcha.dto.response.CaptchaVerifyResponse;
+import news.bombom.captcha.service.CaptchaService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.auditing.AuditingHandler;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import news.bombom.NotificationServerApplication;
+
+@WebMvcTest(CaptchaController.class)
+@ContextConfiguration(classes = NotificationServerApplication.class)
+class CaptchaControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private CaptchaService captchaService;
+
+    @MockitoBean
+    private JpaMetamodelMappingContext jpaMappingContext;
+
+    @MockitoBean
+    private AuditingHandler jpaAuditingHandler;
+
+    @Test
+    @DisplayName("캡차 검증 성공")
+    void verify_success() throws Exception {
+        // given
+        CaptchaVerifyRequest request = new CaptchaVerifyRequest("valid-token");
+        when(captchaService.verify(anyString(), anyString()))
+                .thenReturn(CaptchaVerifyResponse.success());
+
+        // when & then
+        mockMvc.perform(post("/api/v1/captcha")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.message").value("캡차 검증 성공"));
+    }
+
+    @Test
+    @DisplayName("캡차 검증 실패")
+    void verify_fail() throws Exception {
+        // given
+        CaptchaVerifyRequest request = new CaptchaVerifyRequest("invalid-token");
+        when(captchaService.verify(anyString(), anyString()))
+                .thenReturn(CaptchaVerifyResponse.fail("캡차 검증에 실패했습니다."));
+
+        // when & then
+        mockMvc.perform(post("/api/v1/captcha")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.isSuccess").value(false))
+                .andExpect(jsonPath("$.message").value("캡차 검증에 실패했습니다."));
+    }
+
+    @Test
+    @DisplayName("캡차 토큰 없음 - validation 실패")
+    void verify_blank_token() throws Exception {
+        // given
+        CaptchaVerifyRequest request = new CaptchaVerifyRequest("");
+
+        // when & then
+        mockMvc.perform(post("/api/v1/captcha")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("캡차 토큰 null - validation 실패")
+    void verify_null_token() throws Exception {
+        // when & then
+        mockMvc.perform(post("/api/v1/captcha")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"gRecaptchaResponse\": null}"))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/controller/CaptchaControllerTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/controller/CaptchaControllerTest.java
@@ -51,7 +51,7 @@ class CaptchaControllerTest {
                 .thenReturn(CaptchaVerifyResponse.success());
 
         // when & then
-        mockMvc.perform(post("/api/v1/captcha")
+        mockMvc.perform(post("/api/v1/notifications/captcha")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -68,7 +68,7 @@ class CaptchaControllerTest {
                 .thenReturn(CaptchaVerifyResponse.fail("캡차 검증에 실패했습니다."));
 
         // when & then
-        mockMvc.perform(post("/api/v1/captcha")
+        mockMvc.perform(post("/api/v1/notifications/captcha")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -83,7 +83,7 @@ class CaptchaControllerTest {
         CaptchaVerifyRequest request = new CaptchaVerifyRequest("");
 
         // when & then
-        mockMvc.perform(post("/api/v1/captcha")
+        mockMvc.perform(post("/api/v1/notifications/captcha")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
@@ -93,7 +93,7 @@ class CaptchaControllerTest {
     @DisplayName("캡차 토큰 null - validation 실패")
     void verify_null_token() throws Exception {
         // when & then
-        mockMvc.perform(post("/api/v1/captcha")
+        mockMvc.perform(post("/api/v1/notifications/captcha")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"gRecaptchaResponse\": null}"))
                 .andExpect(status().isBadRequest());

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/service/CaptchaServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/service/CaptchaServiceTest.java
@@ -1,0 +1,177 @@
+package news.bombom.captcha.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import news.bombom.captcha.client.GoogleRecaptchaClient;
+import news.bombom.captcha.config.RecaptchaProperties;
+import news.bombom.captcha.dto.response.GoogleRecaptchaResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CaptchaServiceTest {
+
+    @Mock
+    private GoogleRecaptchaClient googleRecaptchaClient;
+
+    @Mock
+    private RecaptchaProperties recaptchaProperties;
+
+    @InjectMocks
+    private CaptchaService captchaService;
+
+    private static final String TEST_IP = "127.0.0.1";
+    private static final String TEST_TOKEN = "test-token";
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(recaptchaProperties.getMaxAgeSeconds()).thenReturn(120L);
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 성공")
+    void verify_success() {
+        // given
+        String currentTime = Instant.now().toString();
+        
+        GoogleRecaptchaResponse mockResponse = new GoogleRecaptchaResponse();
+        mockResponse.setSuccess(true);
+        mockResponse.setChallengeTs(currentTime);
+        mockResponse.setHostname("example.com");
+
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.message()).isEqualTo("캡차 검증 성공");
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - Google에서 success=false 반환")
+    void verify_fail_google_returns_false() {
+        // given
+        GoogleRecaptchaResponse mockResponse = new GoogleRecaptchaResponse();
+        mockResponse.setSuccess(false);
+        mockResponse.setErrorCodes(List.of("invalid-input-response"));
+
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.message()).isEqualTo("캡차 검증에 실패했습니다.");
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - 토큰 만료 (2분 초과)")
+    void verify_fail_token_expired() {
+        // given
+        // 3분 전 시간
+        String expiredTime = Instant.now().minusSeconds(180).toString();
+        
+        GoogleRecaptchaResponse mockResponse = new GoogleRecaptchaResponse();
+        mockResponse.setSuccess(true);
+        mockResponse.setChallengeTs(expiredTime);
+        mockResponse.setHostname("example.com");
+
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.message()).isEqualTo("캡차 토큰이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 성공 - 2분 이내 토큰")
+    void verify_success_within_two_minutes() {
+        // given
+        // 1분 전 시간
+        String recentTime = Instant.now().minusSeconds(60).toString();
+        
+        GoogleRecaptchaResponse mockResponse = new GoogleRecaptchaResponse();
+        mockResponse.setSuccess(true);
+        mockResponse.setChallengeTs(recentTime);
+        mockResponse.setHostname("example.com");
+
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isTrue();
+        assertThat(result.message()).isEqualTo("캡차 검증 성공");
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - Google 응답이 null")
+    void verify_fail_null_response() {
+        // given
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(null);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.message()).isEqualTo("캡차 검증 중 오류가 발생했습니다.");
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - challenge_ts가 null")
+    void verify_fail_null_challenge_ts() {
+        // given
+        GoogleRecaptchaResponse mockResponse = new GoogleRecaptchaResponse();
+        mockResponse.setSuccess(true);
+        mockResponse.setChallengeTs(null);
+        mockResponse.setHostname("example.com");
+
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.message()).isEqualTo("캡차 토큰이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - 예외 발생")
+    void verify_fail_exception() {
+        // given
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenThrow(new RuntimeException("Network error"));
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.message()).isEqualTo("캡차 검증 중 오류가 발생했습니다.");
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/service/CaptchaServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/service/CaptchaServiceTest.java
@@ -174,4 +174,67 @@ class CaptchaServiceTest {
         assertThat(result.isSuccess()).isFalse();
         assertThat(result.message()).isEqualTo("캡차 검증 중 오류가 발생했습니다.");
     }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - 미래 시간 토큰 (비정상)")
+    void verify_fail_future_time() {
+        // given
+        // 1시간 후 시간 (비정상)
+        String futureTime = Instant.now().plusSeconds(3600).toString();
+        
+        GoogleRecaptchaResponse mockResponse = new GoogleRecaptchaResponse();
+        mockResponse.setSuccess(true);
+        mockResponse.setChallengeTs(futureTime);
+        mockResponse.setHostname("example.com");
+
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.message()).isEqualTo("캡차 토큰이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - 빈 challenge_ts")
+    void verify_fail_empty_challenge_ts() {
+        // given
+        GoogleRecaptchaResponse mockResponse = new GoogleRecaptchaResponse();
+        mockResponse.setSuccess(true);
+        mockResponse.setChallengeTs("");
+        mockResponse.setHostname("example.com");
+
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.message()).isEqualTo("캡차 토큰이 만료되었습니다.");
+    }
+
+    @Test
+    @DisplayName("reCAPTCHA 검증 실패 - 잘못된 형식의 challenge_ts")
+    void verify_fail_invalid_format_challenge_ts() {
+        // given
+        GoogleRecaptchaResponse mockResponse = new GoogleRecaptchaResponse();
+        mockResponse.setSuccess(true);
+        mockResponse.setChallengeTs("invalid-timestamp");
+        mockResponse.setHostname("example.com");
+
+        when(googleRecaptchaClient.verify(anyString(), anyString()))
+                .thenReturn(mockResponse);
+
+        // when
+        var result = captchaService.verify(TEST_TOKEN, TEST_IP);
+
+        // then
+        assertThat(result.isSuccess()).isFalse();
+        assertThat(result.message()).isEqualTo("캡차 토큰이 만료되었습니다.");
+    }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/util/ClientIpResolverTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/util/ClientIpResolverTest.java
@@ -79,16 +79,6 @@ class ClientIpResolverTest {
     }
 
     @Test
-    @DisplayName("request가 null인 경우 기본 IP 반환")
-    void getClientIp_null_request() {
-        // when
-        String actualIp = ClientIpResolver.getClientIp(null);
-
-        // then
-        assertThat(actualIp).isEqualTo("0.0.0.0");
-    }
-
-    @Test
     @DisplayName("빈 문자열은 무시하고 다음 헤더 확인")
     void getClientIp_skip_empty_string() {
         // given
@@ -152,5 +142,23 @@ class ClientIpResolverTest {
 
         // then
         assertThat(actualIp).isEqualTo(expectedIp);
+    }
+
+    @Test
+    @DisplayName("모든 헤더와 RemoteAddr이 null인 경우 null 반환")
+    void getClientIp_all_null_returns_null() {
+        // given
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("WL-Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("HTTP_CLIENT_IP")).thenReturn(null);
+        when(request.getHeader("HTTP_X_FORWARDED_FOR")).thenReturn(null);
+        when(request.getRemoteAddr()).thenReturn(null);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isNull();
     }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/captcha/util/ClientIpResolverTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/captcha/util/ClientIpResolverTest.java
@@ -1,0 +1,156 @@
+package news.bombom.captcha.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ClientIpResolverTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Test
+    @DisplayName("X-Forwarded-For 헤더에서 IP 추출")
+    void getClientIp_from_x_forwarded_for() {
+        // given
+        String expectedIp = "192.168.1.100";
+        when(request.getHeader("X-Forwarded-For")).thenReturn(expectedIp);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isEqualTo(expectedIp);
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For에 여러 IP가 있는 경우 첫 번째 IP 추출")
+    void getClientIp_from_x_forwarded_for_multiple() {
+        // given
+        String multipleIps = "192.168.1.100, 10.0.0.1, 172.16.0.1";
+        when(request.getHeader("X-Forwarded-For")).thenReturn(multipleIps);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isEqualTo("192.168.1.100");
+    }
+
+    @Test
+    @DisplayName("X-Forwarded-For가 unknown인 경우 Proxy-Client-IP에서 추출")
+    void getClientIp_from_proxy_client_ip() {
+        // given
+        String expectedIp = "192.168.1.101";
+        when(request.getHeader("X-Forwarded-For")).thenReturn("unknown");
+        when(request.getHeader("Proxy-Client-IP")).thenReturn(expectedIp);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isEqualTo(expectedIp);
+    }
+
+    @Test
+    @DisplayName("모든 헤더가 없는 경우 RemoteAddr에서 추출")
+    void getClientIp_from_remote_addr() {
+        // given
+        String expectedIp = "127.0.0.1";
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("WL-Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("HTTP_CLIENT_IP")).thenReturn(null);
+        when(request.getHeader("HTTP_X_FORWARDED_FOR")).thenReturn(null);
+        when(request.getRemoteAddr()).thenReturn(expectedIp);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isEqualTo(expectedIp);
+    }
+
+    @Test
+    @DisplayName("request가 null인 경우 기본 IP 반환")
+    void getClientIp_null_request() {
+        // when
+        String actualIp = ClientIpResolver.getClientIp(null);
+
+        // then
+        assertThat(actualIp).isEqualTo("0.0.0.0");
+    }
+
+    @Test
+    @DisplayName("빈 문자열은 무시하고 다음 헤더 확인")
+    void getClientIp_skip_empty_string() {
+        // given
+        String expectedIp = "192.168.1.102";
+        when(request.getHeader("X-Forwarded-For")).thenReturn("");
+        when(request.getHeader("Proxy-Client-IP")).thenReturn(expectedIp);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isEqualTo(expectedIp);
+    }
+
+    @Test
+    @DisplayName("WL-Proxy-Client-IP 헤더에서 IP 추출")
+    void getClientIp_from_wl_proxy_client_ip() {
+        // given
+        String expectedIp = "192.168.1.103";
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("WL-Proxy-Client-IP")).thenReturn(expectedIp);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isEqualTo(expectedIp);
+    }
+
+    @Test
+    @DisplayName("HTTP_CLIENT_IP 헤더에서 IP 추출")
+    void getClientIp_from_http_client_ip() {
+        // given
+        String expectedIp = "192.168.1.104";
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("WL-Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("HTTP_CLIENT_IP")).thenReturn(expectedIp);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isEqualTo(expectedIp);
+    }
+
+    @Test
+    @DisplayName("HTTP_X_FORWARDED_FOR 헤더에서 IP 추출")
+    void getClientIp_from_http_x_forwarded_for() {
+        // given
+        String expectedIp = "192.168.1.105";
+        when(request.getHeader("X-Forwarded-For")).thenReturn(null);
+        when(request.getHeader("Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("WL-Proxy-Client-IP")).thenReturn(null);
+        when(request.getHeader("HTTP_CLIENT_IP")).thenReturn(null);
+        when(request.getHeader("HTTP_X_FORWARDED_FOR")).thenReturn(expectedIp);
+
+        // when
+        String actualIp = ClientIpResolver.getClientIp(request);
+
+        // then
+        assertThat(actualIp).isEqualTo(expectedIp);
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
Google reCAPTCHA v2 검증 API를 구현했습니다.

fcm-server에 봇 공격 방지를 위한 캡차 검증 엔드포인트를 추가했습니다.
- 엔드포인트: `POST /api/v1/notifications/captcha` 
- 프론트엔드에서 생성한 reCAPTCHA 토큰을 검증
- 2분 만료 시간 검증 포함
- 클라이언트 IP를 Google API에 전송하여 추가 보안 강화

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
선착순 이벤트 대비 봇 공격 방지와 서비스 안정성, 보안 강화를 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

### 1. 핵심 기능 구현

#### 2분 만료 검증
- Google API 응답의 `challenge_ts` (토큰 생성 시각)를 파싱
- 현재 시간과 비교하여 120초 이내인지 검증
- 미래 시간 토큰도 거부하여 비정상 토큰 차단
- 설정 파일(`application.yml`)에서 만료 시간 조정 가능

#### 클라이언트 IP 추출 및 전송
- 다양한 프록시 헤더 지원 (X-Forwarded-For, Proxy-Client-IP 등)
- 여러 IP가 콤마로 구분된 경우 첫 번째 IP(원본 클라이언트) 추출
- Google API에 `remoteip` 파라미터로 전송하여 추가 검증
- IP를 찾지 못한 경우 `remoteip` 파라미터 제외 (선택적 파라미터)

#### 응답 처리
- 성공/실패를 응답 객체의 `isSuccess` 필드로 구분
- 실패 유형에 따라 구체적인 메시지 제공
  - Google API 실패: "캡차 검증에 실패했습니다."
  - 토큰 만료: "캡차 토큰이 만료되었습니다."
  - 예외 발생: "캡차 검증 중 오류가 발생했습니다."

### 3. 성능 최적화

#### 동시 요청 처리
- RestTemplate 타임아웃 설정 (연결 3초, 읽기 5초)
  - **안정적인 값이라고 추천받았는데요. 이것은 테스트를 통해서 안정적인 값을 찾으라고 해서 yml을 통해서 값을 쉽게 바꿀 수 있도록 했습니다.** 
- SimpleClientHttpRequestFactory 사용
- 동시 50명 이상 처리 가능하도록 설계

### 4. 보안 고려사항

#### IP 기반 추가 검증
- 클라이언트 IP를 Google API에 전송
- Google이 IP 기반 이상 패턴 감지
- 보안성 강화

### 5. API 문서화 (Swagger)

#### Swagger 의존성 추가
- `springdoc-openapi-starter-webmvc-ui:2.8.15`
- `/swagger-ui.html`에서 API 문서 확인 가능

#### 상세한 API 문서
- 요청/응답 스키마 정의
- 예제 값 제공
- 에러 케이스 명시

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->