### PR TITLE
[BOM-986] feat: 챌린지 추가 신청을 위한 신청 단계 필드 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/Challenge.java
@@ -19,6 +19,8 @@ import me.bombom.api.v1.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Challenge extends BaseEntity {
 
+    private static final double LATE_REGISTRATION_ALLOWED_RATIO = 0.2;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -88,6 +90,24 @@ public class Challenge extends BaseEntity {
         return this.startDate != null && !now.isBefore(this.startDate);
     }
 
+    public RegistrationPhase getRegistrationPhase(LocalDate now) {
+        if (!hasStarted(now)) {
+            return RegistrationPhase.EARLY;
+        }
+        if (isWithinLatePhase(now)) {
+            return RegistrationPhase.LATE;
+        }
+        return RegistrationPhase.CLOSED;
+    }
+
+    public boolean isRegistrationClosed(LocalDate now) {
+        return getRegistrationPhase(now) == RegistrationPhase.CLOSED;
+    }
+
+    public boolean isLatePhase(LocalDate now) {
+        return getRegistrationPhase(now) == RegistrationPhase.LATE;
+    }
+
     public int calculatePassedDays(LocalDate targetDate) {
         if (this.startDate == null) {
             return 0;
@@ -106,5 +126,11 @@ public class Challenge extends BaseEntity {
     private boolean isWeekday(LocalDate currentDate) {
         DayOfWeek dayOfWeek = currentDate.getDayOfWeek();
         return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY;
+    }
+
+    private boolean isWithinLatePhase(LocalDate targetDate) {
+        int passedDays = calculatePassedDays(targetDate);
+        int maxPassedDaysForLateRegistration = (int) (this.totalDays * LATE_REGISTRATION_ALLOWED_RATIO);
+        return passedDays <= maxPassedDaysForLateRegistration;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/RegistrationPhase.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/RegistrationPhase.java
@@ -1,0 +1,9 @@
+package me.bombom.api.v1.challenge.domain;
+
+public enum RegistrationPhase {
+
+    EARLY,
+    LATE,
+    CLOSED,
+    ;
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeResponse.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.util.List;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
+import me.bombom.api.v1.challenge.domain.RegistrationPhase;
 
 public record ChallengeResponse(
 
@@ -33,7 +34,10 @@ public record ChallengeResponse(
         @NotNull
         ChallengeStatus status,
 
-        ChallengeDetailResponse detail
+        @NotNull
+        RegistrationPhase registrationPhase,
+
+        ChallengeDetailResponse participationInfo
 ) {
 
     public static ChallengeResponse of(
@@ -41,7 +45,8 @@ public record ChallengeResponse(
             long participantCount,
             List<ChallengeNewsletterResponse> newsletters,
             ChallengeStatus status,
-            ChallengeDetailResponse detail
+            RegistrationPhase registrationPhase,
+            ChallengeDetailResponse participationInfo
     ) {
         return new ChallengeResponse(
                 challenge.getId(),
@@ -52,7 +57,8 @@ public record ChallengeResponse(
                 participantCount,
                 newsletters,
                 status,
-                detail
+                registrationPhase,
+                participationInfo
         );
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -18,6 +18,7 @@ import me.bombom.api.v1.badge.service.BadgeService;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeGrade;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.RegistrationPhase;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.domain.EligibilityReason;
@@ -52,7 +53,6 @@ public class ChallengeService {
 
     // TODO: 이후에 수료 처리 등 구현 시 관리 방법 고려
     private static final double SUCCESS_REQUIRED_RATIO = 0.8;
-    private static final double ADDITIONAL_APPLICATION_ALLOWED_RATIO = 0.2;
     private static final int MIN_CHALLENGE_TOTAL_DAYS_FOR_BADGE = 15;
 
     private final ChallengeRepository challengeRepository;
@@ -222,7 +222,7 @@ public class ChallengeService {
         return status == ChallengeStatus.COMING_SOON
                 || status == ChallengeStatus.BEFORE_START
                 || isJoined
-                || isWithinAdditionalApplicationPeriod(challenge, today);
+                || challenge.isLatePhase(today);
     }
 
     private ChallengeResponse toChallengeResponse(
@@ -238,10 +238,18 @@ public class ChallengeService {
                 Collections.emptyList()
         );
         ChallengeStatus status = challenge.getStatus(today);
+        RegistrationPhase registrationPhase = challenge.getRegistrationPhase(today);
         ChallengeParticipant myParticipant = myParticipation.get(challenge.getId());
-        ChallengeDetailResponse detailResponse = calculateDetailResponse(challenge, myParticipant, today);
+        ChallengeDetailResponse participationInfo = calculateParticipationInfo(challenge, myParticipant, today);
 
-        return ChallengeResponse.of(challenge, participantCount, newsletterResponses, status, detailResponse);
+        return ChallengeResponse.of(
+                challenge,
+                participantCount,
+                newsletterResponses,
+                status,
+                registrationPhase,
+                participationInfo
+        );
     }
 
     private Map<Long, Long> getParticipantCounts(List<Long> challengeIds) {
@@ -269,7 +277,7 @@ public class ChallengeService {
                 ));
     }
 
-    private ChallengeDetailResponse calculateDetailResponse(
+    private ChallengeDetailResponse calculateParticipationInfo(
             Challenge challenge,
             ChallengeParticipant myParticipant,
             LocalDate today
@@ -312,19 +320,10 @@ public class ChallengeService {
                 .addContext("reason", "ELIGIBLE 상태에서는 예외를 생성할 수 없습니다.");
     }
 
-    private boolean isWithinAdditionalApplicationPeriod(Challenge challenge, LocalDate today) {
-        if (!challenge.hasStarted(today)) {
-            return false;
-        }
-        int passedDays = challenge.calculatePassedDays(today);
-        int maxPassedDaysForApplication = (int) (challenge.getTotalDays() * ADDITIONAL_APPLICATION_ALLOWED_RATIO);
-        return passedDays <= maxPassedDaysForApplication;
-    }
-
     private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
         LocalDate today = LocalDate.now(clock);
 
-        if (challenge.hasStarted(today) && !isWithinAdditionalApplicationPeriod(challenge, today)) {
+        if (challenge.isRegistrationClosed(today)) {
             return EligibilityReason.ALREADY_STARTED;
         }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
@@ -134,7 +134,7 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$[0].participantCount").exists())
                 .andExpect(jsonPath("$[0].newsletters").isArray())
                 .andExpect(jsonPath("$[0].status").exists())
-                .andExpect(jsonPath("$[0].detail.isJoined").value(false));
+                .andExpect(jsonPath("$[0].participationInfo.isJoined").value(false));
     }
 
     @Test
@@ -162,8 +162,8 @@ class ChallengeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$[0].id").value(challenge.getId()))
-                .andExpect(jsonPath("$[0].detail.isJoined").value(true))
-                .andExpect(jsonPath("$[0].detail.progress").exists());
+                .andExpect(jsonPath("$[0].participationInfo.isJoined").value(true))
+                .andExpect(jsonPath("$[0].participationInfo.progress").exists());
     }
 
     @Test

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -11,6 +11,7 @@ import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
 import me.bombom.api.v1.challenge.domain.EligibilityReason;
+import me.bombom.api.v1.challenge.domain.RegistrationPhase;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.dto.response.ChallengeDetailResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeEligibilityResponse;
@@ -132,8 +133,9 @@ class ChallengeServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).id()).isEqualTo(challenge2.getId());
-            softly.assertThat(result.get(0).detail().isJoined()).isFalse();
-            softly.assertThat(result.get(0).detail().progress()).isEqualTo(0);
+            softly.assertThat(result.get(0).registrationPhase()).isEqualTo(RegistrationPhase.EARLY);
+            softly.assertThat(result.get(0).participationInfo().isJoined()).isFalse();
+            softly.assertThat(result.get(0).participationInfo().progress()).isEqualTo(0);
         });
     }
 
@@ -175,10 +177,12 @@ class ChallengeServiceTest {
                     .findFirst()
                     .orElseThrow();
 
-            softly.assertThat(challenge1Response.detail().isJoined()).isTrue();
-            softly.assertThat(challenge1Response.detail().progress()).isGreaterThan(0);
-            softly.assertThat(challenge2Response.detail().isJoined()).isFalse();
-            softly.assertThat(challenge2Response.detail().progress()).isEqualTo(0);
+            softly.assertThat(challenge1Response.participationInfo().isJoined()).isTrue();
+            softly.assertThat(challenge1Response.participationInfo().progress()).isGreaterThan(0);
+            softly.assertThat(challenge1Response.registrationPhase()).isEqualTo(RegistrationPhase.CLOSED);
+            softly.assertThat(challenge2Response.participationInfo().isJoined()).isFalse();
+            softly.assertThat(challenge2Response.participationInfo().progress()).isEqualTo(0);
+            softly.assertThat(challenge2Response.registrationPhase()).isEqualTo(RegistrationPhase.EARLY);
         });
     }
 
@@ -206,7 +210,8 @@ class ChallengeServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
             softly.assertThat(result.get(0).id()).isEqualTo(challenge.getId());
-            softly.assertThat(result.get(0).detail().isJoined()).isFalse();
+            softly.assertThat(result.get(0).registrationPhase()).isEqualTo(RegistrationPhase.LATE);
+            softly.assertThat(result.get(0).participationInfo().isJoined()).isFalse();
         });
     }
 
@@ -360,18 +365,18 @@ class ChallengeServiceTest {
         List<ChallengeResponse> result = challengeService.getChallenges(member);
 
         // then
-        ChallengeDetailResponse detail = result.get(0).detail();
+        ChallengeDetailResponse participationInfo = result.get(0).participationInfo();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(detail.isJoined()).isTrue();
-            softly.assertThat(detail.progress()).isGreaterThan(0);
-            softly.assertThat(detail.grade()).isNotNull();
-            softly.assertThat(detail.isSurvived()).isNotNull();
+            softly.assertThat(participationInfo.isJoined()).isTrue();
+            softly.assertThat(participationInfo.progress()).isGreaterThan(0);
+            softly.assertThat(participationInfo.grade()).isNotNull();
+            softly.assertThat(participationInfo.isSurvived()).isNotNull();
         });
     }
 
     @Test
