### PR TITLE
[BOM-951] feat: 이벤트 알림 자동 발송 기능 구현

### DIFF
--- a/backend/fcm-server/src/main/java/news/bombom/event/domain/Event.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/domain/Event.java
@@ -1,0 +1,46 @@
+package news.bombom.event.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombom.notification.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Event extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String name;
+
+    @Column(nullable = false)
+    private LocalDateTime startTime;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private EventStatus status;
+
+    @Builder
+    public Event(
+            @NonNull String name,
+            @NonNull LocalDateTime startTime,
+            @NonNull EventStatus status
+    ) {
+        this.name = name;
+        this.startTime = startTime;
+        this.status = status;
+    }
+
+    public void updateStatus(EventStatus status) {
+        this.status = status;
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/event/domain/EventNotificationSchedule.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/domain/EventNotificationSchedule.java
@@ -1,0 +1,58 @@
+package news.bombom.event.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombom.notification.common.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "event_notification_schedule")
+public class EventNotificationSchedule extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long eventId;
+
+    @Column(nullable = false)
+    private LocalDateTime scheduledAt;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private NotificationScheduleType type;
+
+    private Integer minutesBefore;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+    private boolean sent = false;
+
+    private LocalDateTime sentAt;
+
+    @Builder
+    public EventNotificationSchedule(
+            @NonNull Long eventId,
+            @NonNull LocalDateTime scheduledAt,
+            @NonNull NotificationScheduleType type,
+            Integer minutesBefore
+    ) {
+        this.eventId = eventId;
+        this.scheduledAt = scheduledAt;
+        this.type = type;
+        this.minutesBefore = minutesBefore;
+        this.sent = false;
+    }
+
+    public void markAsSent() {
+        this.sent = true;
+        this.sentAt = LocalDateTime.now();
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/event/domain/EventStatus.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/domain/EventStatus.java
@@ -1,0 +1,9 @@
+package news.bombom.event.domain;
+
+public enum EventStatus {
+
+    SCHEDULED,    // 예정
+    IN_PROGRESS,  // 진행중
+    COMPLETED,    // 완료
+    CANCELLED     // 취소
+}

--- a/backend/fcm-server/src/main/java/news/bombom/event/domain/NotificationScheduleType.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/domain/NotificationScheduleType.java
@@ -1,0 +1,7 @@
+package news.bombom.event.domain;
+
+public enum NotificationScheduleType {
+
+    BEFORE_MINUTES,  // N분 전 알림
+    AT_START         // 시작 시 알림
+}

--- a/backend/fcm-server/src/main/java/news/bombom/event/repository/EventNotificationScheduleRepository.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/repository/EventNotificationScheduleRepository.java
@@ -1,0 +1,22 @@
+package news.bombom.event.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import news.bombom.event.domain.EventNotificationSchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface EventNotificationScheduleRepository extends JpaRepository<EventNotificationSchedule, Long> {
+
+    @Query("""
+       SELECT s
+       FROM EventNotificationSchedule s
+       JOIN Event e ON s.eventId = e.id
+       WHERE s.scheduledAt <= :now
+         AND s.sent = false
+         AND e.status = 'SCHEDULED'
+       ORDER BY s.scheduledAt ASC
+   """)
+    List<EventNotificationSchedule> findPendingSchedules(@Param("now") LocalDateTime now);
+}

--- a/backend/fcm-server/src/main/java/news/bombom/event/repository/EventRepository.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package news.bombom.event.repository;
+
+import news.bombom.event.domain.Event;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EventRepository extends JpaRepository<Event, Long> {
+}

--- a/backend/fcm-server/src/main/java/news/bombom/event/scheduler/EventNotificationScheduler.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/scheduler/EventNotificationScheduler.java
@@ -25,7 +25,6 @@ public class EventNotificationScheduler {
     public void processPendingNotifications() {
         try {
             List<EventNotificationSchedule> pendingSchedules = eventService.getPendingSchedules();
-
             if (pendingSchedules.isEmpty()) {
                 return;
             }

--- a/backend/fcm-server/src/main/java/news/bombom/event/scheduler/EventNotificationScheduler.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/scheduler/EventNotificationScheduler.java
@@ -31,11 +31,7 @@ public class EventNotificationScheduler {
 
             log.info("발송 대상 알림 개수: {}", pendingSchedules.size());
             for (EventNotificationSchedule schedule : pendingSchedules) {
-                try {
-                    notificationService.sendEventNotification(schedule);
-                } catch (Exception e) {
-                    log.error("알림 발송 실패: scheduleId={}", schedule.getId(), e);
-                }
+                notificationService.sendEventNotification(schedule);
             }
         } catch (Exception e) {
             log.error("이벤트 알림 스케줄러 실행 중 오류 발생", e);

--- a/backend/fcm-server/src/main/java/news/bombom/event/scheduler/EventNotificationScheduler.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/scheduler/EventNotificationScheduler.java
@@ -1,0 +1,45 @@
+package news.bombom.event.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.event.domain.EventNotificationSchedule;
+import news.bombom.event.service.EventService;
+import news.bombom.event.service.EventNotificationService;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class EventNotificationScheduler {
+
+    private static final String TIME_ZONE = "Asia/Seoul";
+    private static final int PER_MINUTE = 60000;
+
+    private final EventService eventService;
+    private final EventNotificationService notificationService;
+
+    @Scheduled(fixedDelay = PER_MINUTE, zone = TIME_ZONE)
+    public void processPendingNotifications() {
+        try {
+            List<EventNotificationSchedule> pendingSchedules = eventService.getPendingSchedules();
+
+            if (pendingSchedules.isEmpty()) {
+                return;
+            }
+
+            log.info("발송 대상 알림 개수: {}", pendingSchedules.size());
+            for (EventNotificationSchedule schedule : pendingSchedules) {
+                try {
+                    notificationService.sendEventNotification(schedule);
+                } catch (Exception e) {
+                    log.error("알림 발송 실패: scheduleId={}", schedule.getId(), e);
+                }
+            }
+        } catch (Exception e) {
+            log.error("이벤트 알림 스케줄러 실행 중 오류 발생", e);
+        }
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/event/service/EventNotificationService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/service/EventNotificationService.java
@@ -1,0 +1,82 @@
+package news.bombom.event.service;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.event.domain.Event;
+import news.bombom.event.domain.EventNotificationSchedule;
+import news.bombom.event.domain.EventStatus;
+import news.bombom.event.domain.NotificationScheduleType;
+import news.bombom.event.repository.EventNotificationScheduleRepository;
+import news.bombom.event.repository.EventRepository;
+import news.bombom.notification.client.firebase.FcmNotificationSender;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.NotificationResult;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventNotificationService {
+
+    private final EventNotificationScheduleRepository scheduleRepository;
+    private final EventRepository eventRepository;
+    private final FcmNotificationSender fcmNotificationSender;
+    
+    private static final String EVENT_TOPIC = NotificationCategory.EVENT.getTopicName(); // "bombom_event"
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+    @Transactional
+    public void sendEventNotification(EventNotificationSchedule schedule) {
+        if (schedule.isSent()) {
+            log.warn("이미 발송된 알림입니다. scheduleId={}", schedule.getId());
+            return;
+        }
+
+        Event event = eventRepository.findById(schedule.getEventId())
+                .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다: " + schedule.getEventId()));
+
+        if (event.getStatus() != EventStatus.SCHEDULED) {
+            log.warn("이벤트가 예정 상태가 아닙니다. eventId={}, status={}", 
+                    event.getId(), event.getStatus());
+            return;
+        }
+
+        // 3. 알림 메시지 생성
+        String title = event.getName();
+        String body = buildNotificationBody(event, schedule);
+
+        // 4. FCM 토픽으로 발송 (서버 부하 없이 토픽 알림 사용)
+        Map<String, Object> data = Map.of(
+                "eventId", event.getId().toString(),
+                "notificationType", "eventNotification",
+                "scheduleType", schedule.getType().name()
+        );
+        NotificationResult result = fcmNotificationSender.sendToTopic(EVENT_TOPIC, title, body, data);
+        if (result.isSuccess()) {
+            schedule.markAsSent();
+            scheduleRepository.save(schedule);
+            log.info("이벤트 알림 발송 성공: scheduleId={}, eventId={}, type={}", 
+                    schedule.getId(), event.getId(), schedule.getType());
+        } else {
+            log.error("이벤트 알림 발송 실패: scheduleId={}, error={}", schedule.getId(), result.getErrorMessage());
+        }
+    }
+
+    /**
+     * 알림 본문 생성
+     */
+    private String buildNotificationBody(Event event, EventNotificationSchedule schedule) {
+        String startTimeStr = event.getStartTime().format(TIME_FORMATTER);
+        
+        if (schedule.getType() == NotificationScheduleType.BEFORE_MINUTES) {
+            return String.format("이벤트가 %d분 후 시작됩니다. (%s)", 
+                    schedule.getMinutesBefore(), startTimeStr);
+        } else {
+            return String.format("이벤트가 시작되었습니다! (%s)", startTimeStr);
+        }
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/event/service/EventNotificationService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/service/EventNotificationService.java
@@ -6,10 +6,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombom.event.domain.Event;
 import news.bombom.event.domain.EventNotificationSchedule;
-import news.bombom.event.domain.EventStatus;
 import news.bombom.event.domain.NotificationScheduleType;
 import news.bombom.event.repository.EventNotificationScheduleRepository;
-import news.bombom.event.repository.EventRepository;
 import news.bombom.notification.client.firebase.FcmNotificationSender;
 import news.bombom.notification.domain.NotificationCategory;
 import news.bombom.notification.dto.NotificationResult;
@@ -23,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class EventNotificationService {
 
     private final EventNotificationScheduleRepository scheduleRepository;
-    private final EventRepository eventRepository;
+    private final EventService eventService;
     private final FcmNotificationSender fcmNotificationSender;
     
     private static final String EVENT_TOPIC = NotificationCategory.EVENT.getTopicName(); // "bombom_event"
@@ -31,25 +29,10 @@ public class EventNotificationService {
 
     @Transactional
     public void sendEventNotification(EventNotificationSchedule schedule) {
-        if (schedule.isSent()) {
-            log.warn("이미 발송된 알림입니다. scheduleId={}", schedule.getId());
-            return;
-        }
-
-        Event event = eventRepository.findById(schedule.getEventId())
-                .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다: " + schedule.getEventId()));
-
-        if (event.getStatus() != EventStatus.SCHEDULED) {
-            log.warn("이벤트가 예정 상태가 아닙니다. eventId={}, status={}", 
-                    event.getId(), event.getStatus());
-            return;
-        }
-
-        // 3. 알림 메시지 생성
+        Event event = eventService.getEvent(schedule.getEventId());
         String title = event.getName();
         String body = buildNotificationBody(event, schedule);
 
-        // 4. FCM 토픽으로 발송 (서버 부하 없이 토픽 알림 사용)
         Map<String, Object> data = Map.of(
                 "eventId", event.getId().toString(),
                 "notificationType", "eventNotification",
@@ -59,10 +42,10 @@ public class EventNotificationService {
         if (result.isSuccess()) {
             schedule.markAsSent();
             scheduleRepository.save(schedule);
-            log.info("이벤트 알림 발송 성공: scheduleId={}, eventId={}, type={}", 
-                    schedule.getId(), event.getId(), schedule.getType());
+            log.info("이벤트 알림 발송 성공: scheduleId={}, eventId={}, type={}", schedule.getId(), event.getId(), schedule.getType());
         } else {
             log.error("이벤트 알림 발송 실패: scheduleId={}, error={}", schedule.getId(), result.getErrorMessage());
+            // best effort: 실패해도 예외는 전파하지 않음
         }
     }
 
@@ -71,7 +54,6 @@ public class EventNotificationService {
      */
     private String buildNotificationBody(Event event, EventNotificationSchedule schedule) {
         String startTimeStr = event.getStartTime().format(TIME_FORMATTER);
-        
         if (schedule.getType() == NotificationScheduleType.BEFORE_MINUTES) {
             return String.format("이벤트가 %d분 후 시작됩니다. (%s)", 
                     schedule.getMinutesBefore(), startTimeStr);

--- a/backend/fcm-server/src/main/java/news/bombom/event/service/EventService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/service/EventService.java
@@ -1,14 +1,15 @@
 package news.bombom.event.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import news.bombom.event.domain.EventNotificationSchedule;
-import news.bombom.event.repository.EventNotificationScheduleRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.event.domain.Event;
+import news.bombom.event.domain.EventNotificationSchedule;
+import news.bombom.event.repository.EventNotificationScheduleRepository;
+import news.bombom.event.repository.EventRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
@@ -17,8 +18,15 @@ import java.util.List;
 public class EventService {
 
     private final EventNotificationScheduleRepository scheduleRepository;
+    private final EventRepository eventRepository;
 
     public List<EventNotificationSchedule> getPendingSchedules() {
         return scheduleRepository.findPendingSchedules(LocalDateTime.now());
+    }
+
+    @Transactional(readOnly = true)
+    public Event getEvent(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다: " + eventId));
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/event/service/EventService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/event/service/EventService.java
@@ -1,0 +1,24 @@
+package news.bombom.event.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.event.domain.EventNotificationSchedule;
+import news.bombom.event.repository.EventNotificationScheduleRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventService {
+
+    private final EventNotificationScheduleRepository scheduleRepository;
+
+    public List<EventNotificationSchedule> getPendingSchedules() {
+        return scheduleRepository.findPendingSchedules(LocalDateTime.now());
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/client/firebase/FcmNotificationSender.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/client/firebase/FcmNotificationSender.java
@@ -13,6 +13,8 @@ import news.bombom.notification.domain.NotificationType;
 import news.bombom.notification.dto.NotificationMessage;
 import news.bombom.notification.dto.NotificationResult;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
@@ -48,6 +50,7 @@ public class FcmNotificationSender implements NotificationSender {
     /**
      * 토픽으로 알림 전송 (FCM 특화 기능)
      */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
     public NotificationResult sendToTopic(String topic, String title, String content, Map<String, Object> data) {
         try {
             Message message = Message.builder()
@@ -55,7 +58,6 @@ public class FcmNotificationSender implements NotificationSender {
                     .setNotification(createNotification(title, content))
                     .putAllData(convertToStringMap(data))
                     .build();
-
             String response = firebaseMessaging.send(message);
             log.info("FCM 토픽 발송 성공: topic={}, response={}", topic, response);
             return NotificationResult.success(response);

--- a/backend/fcm-server/src/main/java/news/bombom/notification/client/firebase/FcmNotificationSender.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/client/firebase/FcmNotificationSender.java
@@ -59,7 +59,6 @@ public class FcmNotificationSender implements NotificationSender {
             String response = firebaseMessaging.send(message);
             log.info("FCM 토픽 발송 성공: topic={}, response={}", topic, response);
             return NotificationResult.success(response);
-
         } catch (FirebaseMessagingException e) {
             log.error("FCM 토픽 발송 실패: topic={}, error={}", topic, e.getMessage());
             return NotificationResult.failure("FCM 토픽 발송 실패: " + e.getMessage());

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
@@ -1,15 +1,19 @@
 package news.bombom.notification.domain;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+@Getter
 @RequiredArgsConstructor
 public enum NotificationCategory {
 
-    ARTICLE(true),
-    EVENT(false),
+    ARTICLE(true, false, null),           // 개별 발송
+    EVENT(false, true, "bombom_event"),   // 토픽 발송
     ;
 
     private final boolean defaultSetting;
+    private final boolean useTopic;         // FCM 토픽 사용 여부
+    private final String topicName;         // FCM 토픽 이름 (null이면 토픽 사용 안함)
 
     public boolean getDefaultSetting() {
         return defaultSetting;

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/FcmTopicService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/FcmTopicService.java
@@ -1,0 +1,62 @@
+package news.bombom.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.notification.domain.MemberFcmToken;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.repository.MemberFcmTokenRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * FCM 토픽 관리 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FcmTopicService {
+
+    private final FirebaseMessaging firebaseMessaging;
+    private final MemberFcmTokenRepository tokenRepository;
+
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void updateSubscription(Long memberId, NotificationCategory category, boolean enabled) {
+        if (!category.isUseTopic()) {
+            return;
+        }
+        
+        processTopicOperation(memberId, category, enabled);
+    }
+
+    private void processTopicOperation(Long memberId, NotificationCategory category, boolean isSubscribe) {
+        List<String> tokens = getUserTokens(memberId);
+        String operation = isSubscribe ? "구독" : "구독 해제";
+        if (tokens.isEmpty()) {
+            log.warn("토픽 {} 실패 - FCM 토큰이 없습니다. memberId={}, category={}", operation, memberId, category);
+            return;
+        }
+
+        String topic = category.getTopicName();
+        try {
+            if (isSubscribe) {
+                firebaseMessaging.subscribeToTopic(tokens, topic);
+            } else {
+                firebaseMessaging.unsubscribeFromTopic(tokens, topic);
+            }
+            log.info("토픽 {} 성공: memberId={}, category={}, topic={}, tokenCount={}", operation, memberId, category, topic, tokens.size());
+        } catch (FirebaseMessagingException e) {
+            log.error("토픽 {} 실패: memberId={}, category={}, topic={}", operation, memberId, category, topic, e);
+            // Best effort - 실패해도 예외 전파 안함
+        }
+    }
+
+    private List<String> getUserTokens(Long memberId) {
+        return tokenRepository.findByMemberId(memberId).stream()
+                .map(MemberFcmToken::getFcmToken)
+                .toList();
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/FcmTopicService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/FcmTopicService.java
@@ -23,17 +23,18 @@ public class FcmTopicService {
     private final FirebaseMessaging firebaseMessaging;
     private final MemberFcmTokenRepository tokenRepository;
 
+    /**
+     * 토큰을 미리 조회한 후 FCM 토픽 구독/해제 (트랜잭션 내에서 토큰 조회 후 호출용)
+     */
     @Transactional(propagation = Propagation.NOT_SUPPORTED)
-    public void updateSubscription(Long memberId, NotificationCategory category, boolean enabled) {
+    public void updateSubscription(Long memberId, NotificationCategory category, boolean enabled, List<String> tokens) {
         if (!category.isUseTopic()) {
             return;
         }
-        
-        processTopicOperation(memberId, category, enabled);
+        processTopicOperation(memberId, category, enabled, tokens);
     }
 
-    private void processTopicOperation(Long memberId, NotificationCategory category, boolean isSubscribe) {
-        List<String> tokens = getUserTokens(memberId);
+    private void processTopicOperation(Long memberId, NotificationCategory category, boolean isSubscribe, List<String> tokens) {
         String operation = isSubscribe ? "구독" : "구독 해제";
         if (tokens.isEmpty()) {
             log.warn("토픽 {} 실패 - FCM 토큰이 없습니다. memberId={}, category={}", operation, memberId, category);
@@ -52,11 +53,5 @@ public class FcmTopicService {
             log.error("토픽 {} 실패: memberId={}, category={}, topic={}", operation, memberId, category, topic, e);
             // Best effort - 실패해도 예외 전파 안함
         }
-    }
-
-    private List<String> getUserTokens(Long memberId) {
-        return tokenRepository.findByMemberId(memberId).stream()
-                .map(MemberFcmToken::getFcmToken)
-                .toList();
     }
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -18,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationSettingService {
 
     private final MemberNotificationSettingRepository settingRepository;
+    private final FcmTopicService fcmTopicService;
 
     @Transactional
     public List<MemberNotificationSetting> ensureMemberNotificationSetting(Long memberId) {
@@ -43,6 +44,7 @@ public class NotificationSettingService {
 
         setting.updateEnabled(enabled);
         settingRepository.save(setting);
+        fcmTopicService.updateSubscription(memberId, category, enabled);
     }
 
     @Transactional

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationSettingService.java
@@ -1,5 +1,6 @@
 package news.bombom.notification.service;
 
+
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class NotificationSettingService {
 
     private final MemberNotificationSettingRepository settingRepository;
+    private final NotificationTokenService tokenService;
     private final FcmTopicService fcmTopicService;
 
     @Transactional
@@ -41,10 +43,13 @@ public class NotificationSettingService {
     public void updateCategorySetting(Long memberId, NotificationCategory category, boolean enabled) {
         MemberNotificationSetting setting = settingRepository.findByMemberIdAndCategory(memberId, category)
                 .orElseGet(() -> createDefaultSetting(memberId, category));
-
         setting.updateEnabled(enabled);
         settingRepository.save(setting);
-        fcmTopicService.updateSubscription(memberId, category, enabled);
+
+        if (category.isUseTopic()) {
+            List<String> tokens = tokenService.getTokenStrings(memberId);
+            fcmTopicService.updateSubscription(memberId, category, enabled, tokens);
+        }
     }
 
     @Transactional
@@ -55,9 +60,12 @@ public class NotificationSettingService {
 
     @Transactional
     public NotificationCategorySettingResponse getCategorySetting(Long memberId, NotificationCategory category) {
-        MemberNotificationSetting setting = settingRepository.findByMemberIdAndCategory(memberId, category)
-                .orElseGet(() -> settingRepository.save(createDefaultSetting(memberId, category)));
-        return NotificationCategorySettingResponse.from(setting);
+        List<MemberNotificationSetting> settings = ensureMemberNotificationSetting(memberId);
+        return settings.stream()
+                .filter(setting -> setting.getCategory() == category)
+                .findFirst()
+                .map(NotificationCategorySettingResponse::from)
+                .orElseThrow(() -> new IllegalStateException("카테고리 설정이 존재해야 합니다. memberId=" + memberId + ", category=" + category));
     }
 
     public boolean isEnabled(Long memberId, NotificationCategory category) {

--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationTokenService.java
@@ -97,6 +97,15 @@ public class NotificationTokenService {
         return fcmTokens;
     }
 
+    /**
+     * 회원의 FCM 토큰 문자열 리스트 조회
+     */
+    public List<String> getTokenStrings(Long memberId) {
+        return resolveTokens(memberId).stream()
+                .map(MemberFcmToken::getFcmToken)
+                .toList();
+    }
+
     public boolean getNotificationEnabled(Long memberId, String deviceUuid) {
         MemberFcmToken memberFcmToken = fcmTokenRepository.findByMemberIdAndDeviceUuid(memberId, deviceUuid)
                 .orElseThrow(() -> {

--- a/backend/fcm-server/src/test/java/news/bombom/event/repository/EventNotificationScheduleRepositoryTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/event/repository/EventNotificationScheduleRepositoryTest.java
@@ -1,0 +1,185 @@
+package news.bombom.event.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import news.bombom.event.domain.Event;
+import news.bombom.event.domain.EventNotificationSchedule;
+import news.bombom.event.domain.EventStatus;
+import news.bombom.event.domain.NotificationScheduleType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@DisplayName("이벤트 알림 스케줄 Repository 테스트")
+class EventNotificationScheduleRepositoryTest {
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @Autowired
+    private EventNotificationScheduleRepository scheduleRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    private Event scheduledEvent;
+    private Event cancelledEvent;
+
+    @BeforeEach
+    void setUp() {
+        scheduledEvent = Event.builder()
+                .name("예정된 이벤트")
+                .startTime(LocalDateTime.of(2026, 2, 20, 14, 0))
+                .status(EventStatus.SCHEDULED)
+                .build();
+        scheduledEvent = entityManager.persistAndFlush(scheduledEvent);
+
+        cancelledEvent = Event.builder()
+                .name("취소된 이벤트")
+                .startTime(LocalDateTime.of(2026, 2, 20, 15, 0))
+                .status(EventStatus.CANCELLED)
+                .build();
+        cancelledEvent = entityManager.persistAndFlush(cancelledEvent);
+    }
+
+    @Test
+    @DisplayName("발송 대상 조회 - SCHEDULED 상태 이벤트의 미발송 알림만 조회")
+    void findPendingSchedules_OnlyScheduledEvents_ReturnsPendingSchedules() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2026, 2, 20, 13, 30);
+        
+        // 발송 대상 (SCHEDULED 이벤트, 미발송)
+        EventNotificationSchedule pending1 = EventNotificationSchedule.builder()
+                .eventId(scheduledEvent.getId())
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 13, 25))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(35)
+                .build();
+        entityManager.persistAndFlush(pending1);
+
+        EventNotificationSchedule pending2 = EventNotificationSchedule.builder()
+                .eventId(scheduledEvent.getId())
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 13, 30))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(30)
+                .build();
+        entityManager.persistAndFlush(pending2);
+
+        // 이미 발송된 알림 (제외되어야 함)
+        EventNotificationSchedule sent = EventNotificationSchedule.builder()
+                .eventId(scheduledEvent.getId())
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 13, 20))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(40)
+                .build();
+        sent.markAsSent();
+        entityManager.persistAndFlush(sent);
+
+        // 취소된 이벤트의 알림 (제외되어야 함)
+        EventNotificationSchedule cancelledEventSchedule = EventNotificationSchedule.builder()
+                .eventId(cancelledEvent.getId())
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 14, 55))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(5)
+                .build();
+        entityManager.persistAndFlush(cancelledEventSchedule);
+
+        // 미래 시각 알림 (제외되어야 함)
+        EventNotificationSchedule future = EventNotificationSchedule.builder()
+                .eventId(scheduledEvent.getId())
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 13, 35))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(25)
+                .build();
+        entityManager.persistAndFlush(future);
+
+        entityManager.clear();
+
+        // when
+        List<EventNotificationSchedule> result = scheduleRepository.findPendingSchedules(now);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).extracting(EventNotificationSchedule::getId)
+                .containsExactly(pending1.getId(), pending2.getId());
+        assertThat(result).allMatch(schedule -> !schedule.isSent());
+        assertThat(result).allMatch(schedule -> schedule.getEventId().equals(scheduledEvent.getId()));
+    }
+
+    @Test
+    @DisplayName("발송 대상 조회 - scheduledAt 기준 오름차순 정렬")
+    void findPendingSchedules_OrderedByScheduledAt() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2026, 2, 20, 13, 30);
+        
+        EventNotificationSchedule later = EventNotificationSchedule.builder()
+                .eventId(scheduledEvent.getId())
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 13, 30))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(30)
+                .build();
+        entityManager.persistAndFlush(later);
+
+        EventNotificationSchedule earlier = EventNotificationSchedule.builder()
+                .eventId(scheduledEvent.getId())
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 13, 25))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(35)
+                .build();
+        entityManager.persistAndFlush(earlier);
+
+        entityManager.clear();
+
+        // when
+        List<EventNotificationSchedule> result = scheduleRepository.findPendingSchedules(now);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).getScheduledAt()).isBefore(result.get(1).getScheduledAt());
+    }
+
+    @Test
+    @DisplayName("발송 대상 조회 - 대상이 없으면 빈 리스트 반환")
+    void findPendingSchedules_NoPending_ReturnsEmptyList() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2026, 2, 20, 13, 0);
+
+        // when
+        List<EventNotificationSchedule> result = scheduleRepository.findPendingSchedules(now);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("발송 대상 조회 - 정확히 scheduledAt 시각인 알림도 포함")
+    void findPendingSchedules_ExactTime_IncludesSchedule() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2026, 2, 20, 13, 30);
+        
+        EventNotificationSchedule exact = EventNotificationSchedule.builder()
+                .eventId(scheduledEvent.getId())
+                .scheduledAt(now)
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(30)
+                .build();
+        entityManager.persistAndFlush(exact);
+
+        entityManager.clear();
+
+        // when
+        List<EventNotificationSchedule> result = scheduleRepository.findPendingSchedules(now);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getScheduledAt()).isEqualTo(now);
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/event/service/EventNotificationServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/event/service/EventNotificationServiceTest.java
@@ -1,0 +1,257 @@
+package news.bombom.event.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import news.bombom.event.domain.Event;
+import news.bombom.event.domain.EventNotificationSchedule;
+import news.bombom.event.domain.EventStatus;
+import news.bombom.event.domain.NotificationScheduleType;
+import news.bombom.event.repository.EventNotificationScheduleRepository;
+import news.bombom.notification.client.firebase.FcmNotificationSender;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.dto.NotificationResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("이벤트 알림 서비스 테스트")
+class EventNotificationServiceTest {
+
+    private static final String EVENT_TOPIC = NotificationCategory.EVENT.getTopicName();
+    private static final Long EVENT_ID = 1L;
+    private static final Long SCHEDULE_ID = 10L;
+    private static final String EVENT_NAME = "봄봄 이벤트";
+    private static final LocalDateTime EVENT_START_TIME = LocalDateTime.of(2026, 2, 20, 14, 0);
+
+    @Mock
+    private EventNotificationScheduleRepository scheduleRepository;
+
+    @Mock
+    private EventService eventService;
+
+    @Mock
+    private FcmNotificationSender fcmNotificationSender;
+
+    @InjectMocks
+    private EventNotificationService eventNotificationService;
+
+    @Test
+    @DisplayName("이벤트 알림 발송 성공 - N분 전 알림")
+    void sendEventNotification_Success_BeforeMinutes() {
+        // given
+        Event event = createEvent(EventStatus.SCHEDULED);
+        EventNotificationSchedule schedule = createSchedule(NotificationScheduleType.BEFORE_MINUTES, 30);
+        
+        when(eventService.getEvent(EVENT_ID)).thenReturn(event);
+        when(fcmNotificationSender.sendToTopic(anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(NotificationResult.success("message-id-123"));
+        when(scheduleRepository.save(any(EventNotificationSchedule.class))).thenReturn(schedule);
+
+        // when
+        eventNotificationService.sendEventNotification(schedule);
+
+        // then
+        assertThat(schedule.isSent()).isTrue();
+        assertThat(schedule.getSentAt()).isNotNull();
+        verify(eventService, times(1)).getEvent(EVENT_ID);
+        verify(fcmNotificationSender, times(1)).sendToTopic(
+                eq(EVENT_TOPIC),
+                eq(EVENT_NAME),
+                anyString(),
+                anyMap()
+        );
+        verify(scheduleRepository, times(1)).save(schedule);
+    }
+
+    @Test
+    @DisplayName("이벤트 알림 발송 성공 - 시작 시 알림")
+    void sendEventNotification_Success_AtStart() {
+        // given
+        Event event = createEvent(EventStatus.SCHEDULED);
+        EventNotificationSchedule schedule = createSchedule(NotificationScheduleType.AT_START, null);
+        
+        when(eventService.getEvent(EVENT_ID)).thenReturn(event);
+        when(fcmNotificationSender.sendToTopic(anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(NotificationResult.success("message-id-123"));
+        when(scheduleRepository.save(any(EventNotificationSchedule.class))).thenReturn(schedule);
+
+        // when
+        eventNotificationService.sendEventNotification(schedule);
+
+        // then
+        assertThat(schedule.isSent()).isTrue();
+        verify(fcmNotificationSender, times(1)).sendToTopic(
+                eq(EVENT_TOPIC),
+                eq(EVENT_NAME),
+                anyString(),
+                anyMap()
+        );
+        verify(scheduleRepository, times(1)).save(schedule);
+    }
+
+    @Test
+    @DisplayName("이벤트를 찾을 수 없으면 예외 발생")
+    void sendEventNotification_EventNotFound_ThrowsException() {
+        // given
+        EventNotificationSchedule schedule = createSchedule(NotificationScheduleType.AT_START, null);
+        when(eventService.getEvent(EVENT_ID))
+                .thenThrow(new IllegalArgumentException("이벤트를 찾을 수 없습니다: " + EVENT_ID));
+
+        // when & then
+        assertThatThrownBy(() -> eventNotificationService.sendEventNotification(schedule))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("이벤트를 찾을 수 없습니다");
+        
+        verify(fcmNotificationSender, never()).sendToTopic(anyString(), anyString(), anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("FCM 발송 실패 시 예외를 전파하지 않음 (Best effort)")
+    void sendEventNotification_FcmFailure_DoesNotPropagate() {
+        // given
+        Event event = createEvent(EventStatus.SCHEDULED);
+        EventNotificationSchedule schedule = createSchedule(NotificationScheduleType.AT_START, null);
+        
+        when(eventService.getEvent(EVENT_ID)).thenReturn(event);
+        when(fcmNotificationSender.sendToTopic(anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(NotificationResult.failure("FCM 발송 실패"));
+
+        // when & then
+        eventNotificationService.sendEventNotification(schedule);
+
+        // then
+        assertThat(schedule.isSent()).isFalse();
+        verify(fcmNotificationSender, times(1)).sendToTopic(anyString(), anyString(), anyString(), anyMap());
+        verify(scheduleRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("알림 본문 생성 - N분 전 알림")
+    void buildNotificationBody_BeforeMinutes_ContainsMinutes() {
+        // given
+        Event event = createEvent(EventStatus.SCHEDULED);
+        EventNotificationSchedule schedule = createSchedule(NotificationScheduleType.BEFORE_MINUTES, 30);
+        
+        when(eventService.getEvent(EVENT_ID)).thenReturn(event);
+        when(fcmNotificationSender.sendToTopic(anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(NotificationResult.success("message-id"));
+
+        // when
+        eventNotificationService.sendEventNotification(schedule);
+
+        // then
+        verify(fcmNotificationSender).sendToTopic(
+                eq(EVENT_TOPIC),
+                eq(EVENT_NAME),
+                org.mockito.ArgumentMatchers.argThat(body -> 
+                        body.contains("30분 후 시작됩니다") && body.contains("2026-02-20 14:00")
+                ),
+                anyMap()
+        );
+    }
+
+    @Test
+    @DisplayName("알림 본문 생성 - 시작 시 알림")
+    void buildNotificationBody_AtStart_ContainsStartMessage() {
+        // given
+        Event event = createEvent(EventStatus.SCHEDULED);
+        EventNotificationSchedule schedule = createSchedule(NotificationScheduleType.AT_START, null);
+        
+        when(eventService.getEvent(EVENT_ID)).thenReturn(event);
+        when(fcmNotificationSender.sendToTopic(anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(NotificationResult.success("message-id"));
+
+        // when
+        eventNotificationService.sendEventNotification(schedule);
+
+        // then
+        verify(fcmNotificationSender).sendToTopic(
+                eq(EVENT_TOPIC),
+                eq(EVENT_NAME),
+                org.mockito.ArgumentMatchers.argThat(body -> 
+                        body.contains("시작되었습니다") && body.contains("2026-02-20 14:00")
+                ),
+                anyMap()
+        );
+    }
+
+    @Test
+    @DisplayName("알림 데이터에 eventId와 scheduleType 포함")
+    void sendEventNotification_DataContainsEventIdAndScheduleType() {
+        // given
+        Event event = createEvent(EventStatus.SCHEDULED);
+        EventNotificationSchedule schedule = createSchedule(NotificationScheduleType.BEFORE_MINUTES, 30);
+        
+        when(eventService.getEvent(EVENT_ID)).thenReturn(event);
+        when(fcmNotificationSender.sendToTopic(anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(NotificationResult.success("message-id"));
+
+        // when
+        eventNotificationService.sendEventNotification(schedule);
+
+        // then
+        verify(fcmNotificationSender).sendToTopic(
+                eq(EVENT_TOPIC),
+                anyString(),
+                anyString(),
+                org.mockito.ArgumentMatchers.argThat(data -> {
+                    Map<String, Object> dataMap = (Map<String, Object>) data;
+                    return dataMap.containsKey("eventId") 
+                            && dataMap.containsKey("notificationType")
+                            && dataMap.containsKey("scheduleType")
+                            && dataMap.get("eventId").equals(EVENT_ID.toString())
+                            && dataMap.get("scheduleType").equals("BEFORE_MINUTES");
+                })
+        );
+    }
+
+    private Event createEvent(EventStatus status) {
+        Event event = Event.builder()
+                .name(EVENT_NAME)
+                .startTime(EVENT_START_TIME)
+                .status(status)
+                .build();
+        // ID 설정을 위해 리플렉션 사용 (테스트용)
+        try {
+            java.lang.reflect.Field idField = Event.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(event, EVENT_ID);
+        } catch (Exception e) {
+            // 테스트용이므로 무시
+        }
+        return event;
+    }
+
+    private EventNotificationSchedule createSchedule(NotificationScheduleType type, Integer minutesBefore) {
+        EventNotificationSchedule schedule = EventNotificationSchedule.builder()
+                .eventId(EVENT_ID)
+                .scheduledAt(EVENT_START_TIME.minusMinutes(minutesBefore != null ? minutesBefore : 0))
+                .type(type)
+                .minutesBefore(minutesBefore)
+                .build();
+        // ID 설정을 위해 리플렉션 사용 (테스트용)
+        try {
+            java.lang.reflect.Field idField = EventNotificationSchedule.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(schedule, SCHEDULE_ID);
+        } catch (Exception e) {
+            // 테스트용이므로 무시
+        }
+        return schedule;
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/event/service/EventServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/event/service/EventServiceTest.java
@@ -1,0 +1,85 @@
+package news.bombom.event.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import news.bombom.event.domain.Event;
+import news.bombom.event.domain.EventNotificationSchedule;
+import news.bombom.event.domain.EventStatus;
+import news.bombom.event.domain.NotificationScheduleType;
+import news.bombom.event.repository.EventNotificationScheduleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("이벤트 서비스 테스트")
+class EventServiceTest {
+
+    @Mock
+    private EventNotificationScheduleRepository scheduleRepository;
+
+    @InjectMocks
+    private EventService eventService;
+
+    @Test
+    @DisplayName("발송 대상 알림 예약 조회 성공")
+    void getPendingSchedules_Success() {
+        // given
+        LocalDateTime now = LocalDateTime.of(2026, 2, 20, 13, 30);
+        Event event = Event.builder()
+                .name("테스트 이벤트")
+                .startTime(LocalDateTime.of(2026, 2, 20, 14, 0))
+                .status(EventStatus.SCHEDULED)
+                .build();
+        
+        EventNotificationSchedule schedule1 = EventNotificationSchedule.builder()
+                .eventId(1L)
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 13, 30))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(30)
+                .build();
+        
+        EventNotificationSchedule schedule2 = EventNotificationSchedule.builder()
+                .eventId(1L)
+                .scheduledAt(LocalDateTime.of(2026, 2, 20, 13, 25))
+                .type(NotificationScheduleType.BEFORE_MINUTES)
+                .minutesBefore(35)
+                .build();
+
+        List<EventNotificationSchedule> expectedSchedules = List.of(schedule2, schedule1);
+        when(scheduleRepository.findPendingSchedules(any(LocalDateTime.class)))
+                .thenReturn(expectedSchedules);
+
+        // when
+        List<EventNotificationSchedule> result = eventService.getPendingSchedules();
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactly(schedule2, schedule1);
+        verify(scheduleRepository, times(1)).findPendingSchedules(any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("발송 대상이 없으면 빈 리스트 반환")
+    void getPendingSchedules_Empty_ReturnsEmptyList() {
+        // given
+        when(scheduleRepository.findPendingSchedules(any(LocalDateTime.class)))
+                .thenReturn(List.of());
+
+        // when
+        List<EventNotificationSchedule> result = eventService.getPendingSchedules();
+
+        // then
+        assertThat(result).isEmpty();
+        verify(scheduleRepository, times(1)).findPendingSchedules(any(LocalDateTime.class));
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/FcmTopicServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/FcmTopicServiceTest.java
@@ -1,0 +1,93 @@
+package news.bombom.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import java.util.List;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.repository.MemberFcmTokenRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("FcmTopicService 테스트")
+class FcmTopicServiceTest {
+
+    private static final String EVENT_TOPIC_NAME = "bombom_event";
+    private static final Long MEMBER_ID = 1L;
+
+    @Mock
+    private FirebaseMessaging firebaseMessaging;
+
+    @Mock
+    private MemberFcmTokenRepository tokenRepository;
+
+    @InjectMocks
+    private FcmTopicService fcmTopicService;
+
+
+    @Test
+    @DisplayName("토큰 목록이 비어있으면 Firebase 호출을 하지 않는다")
+    void updateSubscriptionWithTokens_EmptyTokens_NoFirebaseCall() throws Exception {
+        // when
+        fcmTopicService.updateSubscription(MEMBER_ID, NotificationCategory.EVENT, true, List.of());
+
+        // then
+        verify(firebaseMessaging, never()).subscribeToTopic(anyList(), eq(EVENT_TOPIC_NAME));
+        verify(firebaseMessaging, never()).unsubscribeFromTopic(anyList(), eq(EVENT_TOPIC_NAME));
+    }
+
+    @Test
+    @DisplayName("구독 요청 시 subscribeToTopic을 호출한다")
+    void updateSubscriptionWithTokens_Subscribe_CallsSubscribe() throws Exception {
+        // given
+        List<String> tokens = List.of("token1", "token2");
+
+        // when
+        fcmTopicService.updateSubscription(MEMBER_ID, NotificationCategory.EVENT, true, tokens);
+
+        // then
+        verify(firebaseMessaging, times(1)).subscribeToTopic(tokens, EVENT_TOPIC_NAME);
+        verify(firebaseMessaging, never()).unsubscribeFromTopic(anyList(), eq(EVENT_TOPIC_NAME));
+    }
+
+    @Test
+    @DisplayName("구독 해제 요청 시 unsubscribeFromTopic을 호출한다")
+    void updateSubscriptionWithTokens_Unsubscribe_CallsUnsubscribe() throws Exception {
+        // given
+        List<String> tokens = List.of("token1", "token2");
+
+        // when
+        fcmTopicService.updateSubscription(MEMBER_ID, NotificationCategory.EVENT, false, tokens);
+
+        // then
+        verify(firebaseMessaging, times(1)).unsubscribeFromTopic(tokens, EVENT_TOPIC_NAME);
+        verify(firebaseMessaging, never()).subscribeToTopic(anyList(), eq(EVENT_TOPIC_NAME));
+    }
+
+    @Test
+    @DisplayName("Firebase 예외 발생 시 예외를 전파하지 않는다 (Best effort)")
+    void updateSubscriptionWithTokens_FirebaseException_DoesNotPropagate() throws Exception {
+        // given
+        List<String> tokens = List.of("token1");
+        when(firebaseMessaging.subscribeToTopic(tokens, EVENT_TOPIC_NAME))
+                .thenThrow(FirebaseMessagingException.class);
+
+        // when & then
+        assertThatCode(() ->
+                fcmTopicService.updateSubscription(MEMBER_ID, NotificationCategory.EVENT, true, tokens)
+        ).doesNotThrowAnyException();
+    }
+}
+

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
@@ -25,6 +25,9 @@ class NotificationSettingServiceTest {
     @Mock
     private MemberNotificationSettingRepository settingRepository;
 
+    @Mock
+    private FcmTopicService fcmTopicService;
+
     @InjectMocks
     private NotificationSettingService notificationSettingService;
 

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationSettingServiceTest.java
@@ -1,7 +1,10 @@
 package news.bombom.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -24,6 +27,9 @@ class NotificationSettingServiceTest {
 
     @Mock
     private MemberNotificationSettingRepository settingRepository;
+
+    @Mock
+    private NotificationTokenService tokenService;
 
     @Mock
     private FcmTopicService fcmTopicService;
@@ -60,6 +66,27 @@ class NotificationSettingServiceTest {
         // Then
         assertThat(setting.isEnabled()).isFalse();
         verify(settingRepository).save(setting);
+        // ARTICLE은 useTopic=false이므로 토큰 조회 및 FCM 호출 안 함
+    }
+
+    @Test
+    @DisplayName("카테고리 설정 업데이트 - 토픽 사용 카테고리인 경우 FCM 호출")
+    void updateCategorySetting_WithTopic_CallsFcmService() {
+        // Given
+        MemberNotificationSetting setting = createSetting(NotificationCategory.EVENT, false);
+        when(settingRepository.findByMemberIdAndCategory(TEST_MEMBER_ID, NotificationCategory.EVENT))
+                .thenReturn(Optional.of(setting));
+        
+        when(tokenService.getTokenStrings(TEST_MEMBER_ID)).thenReturn(List.of("fcm-token-1", "fcm-token-2"));
+
+        // When
+        notificationSettingService.updateCategorySetting(TEST_MEMBER_ID, NotificationCategory.EVENT, true);
+
+        // Then
+        assertThat(setting.isEnabled()).isTrue();
+        verify(settingRepository).save(setting);
+        verify(tokenService).getTokenStrings(TEST_MEMBER_ID);
+        verify(fcmTopicService).updateSubscription(anyLong(), any(NotificationCategory.class), anyBoolean(), anyList());
     }
 
     @Test
@@ -92,6 +119,25 @@ class NotificationSettingServiceTest {
 
         // Then
         assertThat(result).isEqualTo(NotificationCategory.EVENT.getDefaultSetting());
+    }
+
+    @Test
+    @DisplayName("단일 카테고리 설정 조회 - ensureMemberNotificationSetting 사용하여 일관성 유지")
+    void getCategorySetting_UsesEnsureMemberNotificationSetting() {
+        // Given
+        List<MemberNotificationSetting> settings = List.of(
+                createSetting(NotificationCategory.ARTICLE, true),
+                createSetting(NotificationCategory.EVENT, false));
+        when(settingRepository.findAllByMemberId(TEST_MEMBER_ID)).thenReturn(settings);
+
+        // When
+        NotificationCategorySettingResponse result = notificationSettingService
+                .getCategorySetting(TEST_MEMBER_ID, NotificationCategory.ARTICLE);
+
+        // Then
+        assertThat(result.category()).isEqualTo(NotificationCategory.ARTICLE);
+        assertThat(result.enabled()).isTrue();
+        verify(settingRepository, times(1)).findAllByMemberId(TEST_MEMBER_ID);
     }
 
     private MemberNotificationSetting createSetting(NotificationCategory category, boolean isEnabled) {

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationTokenServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationTokenServiceTest.java
@@ -158,6 +158,34 @@ class NotificationTokenServiceTest {
         verify(fcmTokenRepository, times(1)).findByMemberId(TEST_MEMBER_ID);
     }
 
+    @Test
+    @DisplayName("getTokenStrings - 토큰 문자열 리스트 반환")
+    void getTokenStrings_ReturnsTokenStrings() {
+        // Given
+        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID)).thenReturn(List.of(createTestToken()));
+
+        // When
+        List<String> result = notificationTokenService.getTokenStrings(TEST_MEMBER_ID);
+
+        // Then
+        assertThat(result).containsExactly(TEST_FCM_TOKEN);
+        verify(fcmTokenRepository, times(1)).findByMemberId(TEST_MEMBER_ID);
+    }
+
+    @Test
+    @DisplayName("getTokenStrings - 토큰 없으면 빈 리스트 반환")
+    void getTokenStrings_NoTokens_ReturnsEmptyList() {
+        // Given
+        when(fcmTokenRepository.findByMemberId(TEST_MEMBER_ID)).thenReturn(List.of());
+
+        // When
+        List<String> result = notificationTokenService.getTokenStrings(TEST_MEMBER_ID);
+
+        // Then
+        assertThat(result).isEmpty();
+        verify(fcmTokenRepository, times(1)).findByMemberId(TEST_MEMBER_ID);
+    }
+
     private MemberFcmToken createTestToken() {
         return MemberFcmToken.builder()
                 .id(1L)


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 이벤트 알림 자동 발송 기능을 추가했습니다.
- `event`, `event_notification_schedule` 테이블을 기반으로, N분 전 / 시작 시 FCM 토픽 알림을 자동으로 보내는 로직과 테스트를 구현했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 기존에는 “이벤트” 개념과 예약 알림 구조가 없어, 어드민에서 이벤트 관리/예약 알림 기능을 만들기 어렵고 알림 시점을 자동화하기도 힘든 상태였습니다.
- 이벤트 정보를 테이블에 저장하고, 알림 스케줄을 별도 테이블로 관리하면 어드민 서버에서 이벤트/알림을 한 번에 정의하고 fcm-server가 자체 스케줄러로 안정적으로 푸시를 발송할 수 있어 운영/확장이 쉬운 구조가 됩니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 테이블 추가
  - `event`, `event_notification_schedule` 두 테이블 생성 (이벤트 정보 + 알림 예약 정보 저장).
- 도메인/리포지토리 구현
  - `Event`, `EventNotificationSchedule` 엔티티 및 enum(`EventStatus`, `NotificationScheduleType`) 추가.
  - `EventNotificationScheduleRepository`에 `findPendingSchedules(now)` 쿼리 구현.
- 서비스/스케줄러 로직
  - `EventService`에서 발송 대상 예약 조회 + 이벤트 단건 조회.
  - `EventNotificationService`에서 이벤트 상세 기반으로 알림 제목/본문 생성 후, FCM 토픽(`bombom_event`)으로 발송하고 성공 시 sent=true 업데이트.
  - `EventNotificationScheduler`가 1분 주기로 실행되며, 발송 대상 예약들을 순회하면서 `sendEventNotification` 호출.
- 테스트 작성
  - 서비스/리포지토리/스케줄 동작을 단위/통합 테스트로 검증해 발송 대상 필터링, 메시지 내용, sent 플래그 업데이트까지 확인.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->