### PR TITLE
[BOM-977] feat: 챌린지 TODO 알림 2번 추가하도록 스케줄러 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/notification/ChallengeTodoReminderNotification.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/notification/ChallengeTodoReminderNotification.java
@@ -45,6 +45,10 @@ public class ChallengeTodoReminderNotification extends BaseEntity {
     @Column(nullable = false)
     private String challengeName;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ChallengeTodoReminderPhase phase;
+
     @Builder
     public ChallengeTodoReminderNotification(
             @NonNull Long memberId,
@@ -53,7 +57,8 @@ public class ChallengeTodoReminderNotification extends BaseEntity {
             LocalDateTime nextRetryAt,
             String lastError,
             @NonNull Long challengeId,
-            @NonNull String challengeName
+            @NonNull String challengeName,
+            @NonNull ChallengeTodoReminderPhase phase
     ) {
         this.memberId = memberId;
         this.status = status;
@@ -62,12 +67,14 @@ public class ChallengeTodoReminderNotification extends BaseEntity {
         this.lastError = lastError;
         this.challengeId = challengeId;
         this.challengeName = challengeName;
+        this.phase = phase;
     }
 
     public static ChallengeTodoReminderNotification createPending(
             Long memberId,
             Long challengeId,
-            String challengeName
+            String challengeName,
+            ChallengeTodoReminderPhase phase
     ) {
         return ChallengeTodoReminderNotification.builder()
                 .memberId(memberId)
@@ -75,6 +82,7 @@ public class ChallengeTodoReminderNotification extends BaseEntity {
                 .attempts(0)
                 .challengeId(challengeId)
                 .challengeName(challengeName)
+                .phase(phase)
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/notification/ChallengeTodoReminderPhase.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/notification/ChallengeTodoReminderPhase.java
@@ -1,0 +1,6 @@
+package me.bombom.api.v1.challenge.domain.notification;
+
+public enum ChallengeTodoReminderPhase {
+    FIRST,
+    SECOND
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTodoReminderNotificationRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTodoReminderNotificationRepository.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.challenge.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderNotification;
+import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderPhase;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,11 +14,13 @@ public interface ChallengeTodoReminderNotificationRepository extends JpaReposito
                 SELECT n.memberId
                 FROM ChallengeTodoReminderNotification n
                 WHERE n.challengeId = :challengeId
+                  AND n.phase = :phase
                   AND n.createdAt >= :startAt
                   AND n.createdAt <= :endAt
             """)
-    List<Long> findMemberIdsByChallengeIdAndCreatedAtBetween(
+    List<Long> findMemberIdsByChallengeIdAndPhaseAndCreatedAtBetween(
             @Param("challengeId") Long challengeId,
+            @Param("phase") ChallengeTodoReminderPhase phase,
             @Param("startAt") LocalDateTime startAt,
             @Param("endAt") LocalDateTime endAt
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderPhase;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
 import me.bombom.api.v1.challenge.service.ChallengeService;
 import me.bombom.api.v1.challenge.service.ChallengeStartNotificationService;
@@ -80,16 +81,31 @@ public class ChallengeScheduler {
         }
     }
 
-    @Scheduled(cron = "${challenge.scheduler.todo-reminder-cron}", zone = "Asia/Seoul")
-    @SchedulerLock(name = "create_challenge_todo_reminder_notifications", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
-    public void createChallengeTodoReminderNotifications() {
+    @Scheduled(cron = "${challenge.scheduler.todo-reminder-first-cron}", zone = "Asia/Seoul")
+    @SchedulerLock(name = "create_challenge_todo_reminder_notifications_first", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
+    public void createChallengeTodoReminderNotificationsFirst() {
         LocalDate today = LocalDate.now(clock);
-        log.info("챌린지 TODO 리마인더 알림 추가 시작 - date={}", today);
+        log.info("챌린지 TODO 리마인더 알림 1차 추가 시작 - date={}, phase={}", today, ChallengeTodoReminderPhase.FIRST);
 
         try {
-            challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today);
+            challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today,
+                    ChallengeTodoReminderPhase.FIRST);
         } catch (Exception e) {
-            log.error("챌린지 TODO 리마인더 알림 적재 중 오류 발생 - date={}", today, e);
+            log.error("챌린지 TODO 리마인더 알림 1차 적재 중 오류 발생 - date={}, phase={}", today, ChallengeTodoReminderPhase.FIRST, e);
+        }
+    }
+
+    @Scheduled(cron = "${challenge.scheduler.todo-reminder-second-cron}", zone = "Asia/Seoul")
+    @SchedulerLock(name = "create_challenge_todo_reminder_notifications_second", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
+    public void createChallengeTodoReminderNotificationsSecond() {
+        LocalDate today = LocalDate.now(clock);
+        log.info("챌린지 TODO 리마인더 알림 2차 추가 시작 - date={}, phase={}", today, ChallengeTodoReminderPhase.SECOND);
+
+        try {
+            challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today,
+                    ChallengeTodoReminderPhase.SECOND);
+        } catch (Exception e) {
+            log.error("챌린지 TODO 리마인더 알림 2차 적재 중 오류 발생 - date={}, phase={}", today, ChallengeTodoReminderPhase.SECOND, e);
         }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoReminderNotificationService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoReminderNotificationService.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderNotification;
+import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderPhase;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeTodoReminderNotificationRepository;
@@ -27,11 +28,11 @@ public class ChallengeTodoReminderNotificationService {
     private final ChallengeTodoReminderNotificationRepository challengeTodoReminderNotificationRepository;
 
     @Transactional
-    public void createPendingNotificationsForIncompleteTodos(LocalDate reminderDate) {
+    public void createPendingNotificationsForIncompleteTodos(LocalDate reminderDate, ChallengeTodoReminderPhase phase) {
         List<Challenge> ongoingChallenges = challengeRepository.findOngoingChallenges(reminderDate);
 
         if (ongoingChallenges.isEmpty()) {
-            log.info("진행 중 챌린지가 없습니다. reminderDate={}", reminderDate);
+            log.info("진행 중 챌린지가 없습니다. reminderDate={}, phase={}", reminderDate, phase);
             return;
         }
 
@@ -48,8 +49,9 @@ public class ChallengeTodoReminderNotificationService {
 
                 Set<Long> existingMemberIds = new HashSet<>(
                         challengeTodoReminderNotificationRepository
-                                .findMemberIdsByChallengeIdAndCreatedAtBetween(
+                                .findMemberIdsByChallengeIdAndPhaseAndCreatedAtBetween(
                                         challenge.getId(),
+                                        phase,
                                         reminderDate.atStartOfDay(),
                                         endOfDay(reminderDate)
                                 )
@@ -61,22 +63,23 @@ public class ChallengeTodoReminderNotificationService {
                         .map(memberId -> ChallengeTodoReminderNotification.createPending(
                                 memberId,
                                 challenge.getId(),
-                                challenge.getName()
+                                challenge.getName(),
+                                phase
                         ))
                         .toList();
 
                 if (notifications.isEmpty()) {
-                    log.info("이미 TODO 리마인더 알림이 모두 적재된 챌린지입니다. challengeName={}, reminderDate={}",
-                            challenge.getName(), reminderDate);
+                    log.info("이미 TODO 리마인더 알림이 모두 적재된 챌린지입니다. challengeName={}, reminderDate={}, phase={}",
+                            challenge.getName(), reminderDate, phase);
                     continue;
                 }
 
                 challengeTodoReminderNotificationRepository.saveAll(notifications);
-                log.info("챌린지 TODO 리마인더 알림 적재 완료. challengeId={}, challengeName={}, reminderDate={}, createdCount={}",
-                        challenge.getId(), challenge.getName(), reminderDate, notifications.size());
+                log.info("챌린지 TODO 리마인더 알림 적재 완료. challengeId={}, challengeName={}, reminderDate={}, phase={}, createdCount={}",
+                        challenge.getId(), challenge.getName(), reminderDate, phase, notifications.size());
             } catch (Exception e) {
-                log.error("챌린지 TODO 리마인더 알림 적재 실패. challengeId={}, challengeName={}, reminderDate={}",
-                        challenge.getId(), challenge.getName(), reminderDate, e);
+                log.error("챌린지 TODO 리마인더 알림 적재 실패. challengeId={}, challengeName={}, reminderDate={}, phase={}",
+                        challenge.getId(), challenge.getName(), reminderDate, phase, e);
             }
         }
     }

--- a/backend/bom-bom-server/src/main/resources/db/migration/V30.1.0__add_phase_to_challenge_todo_reminder_notification.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V30.1.0__add_phase_to_challenge_todo_reminder_notification.sql
@@ -1,0 +1,2 @@
+ALTER TABLE challenge_todo_reminder_notification
+    ADD COLUMN phase VARCHAR(255) NOT NULL DEFAULT 'FIRST' AFTER challenge_name;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoReminderNotificationServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoReminderNotificationServiceTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
+import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderPhase;
 import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderNotification;
 import me.bombom.api.v1.challenge.domain.notification.NotificationStatus;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
@@ -90,7 +91,7 @@ class ChallengeTodoReminderNotificationServiceTest {
         challengeDailyTodoRepository.save(TestFixture.createChallengeDailyTodo(participant3.getId(), today, readTodo.getId()));
 
         // when
-        challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today);
+        challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today, ChallengeTodoReminderPhase.FIRST);
 
         // then
         List<ChallengeTodoReminderNotification> notifications = challengeTodoReminderNotificationRepository.findAll();
@@ -99,6 +100,7 @@ class ChallengeTodoReminderNotificationServiceTest {
                         ChallengeTodoReminderNotification::getMemberId,
                         ChallengeTodoReminderNotification::getChallengeId,
                         ChallengeTodoReminderNotification::getChallengeName,
+                        ChallengeTodoReminderNotification::getPhase,
                         ChallengeTodoReminderNotification::getStatus,
                         ChallengeTodoReminderNotification::getAttempts
                 )
@@ -107,6 +109,7 @@ class ChallengeTodoReminderNotificationServiceTest {
                                 incompleteMember.getId(),
                                 challenge.getId(),
                                 challenge.getName(),
+                                ChallengeTodoReminderPhase.FIRST,
                                 NotificationStatus.PENDING,
                                 0
                         ),
@@ -114,6 +117,7 @@ class ChallengeTodoReminderNotificationServiceTest {
                                 anotherIncompleteMember.getId(),
                                 challenge.getId(),
                                 challenge.getName(),
+                                ChallengeTodoReminderPhase.FIRST,
                                 NotificationStatus.PENDING,
                                 0
                         )
@@ -136,10 +140,15 @@ class ChallengeTodoReminderNotificationServiceTest {
         challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ));
 
         challengeTodoReminderNotificationRepository.save(
-                ChallengeTodoReminderNotification.createPending(member1.getId(), challenge.getId(), challenge.getName()));
+                ChallengeTodoReminderNotification.createPending(
+                        member1.getId(),
+                        challenge.getId(),
+                        challenge.getName(),
+                        ChallengeTodoReminderPhase.FIRST
+                ));
 
         // when
-        challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today);
+        challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today, ChallengeTodoReminderPhase.FIRST);
 
         // then
         List<ChallengeTodoReminderNotification> notifications = challengeTodoReminderNotificationRepository.findAll();
@@ -147,5 +156,36 @@ class ChallengeTodoReminderNotificationServiceTest {
         assertThat(notifications)
                 .extracting(ChallengeTodoReminderNotification::getMemberId)
                 .containsExactlyInAnyOrder(member1.getId(), member2.getId());
+    }
+
+    @Test
+    void 같은_날짜라도_phase가_다르면_알림을_생성한다() {
+        // given
+        LocalDate today = LocalDate.now();
+        NewsletterGroup group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("group"));
+        Challenge challenge = challengeRepository.save(
+                TestFixture.createChallenge("진행 중 챌린지", today.minusDays(1), today.plusDays(3), 5, group.getId()));
+
+        Member member = memberRepository.save(TestFixture.createUniqueMember("m1", "p1"));
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipant(challenge.getId(), member.getId(), 0));
+        challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ));
+
+        challengeTodoReminderNotificationRepository.save(
+                ChallengeTodoReminderNotification.createPending(
+                        member.getId(),
+                        challenge.getId(),
+                        challenge.getName(),
+                        ChallengeTodoReminderPhase.FIRST
+                ));
+
+        // when
+        challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today, ChallengeTodoReminderPhase.SECOND);
+
+        // then
+        List<ChallengeTodoReminderNotification> notifications = challengeTodoReminderNotificationRepository.findAll();
+        assertThat(notifications).hasSize(2);
+        assertThat(notifications)
+                .extracting(ChallengeTodoReminderNotification::getPhase)
+                .containsExactlyInAnyOrder(ChallengeTodoReminderPhase.FIRST, ChallengeTodoReminderPhase.SECOND);
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 챌린지 TODO 미완료 알림을 2번 전송하도록 스케줄러를 분리했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- phase 컬럼을 둬서 fcm-server에서는 이를 가지고 메세지를 분기처리합니다.
- 알림 등록 시간은 오후 8시 59분, 10시 59분입니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