-    void 참가하지_않은_챌린지_detail_조회() {
+    void 참가하지_않은_챌린지_participationInfo_조회() {
         // given
         NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
         newsletterGroupRepository.save(group);
@@ -382,12 +387,12 @@ class ChallengeServiceTest {
         List<ChallengeResponse> result = challengeService.getChallenges(member);
 
         // then - 시작전 챌린지이므로 반환되어야 함
-        ChallengeDetailResponse detail = result.get(0).detail();
+        ChallengeDetailResponse participationInfo = result.get(0).participationInfo();
         assertSoftly(softly -> {
             softly.assertThat(result).hasSize(1);
-            softly.assertThat(detail).isNotNull();
-            softly.assertThat(detail.isJoined()).isFalse();
-            softly.assertThat(detail.progress()).isEqualTo(0);
+            softly.assertThat(participationInfo).isNotNull();
+            softly.assertThat(participationInfo.isJoined()).isFalse();
+            softly.assertThat(participationInfo.progress()).isEqualTo(0);
         });
     }
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 챌린지 목록 조회 시 신청 단계(registrationPhase) 정보가 없어, 클라이언트에서 추가 신청 가능 여부를 구분하기 어려웠음
- 챌린지별 내 참여 정보를 담는 필드명이 detail이라 의미가 불명확했음

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 사용자에게 “지금 신청 가능한지 / 추가 신청만 가능한지 / 마감인지”를 구분해서 보여주려면, 서버에서 신청 단계(early / late / closed) 를 명시해 줄 필요가 있음
- detail은 범용적이라 “챌린지에 대한 내 참여 정보”라는 의미가 드러나지 않아, participationInfo로 바꿔 의도를 분명히 하고자 함

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
### registrationPhase
- EARLY / LATE / CLOSED 로 사전 신청 / 추가 신청 / 신청 마감 구분

### participationInfo
- 참여 정보라는 의미를 위해 detail에서 필드명 변경 

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 현재 응답 구조 적절한지
