### PR TITLE
[BOM-972] feat: 챌린지 전체 조회 시 추가 신청 가능 챌린지 포함

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -76,17 +76,15 @@ public class ChallengeService {
         Map<Long, List<ChallengeNewsletterResponse>> newslettersByChallengeId = getNewslettersByChallengeId(challengeIds);
         Map<Long, ChallengeParticipant> myParticipation = findMyParticipation(member, challengeIds);
 
+        LocalDate today = LocalDate.now(clock);
         return challenges.stream()
-                .filter(challenge -> {
-                    ChallengeStatus status = challenge.getStatus(LocalDate.now(clock));
-                    boolean isJoined = myParticipation.containsKey(challenge.getId());
-                    return status == ChallengeStatus.COMING_SOON || status == ChallengeStatus.BEFORE_START || isJoined;
-                })
+                .filter(challenge -> isVisibleInChallengeList(challenge, today, myParticipation.containsKey(challenge.getId())))
                 .map(challenge -> toChallengeResponse(
                         challenge,
                         participantCounts,
                         newslettersByChallengeId,
-                        myParticipation
+                        myParticipation,
+                        today
                 ))
                 .toList();
     }
@@ -219,20 +217,29 @@ public class ChallengeService {
         return new ChallengeTeamListResponse(teams.size(), myTeamId, teamInfos);
     }
 
+    private boolean isVisibleInChallengeList(Challenge challenge, LocalDate today, boolean isJoined) {
+        ChallengeStatus status = challenge.getStatus(today);
+        return status == ChallengeStatus.COMING_SOON
+                || status == ChallengeStatus.BEFORE_START
+                || isJoined
+                || isWithinAdditionalApplicationPeriod(challenge, today);
+    }
+
     private ChallengeResponse toChallengeResponse(
             Challenge challenge,
             Map<Long, Long> participantCounts,
             Map<Long, List<ChallengeNewsletterResponse>> newslettersByChallengeId,
-            Map<Long, ChallengeParticipant> myParticipation
+            Map<Long, ChallengeParticipant> myParticipation,
+            LocalDate today
     ) {
         long participantCount = participantCounts.getOrDefault(challenge.getId(), 0L);
         List<ChallengeNewsletterResponse> newsletterResponses = newslettersByChallengeId.getOrDefault(
                 challenge.getId(),
                 Collections.emptyList()
         );
-        ChallengeStatus status = challenge.getStatus(LocalDate.now(clock));
+        ChallengeStatus status = challenge.getStatus(today);
         ChallengeParticipant myParticipant = myParticipation.get(challenge.getId());
-        ChallengeDetailResponse detailResponse = calculateDetailResponse(challenge, myParticipant);
+        ChallengeDetailResponse detailResponse = calculateDetailResponse(challenge, myParticipant, today);
 
         return ChallengeResponse.of(challenge, participantCount, newsletterResponses, status, detailResponse);
     }
@@ -264,13 +271,14 @@ public class ChallengeService {
 
     private ChallengeDetailResponse calculateDetailResponse(
             Challenge challenge,
-            ChallengeParticipant myParticipant
+            ChallengeParticipant myParticipant,
+            LocalDate today
     ) {
         if (myParticipant == null) {
             return ChallengeDetailResponse.notJoined();
         }
 
-        boolean isEnded = challenge.isEnded(LocalDate.now(clock));
+        boolean isEnded = challenge.isEnded(today);
         boolean isSurvived = myParticipant.isSurvived();
         int progress = myParticipant.calculateProgress(challenge.getTotalDays());
 
@@ -304,15 +312,20 @@ public class ChallengeService {
                 .addContext("reason", "ELIGIBLE 상태에서는 예외를 생성할 수 없습니다.");
     }
 
+    private boolean isWithinAdditionalApplicationPeriod(Challenge challenge, LocalDate today) {
+        if (!challenge.hasStarted(today)) {
+            return false;
+        }
+        int passedDays = challenge.calculatePassedDays(today);
+        int maxPassedDaysForApplication = (int) (challenge.getTotalDays() * ADDITIONAL_APPLICATION_ALLOWED_RATIO);
+        return passedDays <= maxPassedDaysForApplication;
+    }
+
     private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
         LocalDate today = LocalDate.now(clock);
 
-        if (challenge.hasStarted(today)) {
-            int passedDays = challenge.calculatePassedDays(today);
-            int maxPassedDaysForApplication = (int) (challenge.getTotalDays() * ADDITIONAL_APPLICATION_ALLOWED_RATIO);
-            if (passedDays > maxPassedDaysForApplication) {
-                return EligibilityReason.ALREADY_STARTED;
-            }
+        if (challenge.hasStarted(today) && !isWithinAdditionalApplicationPeriod(challenge, today)) {
+            return EligibilityReason.ALREADY_STARTED;
         }
 
         boolean alreadyApplied = challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -183,6 +183,34 @@ class ChallengeServiceTest {
     }
 
     @Test
+    void 추가_신청_기간_내_챌린지는_미참여_시에도_목록에_노출된다() {
+        // given: 시작일이 오늘, totalDays 21일 → 추가 신청 기간 내. 참여하지 않은 회원
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        Challenge challenge = TestFixture.createChallenge(
+                "추가 신청 가능 챌린지",
+                today,
+                today.plusDays(30),
+                21,
+                group.getId()
+        );
+        challengeRepository.save(challenge);
+
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(challenge.getNewsletterGroupId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+
+        // when: 참여하지 않은 member로 목록 조회
+        List<ChallengeResponse> result = challengeService.getChallenges(member);
+
+        // then: 추가 신청 기간 내이므로 목록에 포함되어야 함
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result.get(0).id()).isEqualTo(challenge.getId());
+            softly.assertThat(result.get(0).detail().isJoined()).isFalse();
+        });
+    }
+
+    @Test
     void 챌린지가_없을_때_빈_리스트_반환() {
         // when
         List<ChallengeResponse> result = challengeService.getChallenges(null);


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 목록 조회 시, 추가 신청 기간 내인 챌린지는 참여하지 않았어도 노출되지 않던 문제를 수정했습니다. 

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존 조회 로직은 시작 날짜가 지난건 필터링 하고 있었기 때문에 추가 신청이 불가능 했음

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 추가 신청 기간인 챌린지도 필터링 로직에 포함시키도록 수정하였습니다.
- 추가 신청 기간임을 확인하는 로직을 메서드로 분리하여 재사용하도록 하였습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
이전 PR: https://github.com/woowacourse-teams/2025-bom-bom/pull/671
