### PR TITLE
[BOM-968] feat: 챌린지 시작 날짜에 알림 저장 스케줄러 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeStartNotificationStatus.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeStartNotificationStatus.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.challenge.domain;
+
+public enum ChallengeStartNotificationStatus {
+    PENDING,
+    SENT,
+    FAILED
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/notification/ChallengeStartNotification.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/notification/ChallengeStartNotification.java
@@ -28,8 +28,8 @@ public class ChallengeStartNotification extends BaseEntity {
     @Column(nullable = false)
     private Long memberId;
 
+    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 32)
     private ChallengeStartNotificationStatus status;
 
     @Column(nullable = false)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/notification/ChallengeStartNotification.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/notification/ChallengeStartNotification.java
@@ -1,0 +1,83 @@
+package me.bombom.api.v1.challenge.domain.notification;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.challenge.domain.ChallengeStartNotificationStatus;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChallengeStartNotification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private ChallengeStartNotificationStatus status;
+
+    @Column(nullable = false)
+    private int attempts;
+
+    private LocalDateTime nextRetryAt;
+
+    @Column(length = 1024)
+    private String lastError;
+
+    @Column(nullable = false)
+    private Long challengeId;
+
+    @Column(nullable = false)
+    private String challengeName;
+
+    @Builder
+    public ChallengeStartNotification(
+            Long id,
+            @NonNull Long memberId,
+            @NonNull ChallengeStartNotificationStatus status,
+            int attempts,
+            LocalDateTime nextRetryAt,
+            String lastError,
+            @NonNull Long challengeId,
+            @NonNull String challengeName
+    ) {
+        this.id = id;
+        this.memberId = memberId;
+        this.status = status;
+        this.attempts = attempts;
+        this.nextRetryAt = nextRetryAt;
+        this.lastError = lastError;
+        this.challengeId = challengeId;
+        this.challengeName = challengeName;
+    }
+
+    public static ChallengeStartNotification createPending(
+            Long memberId,
+            Long challengeId,
+            String challengeName
+    ) {
+        return ChallengeStartNotification.builder()
+                .memberId(memberId)
+                .status(ChallengeStartNotificationStatus.PENDING)
+                .attempts(0)
+                .challengeId(challengeId)
+                .challengeName(challengeName)
+                .build();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeRepository.java
@@ -12,6 +12,13 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
     @Query("""
         SELECT c
         FROM Challenge c
+        WHERE c.startDate = :date
+    """)
+    List<Challenge> findChallengesStartingOn(@Param("date") LocalDate date);
+
+    @Query("""
+        SELECT c
+        FROM Challenge c
         WHERE :date BETWEEN c.startDate AND c.endDate
     """)
     List<Challenge> findOngoingChallenges(@Param("date") LocalDate date);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeStartNotificationRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeStartNotificationRepository.java
@@ -1,0 +1,17 @@
+package me.bombom.api.v1.challenge.repository;
+
+import java.util.List;
+import me.bombom.api.v1.challenge.domain.notification.ChallengeStartNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ChallengeStartNotificationRepository extends JpaRepository<ChallengeStartNotification, Long> {
+
+    @Query("""
+                SELECT n.memberId
+                FROM ChallengeStartNotification n
+                WHERE n.challengeId = :challengeId
+            """)
+    List<Long> findMemberIdsByChallengeId(@Param("challengeId") Long challengeId);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.challenge.scheduler;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
 import me.bombom.api.v1.challenge.service.ChallengeService;
+import me.bombom.api.v1.challenge.service.ChallengeStartNotificationService;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -17,9 +19,12 @@ import org.springframework.stereotype.Component;
 public class ChallengeScheduler {
 
     private static final String DAILY_CRON = "0 0 0 * * *";
+    private static final String CHALLENGE_START_NOTIFICATION_CRON = "0 0 4 * * *";
 
+    private final Clock clock;
     private final ChallengeService challengeService;
     private final ChallengeProgressService challengeProgressService;
+    private final ChallengeStartNotificationService challengeStartNotificationService;
 
     @Scheduled(cron = DAILY_CRON)
     @SchedulerLock(name = "check_survival", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
@@ -43,7 +48,7 @@ public class ChallengeScheduler {
         log.info("챌린지 종료 처리 및 뱃지 발급 시작");
         LocalDate today = LocalDate.now();
         List<Challenge> endedChallenges = challengeService.getEndedChallengesPendingBadge(today);
-        
+
         if (endedChallenges.isEmpty()) {
             log.info("종료된 챌린지가 없습니다.");
             return;
@@ -56,7 +61,20 @@ public class ChallengeScheduler {
                 log.error("챌린지 종료 처리 중 오류 발생 - challengeId: {}", challenge.getId(), e);
             }
         }
-        
+
         log.info("챌린지 종료 처리 및 뱃지 발급 완료");
+    }
+
+    @Scheduled(cron = CHALLENGE_START_NOTIFICATION_CRON)
+    @SchedulerLock(name = "create_challenge_start_notifications", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
+    public void createChallengeStartNotifications() {
+        LocalDate today = LocalDate.now(clock);
+        log.info("챌린지 시작 알림 추가 시작 - date={}", today);
+
+        try {
+            challengeStartNotificationService.createPendingNotificationsForStartingChallenges(today);
+        } catch (Exception e) {
+            log.error("챌린지 시작 알림 적재 중 오류 발생 - date={}", today, e);
+        }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
 public class ChallengeScheduler {
 
     private static final String DAILY_CRON = "0 0 0 * * *";
-    private static final String CHALLENGE_START_NOTIFICATION_CRON = "0 0 4 * * *";
+    private static final String CHALLENGE_START_NOTIFICATION_CRON = "0 10 3 * * *";
 
     private final Clock clock;
     private final ChallengeService challengeService;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
@@ -65,7 +65,7 @@ public class ChallengeScheduler {
         log.info("챌린지 종료 처리 및 뱃지 발급 완료");
     }
 
-    @Scheduled(cron = CHALLENGE_START_NOTIFICATION_CRON)
+    @Scheduled(cron = CHALLENGE_START_NOTIFICATION_CRON, zone = "Asia/Seoul")
     @SchedulerLock(name = "create_challenge_start_notifications", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void createChallengeStartNotifications() {
         LocalDate today = LocalDate.now(clock);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeStartNotificationService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeStartNotificationService.java
@@ -35,38 +35,43 @@ public class ChallengeStartNotificationService {
         }
 
         for (Challenge challenge : startingChallenges) {
-            List<ChallengeParticipant> participants = challengeParticipantRepository.findAllByChallengeId(challenge.getId());
+            try {
+                List<ChallengeParticipant> participants = challengeParticipantRepository.findAllByChallengeId(challenge.getId());
 
-            if (participants.isEmpty()) {
-                log.info("참여자가 없는 시작 챌린지입니다. challengeId={}", challenge.getId());
-                continue;
+                if (participants.isEmpty()) {
+                    log.info("참여자가 없는 시작 챌린지입니다. challengeId={}", challenge.getId());
+                    continue;
+                }
+
+                Set<Long> existingMemberIds = new HashSet<>(
+                        challengeStartNotificationRepository.findMemberIdsByChallengeId(challenge.getId()));
+
+                List<ChallengeStartNotification> notifications = participants.stream()
+                        .map(ChallengeParticipant::getMemberId)
+                        .filter(memberId -> !existingMemberIds.contains(memberId))
+                        .map(memberId -> ChallengeStartNotification.createPending(
+                                memberId,
+                                challenge.getId(),
+                                challenge.getName()
+                        ))
+                        .toList();
+
+                if (notifications.isEmpty()) {
+                    log.info("이미 시작 알림이 모두 적재된 챌린지입니다. challengeId={}", challenge.getId());
+                    continue;
+                }
+
+                challengeStartNotificationRepository.saveAll(notifications);
+                log.info(
+                        "챌린지 시작 알림 적재 완료. challengeId={}, challengeName={}, createdCount={}",
+                        challenge.getId(),
+                        challenge.getName(),
+                        notifications.size()
+                );
+            } catch (Exception e) {
+                log.error("챌린지 시작 알림 적재 실패. challengeId={}, challengeName={}",
+                        challenge.getId(), challenge.getName(), e);
             }
-
-            Set<Long> existingMemberIds = new HashSet<>(
-                    challengeStartNotificationRepository.findMemberIdsByChallengeId(challenge.getId()));
-
-            List<ChallengeStartNotification> notifications = participants.stream()
-                    .map(ChallengeParticipant::getMemberId)
-                    .filter(memberId -> !existingMemberIds.contains(memberId))
-                    .map(memberId -> ChallengeStartNotification.createPending(
-                            memberId,
-                            challenge.getId(),
-                            challenge.getName()
-                    ))
-                    .toList();
-
-            if (notifications.isEmpty()) {
-                log.info("이미 시작 알림이 모두 적재된 챌린지입니다. challengeId={}", challenge.getId());
-                continue;
-            }
-
-            challengeStartNotificationRepository.saveAll(notifications);
-            log.info(
-                    "챌린지 시작 알림 적재 완료. challengeId={}, challengeName={}, createdCount={}",
-                    challenge.getId(),
-                    challenge.getName(),
-                    notifications.size()
-            );
         }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeStartNotificationService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeStartNotificationService.java
@@ -1,0 +1,72 @@
+package me.bombom.api.v1.challenge.service;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.notification.ChallengeStartNotification;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeStartNotificationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ChallengeStartNotificationService {
+
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeParticipantRepository challengeParticipantRepository;
+    private final ChallengeStartNotificationRepository challengeStartNotificationRepository;
+
+    @Transactional
+    public void createPendingNotificationsForStartingChallenges(LocalDate date) {
+        List<Challenge> startingChallenges = challengeRepository.findChallengesStartingOn(date);
+
+        if (startingChallenges.isEmpty()) {
+            log.info("시작일인 챌린지가 없습니다. date={}", date);
+            return;
+        }
+
+        for (Challenge challenge : startingChallenges) {
+            List<ChallengeParticipant> participants = challengeParticipantRepository.findAllByChallengeId(challenge.getId());
+
+            if (participants.isEmpty()) {
+                log.info("참여자가 없는 시작 챌린지입니다. challengeId={}", challenge.getId());
+                continue;
+            }
+
+            Set<Long> existingMemberIds = new HashSet<>(
+                    challengeStartNotificationRepository.findMemberIdsByChallengeId(challenge.getId()));
+
+            List<ChallengeStartNotification> notifications = participants.stream()
+                    .map(ChallengeParticipant::getMemberId)
+                    .filter(memberId -> !existingMemberIds.contains(memberId))
+                    .map(memberId -> ChallengeStartNotification.createPending(
+                            memberId,
+                            challenge.getId(),
+                            challenge.getName()
+                    ))
+                    .toList();
+
+            if (notifications.isEmpty()) {
+                log.info("이미 시작 알림이 모두 적재된 챌린지입니다. challengeId={}", challenge.getId());
+                continue;
+            }
+
+            challengeStartNotificationRepository.saveAll(notifications);
+            log.info(
+                    "챌린지 시작 알림 적재 완료. challengeId={}, challengeName={}, createdCount={}",
+                    challenge.getId(),
+                    challenge.getName(),
+                    notifications.size()
+            );
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/resources/db/migration/V28.0.0__create_challenge_start_notification_table.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V28.0.0__create_challenge_start_notification_table.sql
@@ -1,0 +1,14 @@
+CREATE TABLE challenge_start_notification (
+      id BIGINT NOT NULL AUTO_INCREMENT,
+      member_id BIGINT NOT NULL,
+      status VARCHAR(32) NOT NULL,
+      attempts INT NOT NULL DEFAULT 0,
+      next_retry_at DATETIME(6) NULL,
+      last_error VARCHAR(1024) NULL,
+      challenge_id BIGINT NOT NULL,
+      challenge_name VARCHAR(255) NOT NULL,
+      created_at DATETIME(6) NOT NULL,
+      updated_at DATETIME(6) NOT NULL,
+      PRIMARY KEY (id),
+      CONSTRAINT uk_challenge_start_notification_challenge_member UNIQUE (challenge_id, member_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeStartNotificationServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeStartNotificationServiceTest.java
@@ -1,0 +1,139 @@
+package me.bombom.api.v1.challenge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeStartNotificationStatus;
+import me.bombom.api.v1.challenge.domain.notification.ChallengeStartNotification;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeStartNotificationRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.domain.NewsletterGroup;
+import me.bombom.api.v1.newsletter.repository.NewsletterGroupRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+class ChallengeStartNotificationServiceTest {
+
+    @Autowired
+    private ChallengeStartNotificationService challengeStartNotificationService;
+
+    @Autowired
+    private ChallengeStartNotificationRepository challengeStartNotificationRepository;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private NewsletterGroupRepository newsletterGroupRepository;
+
+    @BeforeEach
+    void setUp() {
+        challengeStartNotificationRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        newsletterGroupRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 시작일_챌린지_참여자에게_PENDING_알림을_생성한다() {
+        // given
+        LocalDate today = LocalDate.now();
+
+        NewsletterGroup group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("group"));
+        Challenge todayChallenge = challengeRepository.save(
+                TestFixture.createChallenge("오늘 시작", today, today.plusDays(5), 6, group.getId()));
+        Challenge tomorrowChallenge = challengeRepository.save(
+                TestFixture.createChallenge("내일 시작", today.plusDays(1), today.plusDays(6), 6, group.getId()));
+
+        Member member1 = memberRepository.save(TestFixture.createUniqueMember("m1", "p1"));
+        Member member2 = memberRepository.save(TestFixture.createUniqueMember("m2", "p2"));
+        Member member3 = memberRepository.save(TestFixture.createUniqueMember("m3", "p3"));
+
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipant(todayChallenge.getId(), member1.getId(), 0));
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipant(todayChallenge.getId(), member2.getId(), 0));
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(tomorrowChallenge.getId(), member3.getId(), 0));
+
+        // when
+        challengeStartNotificationService.createPendingNotificationsForStartingChallenges(today);
+
+        // then
+        List<ChallengeStartNotification> notifications = challengeStartNotificationRepository.findAll();
+        assertThat(notifications)
+                .extracting(
+                        ChallengeStartNotification::getMemberId,
+                        ChallengeStartNotification::getChallengeId,
+                        ChallengeStartNotification::getChallengeName,
+                        ChallengeStartNotification::getStatus,
+                        ChallengeStartNotification::getAttempts,
+                        ChallengeStartNotification::getNextRetryAt,
+                        ChallengeStartNotification::getLastError
+                )
+                .containsExactlyInAnyOrder(
+                        tuple(
+                                member1.getId(),
+                                todayChallenge.getId(),
+                                todayChallenge.getName(),
+                                ChallengeStartNotificationStatus.PENDING,
+                                0,
+                                null,
+                                null
+                        ),
+                        tuple(
+                                member2.getId(),
+                                todayChallenge.getId(),
+                                todayChallenge.getName(),
+                                ChallengeStartNotificationStatus.PENDING,
+                                0,
+                                null,
+                                null
+                        )
+                );
+    }
+
+    @Test
+    void 이미_저장된_알림은_중복_생성하지_않는다() {
+        // given
+        LocalDate today = LocalDate.now();
+
+        NewsletterGroup group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("group"));
+        Challenge challenge = challengeRepository.save(
+                TestFixture.createChallenge("오늘 시작", today, today.plusDays(5), 6, group.getId()));
+
+        Member member1 = memberRepository.save(TestFixture.createUniqueMember("m1", "p1"));
+        Member member2 = memberRepository.save(TestFixture.createUniqueMember("m2", "p2"));
+
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipant(challenge.getId(), member1.getId(), 0));
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipant(challenge.getId(), member2.getId(), 0));
+
+        challengeStartNotificationRepository.save(
+                ChallengeStartNotification.createPending(member1.getId(), challenge.getId(), challenge.getName()));
+
+        // when
+        challengeStartNotificationService.createPendingNotificationsForStartingChallenges(today);
+
+        // then
+        List<ChallengeStartNotification> notifications = challengeStartNotificationRepository.findAll();
+        assertThat(notifications).hasSize(2);
+        assertThat(notifications)
+                .extracting(ChallengeStartNotification::getMemberId)
+                .containsExactlyInAnyOrder(member1.getId(), member2.getId());
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 챌린지 시작 시 알림을 아웃박스 테이블에 저장합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- fcm 서버는 알림 전송 역할, 본서버는 시작한 챌린지의 참여자들에 대해 비즈니스 로직 처리 및 알림 등록의 역할입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- fcm-server와 함께 설명 문서화 첨부할 예정입니다-!

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
