### PR TITLE
[BOM-956] feat: 챌린지 시작 날 알림 전송

### DIFF
--- a/backend/fcm-server/src/main/java/news/bombom/challenge/domain/ChallengeStartNotification.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/domain/ChallengeStartNotification.java
@@ -1,0 +1,54 @@
+package news.bombom.challenge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombom.notification.domain.Notification;
+import news.bombom.notification.domain.NotificationStatus;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChallengeStartNotification extends Notification {
+
+    private static final int MAX_RETRY_ATTEMPTS = 4;
+
+    @Column(nullable = false)
+    private Long challengeId;
+
+    @Column(nullable = false)
+    private String challengeName;
+
+    @Builder
+    public ChallengeStartNotification(
+            Long id,
+            @NonNull Long memberId,
+            @NonNull Long challengeId,
+            @NonNull String challengeName,
+            NotificationStatus status,
+            int attempts,
+            LocalDateTime nextRetryAt,
+            String lastError
+    ) {
+        super(memberId, status, attempts, nextRetryAt, lastError);
+        this.id = id;
+        this.challengeId = challengeId;
+        this.challengeName = challengeName;
+    }
+
+    @Override
+    public boolean shouldRetry() {
+        return this.attempts < MAX_RETRY_ATTEMPTS;
+    }
+
+    @Override
+    public LocalDateTime calculateNextRetryTime(int attempts) {
+        long delaySeconds = 30L * (long) Math.pow(2, Math.max(0, attempts - 1));
+        return LocalDateTime.now().plusSeconds(delaySeconds);
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/challenge/repository/ChallengeStartNotificationRepository.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/repository/ChallengeStartNotificationRepository.java
@@ -1,0 +1,21 @@
+package news.bombom.challenge.repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import news.bombom.challenge.domain.ChallengeStartNotification;
+import news.bombom.notification.domain.NotificationStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChallengeStartNotificationRepository extends JpaRepository<ChallengeStartNotification, Long> {
+
+    @Query("""
+                    SELECT n
+                    FROM ChallengeStartNotification n
+                    WHERE n.status IN :statuses
+                    AND (n.nextRetryAt IS NULL OR n.nextRetryAt <= :now)
+            """)
+    List<ChallengeStartNotification> findRetryCandidates(@Param("statuses") List<NotificationStatus> statuses,
+                                                          @Param("now") LocalDateTime now);
+}

--- a/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeStartMessageBuilder.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeStartMessageBuilder.java
@@ -1,0 +1,36 @@
+package news.bombom.challenge.service;
+
+import java.util.Map;
+import news.bombom.challenge.domain.ChallengeStartNotification;
+import news.bombom.notification.domain.MemberFcmToken;
+import news.bombom.notification.domain.Notification;
+import news.bombom.notification.domain.NotificationPayloadType;
+import news.bombom.notification.domain.NotificationType;
+import news.bombom.notification.dto.NotificationMessage;
+import news.bombom.notification.service.NotificationMessageBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChallengeStartMessageBuilder implements NotificationMessageBuilder {
+
+    @Override
+    public boolean supports(Notification notification) {
+        return notification instanceof ChallengeStartNotification;
+    }
+
+    @Override
+    public NotificationMessage build(Notification notification, MemberFcmToken token) {
+        ChallengeStartNotification startNotification = (ChallengeStartNotification) notification;
+
+        return NotificationMessage.builder()
+                .recipient(token.getFcmToken())
+                .title(startNotification.getChallengeName() + " 챌린지가 시작됐어요!")
+                .content("오늘부터 챌린지를 시작해 볼까요? ✅")
+                .type(NotificationType.FCM)
+                .data(Map.of(
+                        "challengeId", String.valueOf(startNotification.getChallengeId()),
+                        "notificationType", NotificationPayloadType.CHALLENGE_START
+                ))
+                .build();
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeStartMessageBuilder.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeStartMessageBuilder.java
@@ -21,11 +21,13 @@ public class ChallengeStartMessageBuilder implements NotificationMessageBuilder 
     @Override
     public NotificationMessage build(Notification notification, MemberFcmToken token) {
         ChallengeStartNotification startNotification = (ChallengeStartNotification) notification;
+        String title = startNotification.getChallengeName() + " 오늘부터 시작!";
+        String content = "1일차가 열렸어요 ✅ 오늘 미션부터 가볍게 출발해요!";
 
         return NotificationMessage.builder()
                 .recipient(token.getFcmToken())
-                .title(startNotification.getChallengeName() + " 챌린지가 시작됐어요!")
-                .content("오늘부터 챌린지를 시작해 볼까요? ✅")
+                .title(title)
+                .content(content)
                 .type(NotificationType.FCM)
                 .data(Map.of(
                         "challengeId", String.valueOf(startNotification.getChallengeId()),

--- a/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeStartNotificationProcessor.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeStartNotificationProcessor.java
@@ -1,0 +1,57 @@
+package news.bombom.challenge.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.challenge.domain.ChallengeStartNotification;
+import news.bombom.challenge.repository.ChallengeStartNotificationRepository;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.domain.NotificationStatus;
+import news.bombom.notification.scheduler.NotificationProcessor;
+import news.bombom.notification.service.NotificationProcessingService;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChallengeStartNotificationProcessor implements NotificationProcessor {
+
+    private final ChallengeStartNotificationRepository notificationRepository;
+    private final NotificationProcessingService notificationProcessingService;
+    private final ChallengeStartNotificationStatusService challengeStatusService;
+
+    @Override
+    public String type() {
+        return NotificationCategory.CHALLENGE_START.name();
+    }
+
+    @Override
+    public void processPendingNotifications(LocalDateTime now) {
+        List<ChallengeStartNotification> pendingNotifications =
+                notificationRepository.findRetryCandidates(
+                        List.of(NotificationStatus.PENDING, NotificationStatus.FAILED),
+                        now
+                );
+
+        log.info("[{}] 처리할 알림 개수: {}", type(), pendingNotifications.size());
+
+        for (ChallengeStartNotification notification : pendingNotifications) {
+            try {
+                if (!notification.shouldRetry()) {
+                    log.warn("[{}] 최대 재시도 횟수 초과로 처리 중단: notificationId={}, attempts={}",
+                            type(), notification.getId(), notification.getAttempts());
+                    continue;
+                }
+
+                notificationProcessingService.processNotification(
+                        notification,
+                        NotificationCategory.CHALLENGE_START,
+                        challengeStatusService
+                );
+            } catch (Exception e) {
+                log.error("[{}] 알림 처리 중 오류 발생: notificationId={}", type(), notification.getId(), e);
+            }
+        }
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeStartNotificationStatusService.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeStartNotificationStatusService.java
@@ -1,0 +1,51 @@
+package news.bombom.challenge.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombom.challenge.domain.ChallengeStartNotification;
+import news.bombom.challenge.repository.ChallengeStartNotificationRepository;
+import news.bombom.notification.dto.response.NotificationResultResponse;
+import news.bombom.notification.service.NotificationStatusHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeStartNotificationStatusService
+        implements NotificationStatusHandler<ChallengeStartNotification> {
+
+    private final ChallengeStartNotificationRepository notificationRepository;
+
+    @Override
+    @Transactional
+    public void updateStatus(ChallengeStartNotification notification, NotificationResultResponse result) {
+        if (result.successCount() > 0) {
+            notification.markSent();
+            notificationRepository.save(notification);
+            log.info("챌린지 시작 알림 발송 완료: notificationId={}, 성공={}, 실패={}, 스킵={}",
+                    notification.getId(), result.successCount(), result.failCount(), result.skippedCount());
+            return;
+        }
+        if (result.skippedCount() == result.totalDevices()) {
+            notification.markSent();
+            notificationRepository.save(notification);
+            log.info("챌린지 시작 알림 모든 기기 스킵: notificationId={}, 스킵={}",
+                    notification.getId(), result.skippedCount());
+            return;
+        }
+
+        notification.markFailed(result.errorMessages());
+        notificationRepository.save(notification);
+        log.error("챌린지 시작 알림 모든 기기 발송 실패: notificationId={}", notification.getId());
+    }
+
+    @Override
+    @Transactional
+    public void markAsFailed(ChallengeStartNotification notification, String reason) {
+        log.warn("챌린지 시작 알림 FCM 토큰이 없습니다: memberId={}", notification.getMemberId());
+        notification.markFailed(reason);
+        notificationRepository.save(notification);
+    }
+}

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationCategory.java
@@ -13,6 +13,7 @@ public enum NotificationCategory {
     ARTICLE(true, false, null),
     EVENT(false, true, "bombom_event"),
     CHALLENGE_TODO_REMINDER(true, false, null),
+    CHALLENGE_START(true, false, null),
     ;
 
     private final boolean defaultSetting;

--- a/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationPayloadType.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/domain/NotificationPayloadType.java
@@ -10,5 +10,6 @@ public enum NotificationPayloadType {
 
     ARTICLE,
     EVENT,
+    CHALLENGE_START,
     DEFAULT
 }

--- a/backend/fcm-server/src/main/java/news/bombom/notification/scheduler/NotificationScheduler.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/scheduler/NotificationScheduler.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombom.article.service.ArticleArrivalNotificationProcessor;
+import news.bombom.challenge.service.ChallengeStartNotificationProcessor;
 import news.bombom.challenge.service.ChallengeTodoReminderNotificationProcessor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ public class NotificationScheduler {
 
     private final ArticleArrivalNotificationProcessor articleProcessor;
     private final ChallengeTodoReminderNotificationProcessor challengeProcessor;
+    private final ChallengeStartNotificationProcessor challengeStartProcessor;
 
     @Scheduled(fixedDelay = 30000)
     public void processPendingNotifications() {
@@ -37,6 +39,18 @@ public class NotificationScheduler {
             challengeProcessor.processPendingNotifications(now);
         } catch (Exception e) {
             log.error("Processor 실행 중 오류 발생: type={}", challengeProcessor.type(), e);
+        }
+    }
+
+    @Scheduled(cron = "0 0 8 * * *", zone = "Asia/Seoul")
+    public void processChallengeStartNotifications() {
+        LocalDateTime now = LocalDateTime.now();
+        log.info("챌린지 시작 알림 Processor 실행");
+
+        try {
+            challengeStartProcessor.processPendingNotifications(now);
+        } catch (Exception e) {
+            log.error("Processor 실행 중 오류 발생: type={}", challengeStartProcessor.type(), e);
         }
     }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/notification/scheduler/NotificationSchedulerTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/scheduler/NotificationSchedulerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import news.bombom.article.service.ArticleArrivalNotificationProcessor;
+import news.bombom.challenge.service.ChallengeStartNotificationProcessor;
 import news.bombom.challenge.service.ChallengeTodoReminderNotificationProcessor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,9 @@ class NotificationSchedulerTest {
     @Mock
     private ChallengeTodoReminderNotificationProcessor challengeProcessor;
 
+    @Mock
+    private ChallengeStartNotificationProcessor challengeStartProcessor;
+
     @InjectMocks
     private NotificationScheduler notificationScheduler;
 
@@ -39,5 +43,13 @@ class NotificationSchedulerTest {
         notificationScheduler.processChallengeTodoReminderNotifications();
 
         verify(challengeProcessor, times(1)).processPendingNotifications(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("챌린지 시작 알림 스케줄이 챌린지 시작 Processor를 호출한다")
+    void processChallengeStartNotifications_DelegatesToChallengeStartProcessor() {
+        notificationScheduler.processChallengeStartNotifications();
+
+        verify(challengeStartProcessor, times(1)).processPendingNotifications(org.mockito.ArgumentMatchers.any());
     }
 }

--- a/backend/fcm-server/src/test/java/news/bombom/notification/scheduler/processor/ChallengeStartNotificationProcessorTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/scheduler/processor/ChallengeStartNotificationProcessorTest.java
@@ -1,0 +1,91 @@
+package news.bombom.notification.scheduler.processor;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import news.bombom.challenge.domain.ChallengeStartNotification;
+import news.bombom.challenge.repository.ChallengeStartNotificationRepository;
+import news.bombom.challenge.service.ChallengeStartNotificationProcessor;
+import news.bombom.challenge.service.ChallengeStartNotificationStatusService;
+import news.bombom.notification.domain.NotificationCategory;
+import news.bombom.notification.domain.NotificationStatus;
+import news.bombom.notification.service.NotificationProcessingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("챌린지 시작 알림 Processor 테스트")
+class ChallengeStartNotificationProcessorTest {
+
+    @Mock
+    private ChallengeStartNotificationRepository notificationRepository;
+
+    @Mock
+    private NotificationProcessingService notificationProcessingService;
+
+    @Mock
+    private ChallengeStartNotificationStatusService challengeStatusService;
+
+    @InjectMocks
+    private ChallengeStartNotificationProcessor processor;
+
+    @Test
+    @DisplayName("호출 시점의 대기 알림을 조회하고 처리한다")
+    void processPendingNotifications_ProcessesNotifications() {
+        LocalDateTime now = LocalDateTime.of(2026, 2, 16, 8, 0);
+        ChallengeStartNotification notification = createNotification();
+
+        when(notificationRepository.findRetryCandidates(anyList(), any()))
+                .thenReturn(List.of(notification));
+
+        processor.processPendingNotifications(now);
+
+        verify(notificationRepository, times(1))
+                .findRetryCandidates(List.of(NotificationStatus.PENDING, NotificationStatus.FAILED), now);
+        verify(notificationProcessingService, times(1)).processNotification(
+                notification,
+                NotificationCategory.CHALLENGE_START,
+                challengeStatusService
+        );
+    }
+
+    @Test
+    @DisplayName("최대 재시도 횟수 초과 알림은 건너뛴다")
+    void processPendingNotifications_ExceededRetry_SkipsProcessing() {
+        LocalDateTime now = LocalDateTime.of(2026, 2, 16, 8, 0);
+
+        ChallengeStartNotification exceeded = ChallengeStartNotification.builder()
+                .memberId(1L)
+                .challengeId(99L)
+                .challengeName("챌린지")
+                .status(NotificationStatus.FAILED)
+                .attempts(4)
+                .build();
+
+        when(notificationRepository.findRetryCandidates(anyList(), any()))
+                .thenReturn(Collections.singletonList(exceeded));
+
+        processor.processPendingNotifications(now);
+
+        verify(notificationProcessingService, never()).processNotification(any(), any(), any());
+    }
+
+    private ChallengeStartNotification createNotification() {
+        return ChallengeStartNotification.builder()
+                .memberId(1L)
+                .challengeId(99L)
+                .challengeName("챌린지")
+                .build();
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationProcessingServiceTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/service/NotificationProcessingServiceTest.java
@@ -14,6 +14,8 @@ import java.util.Collections;
 import java.util.List;
 import news.bombom.article.domain.ArticleArrivalNotification;
 import news.bombom.article.service.ArticleArrivalNotificationStatusService;
+import news.bombom.challenge.domain.ChallengeStartNotification;
+import news.bombom.challenge.service.ChallengeStartNotificationStatusService;
 import news.bombom.challenge.domain.ChallengeTodoReminderNotification;
 import news.bombom.challenge.service.ChallengeTodoReminderNotificationStatusService;
 import news.bombom.notification.domain.MemberFcmToken;
@@ -41,6 +43,9 @@ class NotificationProcessingServiceTest {
 
     @Mock
     private ChallengeTodoReminderNotificationStatusService challengeStatusService;
+
+    @Mock
+    private ChallengeStartNotificationStatusService challengeStartStatusService;
 
     @Mock
     private NotificationSettingService notificationSettingService;
@@ -232,6 +237,37 @@ class NotificationProcessingServiceTest {
         verify(notificationSender, never()).sendToAllDevices(any(), anyList());
     }
 
+    @Test
+    @DisplayName("챌린지 시작 알림 설정이 활성화되어 있고 토큰이 있으면 전송한다")
+    void processNotification_ChallengeStart_SettingsEnabledAndTokensExist_SendsNotification() {
+        ChallengeStartNotification notification = createChallengeStartNotification();
+        List<MemberFcmToken> tokens = List.of(MemberFcmToken.builder()
+                .memberId(TEST_MEMBER_ID)
+                .deviceUuid("test-device")
+                .fcmToken("test-token")
+                .isNotificationEnabled(true)
+                .build());
+
+        when(notificationSettingService.isEnabled(TEST_MEMBER_ID, NotificationCategory.CHALLENGE_START))
+                .thenReturn(true);
+        when(notificationTokenService.resolveTokens(TEST_MEMBER_ID))
+                .thenReturn(tokens);
+        when(notificationSender.sendToAllDevices(eq(notification), anyList()))
+                .thenReturn(new NotificationResultResponse(1, 0, 0, ""));
+
+        notificationProcessingService.processNotification(
+                notification,
+                NotificationCategory.CHALLENGE_START,
+                challengeStartStatusService
+        );
+
+        verify(notificationSettingService, times(1))
+                .isEnabled(TEST_MEMBER_ID, NotificationCategory.CHALLENGE_START);
+        verify(notificationTokenService, times(1)).resolveTokens(TEST_MEMBER_ID);
+        verify(notificationSender, times(1)).sendToAllDevices(eq(notification), anyList());
+        verify(challengeStartStatusService, times(1)).updateStatus(eq(notification), any());
+    }
+
     private ArticleArrivalNotification createNotification() {
         return ArticleArrivalNotification.builder()
                 .memberId(TEST_MEMBER_ID)
@@ -247,6 +283,14 @@ class NotificationProcessingServiceTest {
                 .challengeName("테스트 챌린지")
                 .title("리마인더")
                 .content("할 일을 완료해 주세요")
+                .build();
+    }
+
+    private ChallengeStartNotification createChallengeStartNotification() {
+        return ChallengeStartNotification.builder()
+                .memberId(TEST_MEMBER_ID)
+                .challengeId(100L)
+                .challengeName("시작 챌린지")
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 챌린지 시작 날 오전 8시 알림을 전송합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 챌린지 시작을 알리고 참여자들의 시작을 도모하기 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
**추후에 구조 개편과 함께 설명 문서화 첨부하겠습니다!**

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
