### PR TITLE
[BOM-971] feat: 챌린지 추가 신청

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
@@ -74,21 +74,24 @@ public class Challenge extends BaseEntity {
         if (now.isBefore(this.startDate)) {
             return ChallengeStatus.BEFORE_START;
         }
-        if (now.isAfter(this.endDate)) {
+        if (this.endDate != null && now.isAfter(this.endDate)) {
             return ChallengeStatus.COMPLETED;
         }
         return ChallengeStatus.ONGOING;
     }
 
     public boolean isEnded(LocalDate now) {
-        return now.isAfter(this.endDate);
+        return this.endDate != null && now.isAfter(this.endDate);
     }
 
     public boolean hasStarted(LocalDate now) {
-        return !now.isBefore(this.startDate);
+        return this.startDate != null && !now.isBefore(this.startDate);
     }
 
     public int calculatePassedDays(LocalDate targetDate) {
+        if (this.startDate == null) {
+            return 0;
+        }
         int passedDays = 0;
         LocalDate currentDate = this.startDate;
         while (!currentDate.isAfter(targetDate)) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -51,8 +51,8 @@ public class ChallengeService {
 
     // TODO: 이후에 수료 처리 등 구현 시 관리 방법 고려
     private static final double SUCCESS_REQUIRED_RATIO = 0.8;
-    private static final int MIN_CHALLENGE_TOTAL_DAYS_FOR_BADGE = 15;
     private static final double ADDITIONAL_APPLICATION_ALLOWED_RATIO = 0.2;
+    private static final int MIN_CHALLENGE_TOTAL_DAYS_FOR_BADGE = 15;
 
     private final ChallengeRepository challengeRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -52,6 +52,7 @@ public class ChallengeService {
     // TODO: 이후에 수료 처리 등 구현 시 관리 방법 고려
     private static final double SUCCESS_REQUIRED_RATIO = 0.8;
     private static final int MIN_CHALLENGE_TOTAL_DAYS_FOR_BADGE = 15;
+    private static final double ADDITIONAL_APPLICATION_ALLOWED_RATIO = 0.2;
 
     private final ChallengeRepository challengeRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
@@ -302,8 +303,14 @@ public class ChallengeService {
     }
 
     private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
-        if (challenge.hasStarted(LocalDate.now())) {
-            return EligibilityReason.ALREADY_STARTED;
+        LocalDate today = LocalDate.now();
+
+        if (challenge.hasStarted(today)) {
+            int passedDays = challenge.calculatePassedDays(today);
+            int maxPassedDaysForApplication = (int) (challenge.getTotalDays() * ADDITIONAL_APPLICATION_ALLOWED_RATIO);
+            if (passedDays > maxPassedDaysForApplication) {
+                return EligibilityReason.ALREADY_STARTED;
+            }
         }
 
         boolean alreadyApplied = challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.mapping;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -59,6 +60,7 @@ public class ChallengeService {
     private final NewsletterGroupItemRepository newsletterGroupItemRepository;
     private final ChallengeTeamRepository challengeTeamRepository;
     private final BadgeService badgeService;
+    private final Clock clock;
 
     public List<ChallengeResponse> getChallenges(Member member) {
         List<Challenge> challenges = challengeRepository.findAll();
@@ -76,7 +78,7 @@ public class ChallengeService {
 
         return challenges.stream()
                 .filter(challenge -> {
-                    ChallengeStatus status = challenge.getStatus(LocalDate.now());
+                    ChallengeStatus status = challenge.getStatus(LocalDate.now(clock));
                     boolean isJoined = myParticipation.containsKey(challenge.getId());
                     return status == ChallengeStatus.COMING_SOON || status == ChallengeStatus.BEFORE_START || isJoined;
                 })
@@ -160,7 +162,7 @@ public class ChallengeService {
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                         .addContext(ErrorContextKeys.OPERATION, "cancelChallenge"));
 
-        if (challenge.hasStarted(LocalDate.now())) {
+        if (challenge.hasStarted(LocalDate.now(clock))) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                     .addContext(ErrorContextKeys.OPERATION, "cancelChallenge")
@@ -228,7 +230,7 @@ public class ChallengeService {
                 challenge.getId(),
                 Collections.emptyList()
         );
-        ChallengeStatus status = challenge.getStatus(LocalDate.now());
+        ChallengeStatus status = challenge.getStatus(LocalDate.now(clock));
         ChallengeParticipant myParticipant = myParticipation.get(challenge.getId());
         ChallengeDetailResponse detailResponse = calculateDetailResponse(challenge, myParticipant);
 
@@ -268,7 +270,7 @@ public class ChallengeService {
             return ChallengeDetailResponse.notJoined();
         }
 
-        boolean isEnded = challenge.isEnded(LocalDate.now());
+        boolean isEnded = challenge.isEnded(LocalDate.now(clock));
         boolean isSurvived = myParticipant.isSurvived();
         int progress = myParticipant.calculateProgress(challenge.getTotalDays());
 
@@ -303,7 +305,7 @@ public class ChallengeService {
     }
 
     private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(clock);
 
         if (challenge.hasStarted(today)) {
             int passedDays = challenge.calculatePassedDays(today);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -514,6 +514,66 @@ class ChallengeServiceTest {
     }
 
     @Test
+    void 추가_신청_기간_내_시작된_챌린지_신청_가능_여부_조회() {
+        // given: 시작일이 오늘, totalDays 21일 → 허용 영업일 3일. 오늘은 1영업일차 이내이므로 신청 가능
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        Challenge challenge = TestFixture.createChallenge(
+                "챌린지",
+                today,
+                today.plusDays(30),
+                21,
+                group.getId()
+        );
+        challengeRepository.save(challenge);
+
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(challenge.getNewsletterGroupId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+
+        Subscribe subscribe = TestFixture.createSubscribe(newsletters.get(0), member);
+        subscribeRepository.save(subscribe);
+
+        // when
+        ChallengeEligibilityResponse response = challengeService.checkEligibility(challenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.canApply()).isTrue();
+            softly.assertThat(response.reason()).isEqualTo(EligibilityReason.ELIGIBLE);
+        });
+    }
+
+    @Test
+    void 추가_신청_기간_지난_챌린지_신청_가능_여부_조회() {
+        // given: 시작일이 10일 전, totalDays 21일 → 허용 영업일 3일. 이미 지나서 신청 불가
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        Challenge challenge = TestFixture.createChallenge(
+                "챌린지",
+                today.minusDays(10),
+                today.plusDays(20),
+                21,
+                group.getId()
+        );
+        challengeRepository.save(challenge);
+
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(challenge.getNewsletterGroupId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+
+        Subscribe subscribe = TestFixture.createSubscribe(newsletters.get(0), member);
+        subscribeRepository.save(subscribe);
+
+        // when
+        ChallengeEligibilityResponse response = challengeService.checkEligibility(challenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.canApply()).isFalse();
+            softly.assertThat(response.reason()).isEqualTo(EligibilityReason.ALREADY_STARTED);
+        });
+    }
+
+    @Test
     void 존재하지_않는_챌린지_ID로_신청_가능_여부_조회_시_예외가_발생한다() {
         // when & then
         assertThatThrownBy(() -> challengeService.checkEligibility(0L, member))


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 시작일 이후에는 신청이 불가했던 것을, 추가 신청 기간(주말 제외 기간의 20%) 동안에는 신청할 수 있도록 변경했습니다.
-> 뉴스레터 한달읽기 챌린지 2기의 경우에는 시작일이 2/19 지만, 추가 신청은 2/24 까지 가능 

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
이벤트 시기와 겹치는 기간을 늘려서 챌린지에 많은 지원을 할 수 있도록 하기 위해서 추가하였습니다.
추후에도 시작 이후에 신청하고 싶은 사용자를 위해 코드로 남겨두었습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 챌린지 시작 여부 판단 후, 이미 시작된 경우는 **지난 평일 수**를 구하고, 해당 기간의 20% 이하가 지났을 때만 신청 가능하도록 했습니다.
- 20%로 한 이유는 이벤트 기간과 겹치는 기한이기도 하고, 챌린지 탈락 조건이 80% 이하 작성이기 때문입니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 이번 PR에는 팀 자동 배정이 포함되지 않아, 추가 신청에 대해서도 어드민 서버에서 수동 배정이 필요합니다.