### PR TITLE
[BOM-959] hotfix: 명시적인 save 추가

### DIFF
--- a/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationStatusService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/service/NotificationStatusService.java
@@ -23,6 +23,7 @@ public class NotificationStatusService {
     public void updateStatus(ArticleArrivalNotification notification, NotificationResultResponse result) {
         if (result.successCount() > 0) {
             notification.markSent();
+            notificationRepository.save(notification);
             log.info("알림 발송 완료: notificationId={}, 성공={}, 실패={}, 스킵={}",
                     notification.getId(), result.successCount(), result.failCount(), result.skippedCount());
             return;
@@ -30,12 +31,14 @@ public class NotificationStatusService {
         if (result.skippedCount() == result.totalDevices()) {
             // 모든 기기가 알림 설정이 꺼져있으면 SENT로 처리 (정상적인 상황)
             notification.markSent();
+            notificationRepository.save(notification);
             log.info("모든 기기에서 알림 설정이 꺼져있음: notificationId={}, 스킵={}",
                     notification.getId(), result.skippedCount());
             return;
         }
         // 모든 기기에서 실패하면 FAILED로 처리
         notification.markFailed(result.errorMessages());
+        notificationRepository.save(notification);
         log.error("모든 기기에서 알림 발송 실패: notificationId={}", notification.getId());
 
         moveToFailedTableIfExceeded(notification);


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
아티클 알림 발송 성공 후에도 `article_arrival_notification` 상태가 `PENDING`으로 남는 문제를 해결함.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- FCM 발송까지는 되지만 DB의 status가 SENT로 바뀌지 않아 발송 이력 추적과 재시도/모니터링에 어려움이 있었음
- 디바이스에는 알림이 도착하는데 DB는 PENDING이라, 실제 발송 결과와 저장된 상태가 불일치함

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
`NotificationStatusService.updateStatus()`에서 상태를 변경한 뒤 `notificationRepository.save(notification)`를 호출하도록 수정함.
원인: 스케줄러 `findRetryCandidates` 트랜잭션과 `processArticleArrivedNotification` 트랜잭션이 분리되어 있어, 넘어온 엔티티가 `detached` 상태였음
`detached` 엔티티에 `markSent()` / `markFailed()`만 호출하면 `dirty checking` 대상이 아니어서 DB에 반영되지 않음
`save()`로 `merge`를 수행해 영속성 컨텍스트에 넣고, flush 시점에 UPDATE가 실행되도록 함
변경 사항:
- successCount > 0 → `SENT` 처리 후 `save()` 호출
- 전체 스킵 시 `SENT` 처리 후 `save()` 호출
- 전체 실패 시 `FAILED` 처리 후 `save()` 호출

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
