### PR TITLE
[BOM-976] feat: 챌린지 todo 리마인더 알림 2번 전송하도록 수정

### DIFF
--- a/backend/fcm-server/src/main/java/news/bombom/challenge/domain/ChallengeTodoReminderNotification.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/domain/ChallengeTodoReminderNotification.java
@@ -2,6 +2,8 @@ package news.bombom.challenge.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -24,11 +26,16 @@ public class ChallengeTodoReminderNotification extends Notification {
     @Column(nullable = false)
     private String challengeName;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ChallengeTodoReminderPhase phase;
+
     @Builder
     public ChallengeTodoReminderNotification(
             @NonNull Long memberId,
             @NonNull Long challengeId,
             @NonNull String challengeName,
+            ChallengeTodoReminderPhase phase,
             NotificationStatus status,
             int attempts,
             LocalDateTime nextRetryAt,
@@ -37,6 +44,7 @@ public class ChallengeTodoReminderNotification extends Notification {
         super(memberId, status, attempts, nextRetryAt, lastError);
         this.challengeId = challengeId;
         this.challengeName = challengeName;
+        this.phase = phase != null ? phase : ChallengeTodoReminderPhase.FIRST;
     }
 
     @Override

--- a/backend/fcm-server/src/main/java/news/bombom/challenge/domain/ChallengeTodoReminderPhase.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/domain/ChallengeTodoReminderPhase.java
@@ -1,0 +1,6 @@
+package news.bombom.challenge.domain;
+
+public enum ChallengeTodoReminderPhase {
+    FIRST,
+    SECOND
+}

--- a/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeTodoReminderMessageBuilder.java
+++ b/backend/fcm-server/src/main/java/news/bombom/challenge/service/ChallengeTodoReminderMessageBuilder.java
@@ -2,6 +2,7 @@ package news.bombom.challenge.service;
 
 import java.util.Map;
 import news.bombom.challenge.domain.ChallengeTodoReminderNotification;
+import news.bombom.challenge.domain.ChallengeTodoReminderPhase;
 import news.bombom.notification.domain.MemberFcmToken;
 import news.bombom.notification.domain.Notification;
 import news.bombom.notification.domain.NotificationPayloadType;
@@ -22,8 +23,15 @@ public class ChallengeTodoReminderMessageBuilder implements NotificationMessageB
     public NotificationMessage build(Notification notification, MemberFcmToken token) {
         ChallengeTodoReminderNotification remind = (ChallengeTodoReminderNotification) notification;
 
-        String title = remind.getChallengeName() + " 아직 할 일이 남았어요!";
-        String content = "오늘도 기록을 채워볼까요? 지금 참여해서 꾸준하게 이어가요!";
+        String title;
+        String content;
+        if (remind.getPhase() == ChallengeTodoReminderPhase.SECOND) {
+            title = "[" + remind.getChallengeName() + "] 하루가 지나기 한 시간 전!";
+            content = "5분만 읽으면 오늘 출석이예요. 가볍게 완료해봐요!";
+        } else {
+            title = remind.getChallengeName() + " 아직 할 일이 남았어요!";
+            content = "오늘도 기록을 채워볼까요? 지금 참여해서 꾸준하게 이어가요!";
+        }
 
         return NotificationMessage.builder()
                 .recipient(token.getFcmToken())

--- a/backend/fcm-server/src/main/java/news/bombom/notification/scheduler/NotificationScheduler.java
+++ b/backend/fcm-server/src/main/java/news/bombom/notification/scheduler/NotificationScheduler.java
@@ -30,10 +30,22 @@ public class NotificationScheduler {
         }
     }
 
-    @Scheduled(cron = "0 0 21 * * MON-FRI", zone = "Asia/Seoul")
-    public void processChallengeTodoReminderNotifications() {
+    @Scheduled(cron = "${notification.schedule.challenge-todo-reminder.first-cron}", zone = "Asia/Seoul")
+    public void processChallengeTodoReminderNotificationsFirst() {
         LocalDateTime now = LocalDateTime.now();
-        log.info("챌린지 TODO 리마인더 Processor 실행");
+        log.info("챌린지 TODO 리마인더 Processor 실행(1차)");
+
+        try {
+            challengeProcessor.processPendingNotifications(now);
+        } catch (Exception e) {
+            log.error("Processor 실행 중 오류 발생: type={}", challengeProcessor.type(), e);
+        }
+    }
+
+    @Scheduled(cron = "${notification.schedule.challenge-todo-reminder.second-cron}", zone = "Asia/Seoul")
+    public void processChallengeTodoReminderNotificationsSecond() {
+        LocalDateTime now = LocalDateTime.now();
+        log.info("챌린지 TODO 리마인더 Processor 실행(2차)");
 
         try {
             challengeProcessor.processPendingNotifications(now);

--- a/backend/fcm-server/src/test/java/news/bombom/challenge/service/ChallengeTodoReminderMessageBuilderTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/challenge/service/ChallengeTodoReminderMessageBuilderTest.java
@@ -1,0 +1,59 @@
+package news.bombom.challenge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import news.bombom.challenge.domain.ChallengeTodoReminderNotification;
+import news.bombom.challenge.domain.ChallengeTodoReminderPhase;
+import news.bombom.notification.domain.MemberFcmToken;
+import news.bombom.notification.dto.NotificationMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("챌린지 TODO 리마인더 메시지 빌더 테스트")
+class ChallengeTodoReminderMessageBuilderTest {
+
+    private final ChallengeTodoReminderMessageBuilder builder = new ChallengeTodoReminderMessageBuilder();
+
+    @Test
+    @DisplayName("1차 알림이면 기본 리마인드 메시지를 생성한다")
+    void build_FirstPhase() {
+        ChallengeTodoReminderNotification notification = ChallengeTodoReminderNotification.builder()
+                .memberId(1L)
+                .challengeId(100L)
+                .challengeName("러닝")
+                .phase(ChallengeTodoReminderPhase.FIRST)
+                .build();
+        MemberFcmToken token = token();
+
+        NotificationMessage message = builder.build(notification, token);
+
+        assertThat(message.getTitle()).isEqualTo("러닝 아직 할 일이 남았어요!");
+        assertThat(message.getContent()).isEqualTo("오늘도 기록을 채워볼까요? 지금 참여해서 꾸준하게 이어가요!");
+    }
+
+    @Test
+    @DisplayName("2차 알림이면 미완료 안내 메시지를 생성한다")
+    void build_SecondPhase() {
+        ChallengeTodoReminderNotification notification = ChallengeTodoReminderNotification.builder()
+                .memberId(1L)
+                .challengeId(100L)
+                .challengeName("러닝")
+                .phase(ChallengeTodoReminderPhase.SECOND)
+                .build();
+        MemberFcmToken token = token();
+
+        NotificationMessage message = builder.build(notification, token);
+
+        assertThat(message.getTitle()).isEqualTo("오늘 TODO 아직 미완료예요");
+        assertThat(message.getContent()).isEqualTo("출석하고 오늘 기록을 완료해 주세요.");
+    }
+
+    private MemberFcmToken token() {
+        return MemberFcmToken.builder()
+                .memberId(1L)
+                .deviceUuid("device-1")
+                .fcmToken("test-token")
+                .isNotificationEnabled(true)
+                .build();
+    }
+}

--- a/backend/fcm-server/src/test/java/news/bombom/notification/scheduler/NotificationSchedulerTest.java
+++ b/backend/fcm-server/src/test/java/news/bombom/notification/scheduler/NotificationSchedulerTest.java
@@ -38,9 +38,17 @@ class NotificationSchedulerTest {
     }
 
     @Test
-    @DisplayName("챌린지 스케줄이 챌린지 Processor를 호출한다")
-    void processChallengeTodoReminderNotifications_DelegatesToChallengeProcessor() {
-        notificationScheduler.processChallengeTodoReminderNotifications();
+    @DisplayName("챌린지 1차 스케줄이 챌린지 Processor를 호출한다")
+    void processChallengeTodoReminderNotificationsFirst_DelegatesToChallengeProcessor() {
+        notificationScheduler.processChallengeTodoReminderNotificationsFirst();
+
+        verify(challengeProcessor, times(1)).processPendingNotifications(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("챌린지 2차 스케줄이 챌린지 Processor를 호출한다")
+    void processChallengeTodoReminderNotificationsSecond_DelegatesToChallengeProcessor() {
+        notificationScheduler.processChallengeTodoReminderNotificationsSecond();
 
         verify(challengeProcessor, times(1)).processPendingNotifications(org.mockito.ArgumentMatchers.any());
     }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 챌린지 알림을 하루에 두 번 전송하도록 추가합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 챌린지 참여자들의 더 활발한 챌린지 참여 유도를 위함입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 알림 phase에 따라 메세지를 변경하고 이들을 전송하는 스케줄러를 추가했습니다. 
- 두 번째 알림은 지금 오후 11시에 전송됩니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
