### PR TITLE
[BOM-989] fix: 챌린지 비공개 답글 개수 버그 해결

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
@@ -47,7 +47,7 @@ public class ChallengeCommentController implements ChallengeCommentControllerApi
     @Override
     @GetMapping("/{challengeId}/comments")
     public Page<ChallengeCommentResponse> getChallengeComments(
-            @LoginMember Member member,
+            @LoginMember Long memberId,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Valid @ModelAttribute ChallengeCommentOptionsRequest request,
             @PageableDefault(size = 20)
@@ -56,7 +56,7 @@ public class ChallengeCommentController implements ChallengeCommentControllerApi
                     @SortDefault(sort = "id", direction = Sort.Direction.ASC)
             }) Pageable pageable
     ) {
-        return challengeCommentService.getChallengeComments(challengeId, member.getId(), request, pageable);
+        return challengeCommentService.getChallengeComments(challengeId, memberId, request, pageable);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
@@ -43,7 +43,7 @@ public interface ChallengeCommentControllerApi {
             @ApiResponse(responseCode = "403", description = "팀 또는 챌린지 접근 권한 없음", content = @Content)
     })
     Page<ChallengeCommentResponse> getChallengeComments(
-            @Parameter(hidden = true) Member member,
+            @Parameter(hidden = true) Long memberId,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(description = "필터링 관련 요청") @Valid @ModelAttribute ChallengeCommentOptionsRequest request,
             @Parameter(description = "페이징 및 정렬 (예: ?page=0&size=20&sort=createdAt,desc)") Pageable pageable

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyController.java
@@ -7,7 +7,6 @@ import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
 import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
 import me.bombom.api.v1.challenge.service.ChallengeCommentReplyService;
 import me.bombom.api.v1.common.resolver.LoginMember;
-import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -34,22 +33,22 @@ public class ChallengeCommentReplyController implements ChallengeCommentReplyCon
     @PostMapping("{challengeId}/comments/{commentId}/replies")
     @ResponseStatus(HttpStatus.CREATED)
     public void createCommentReply(
-            @LoginMember Member member,
+            @LoginMember Long memberId,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @Valid @RequestBody CreateCommentReplyRequest request
     ) {
-        challengeCommentReplyService.createCommentReply(challengeId, commentId, member.getId(), request);
+        challengeCommentReplyService.createCommentReply(challengeId, commentId, memberId, request);
     }
 
     @Override
     @GetMapping("{challengeId}/comments/{commentId}/replies")
     public Page<CommentReplyResponse> getCommentReplies(
-            @LoginMember Member member,
+            @LoginMember Long memberId,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.ASC) Pageable pageable
     ) {
-        return challengeCommentReplyService.getCommentReplies(member.getId(), challengeId, commentId, pageable);
+        return challengeCommentReplyService.getCommentReplies(memberId, challengeId, commentId, pageable);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentReplyControllerApi.java
@@ -11,7 +11,6 @@ import jakarta.validation.constraints.Positive;
 import me.bombom.api.v1.challenge.dto.request.CreateCommentReplyRequest;
 import me.bombom.api.v1.challenge.dto.response.CommentReplyResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
-import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -39,7 +38,7 @@ public interface ChallengeCommentReplyControllerApi {
             @ApiResponse(responseCode = "404", description = "코멘트를 찾을 수 없음", content = @Content)
     })
     void createCommentReply(
-            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(hidden = true) @LoginMember Long memberId,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(description = "코멘트 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @Valid @RequestBody CreateCommentReplyRequest request
@@ -56,7 +55,7 @@ public interface ChallengeCommentReplyControllerApi {
             @ApiResponse(responseCode = "404", description = "코멘트를 찾을 수 없음", content = @Content)
     })
     Page<CommentReplyResponse> getCommentReplies(
-            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(hidden = true) @LoginMember Long memberId,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(description = "코멘트 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long commentId,
             @Parameter(description = "페이지/정렬 정보 (page, size, sort)") Pageable pageable

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeCommentResponse.java
@@ -41,6 +41,6 @@ public record ChallengeCommentResponse(
         boolean isLiked,
 
         @Schema(requiredMode = RequiredMode.REQUIRED)
-        int replyCount
+        long replyCount
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
@@ -19,8 +19,13 @@ public interface ChallengeCommentRepository extends JpaRepository<ChallengeComme
                     m.profileImageUrl,
                     n.name,
                     CASE
-                        WHEN s.id IS NULL THEN false
-                        ELSE true
+                        WHEN EXISTS (
+                            SELECT 1
+                            FROM Subscribe s
+                            WHERE s.newsletterId = cc.newsletterId
+                              AND s.memberId = :currentMemberId
+                        ) THEN true
+                        ELSE false
                     END,
                     cc.articleTitle,
                     cc.quotation,
@@ -55,7 +60,6 @@ public interface ChallengeCommentRepository extends JpaRepository<ChallengeComme
                     ON ccl.commentId = cc.id AND ccl.participantId = myCp.id
                 LEFT JOIN Member m ON cp.memberId = m.id
                 JOIN Newsletter n ON cc.newsletterId = n.id
-                LEFT JOIN Subscribe s ON s.newsletterId = cc.newsletterId AND s.memberId = :currentMemberId
                 WHERE cp.challengeId = :challengeId
                 AND FUNCTION('DATE', cc.createdAt) BETWEEN :startDate AND :endDate
             """)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeCommentRepository.java
@@ -35,7 +35,17 @@ public interface ChallengeCommentRepository extends JpaRepository<ChallengeComme
                         WHEN ccl.id IS NOT NULL THEN true
                         ELSE false
                     END,
-                    cc.replyCount
+                    (
+                        SELECT COUNT(cr.id)
+                        FROM ChallengeCommentReply cr
+                        JOIN ChallengeParticipant crAuthor ON cr.participantId = crAuthor.id
+                        WHERE cr.commentId = cc.id
+                          AND (
+                              cr.isPrivate = false
+                              OR crAuthor.memberId = :currentMemberId
+                              OR cp.memberId = :currentMemberId
+                          )
+                    )
                 )
                 FROM ChallengeComment cc
                 JOIN ChallengeParticipant cp ON cc.participantId = cp.id

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.UUID;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.repository.ArticleRepository;
@@ -245,10 +246,10 @@ class ChallengeCommentServiceTest {
         LocalDate end = LocalDate.now().plusDays(1);
 
         Member replyAuthorMember = memberRepository.save(
-                TestFixture.createMemberFixture("reply-author@bombom.news", "reply-author")
+                TestFixture.createUniqueMember("reply-author", UUID.randomUUID().toString())
         );
         Member thirdPartyMember = memberRepository.save(
-                TestFixture.createMemberFixture("third-party@bombom.news", "third-party")
+                TestFixture.createUniqueMember("third-party", UUID.randomUUID().toString())
         );
 
         ChallengeTeam replyAuthorTeam = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 0));

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
@@ -25,6 +25,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentLikeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentLikeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeCommentReplyRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
@@ -69,6 +70,9 @@ class ChallengeCommentServiceTest {
     private ChallengeCommentLikeRepository challengeCommentLikeRepository;
 
     @Autowired
+    private ChallengeCommentReplyRepository challengeCommentReplyRepository;
+
+    @Autowired
     private ChallengeParticipantRepository challengeParticipantRepository;
 
     @Autowired
@@ -110,6 +114,7 @@ class ChallengeCommentServiceTest {
 
     @BeforeEach
     void setUp() {
+        challengeCommentReplyRepository.deleteAllInBatch();
         challengeCommentRepository.deleteAllInBatch();
         challengeCommentLikeRepository.deleteAllInBatch();
         challengeParticipantRepository.deleteAllInBatch();
@@ -231,6 +236,90 @@ class ChallengeCommentServiceTest {
         // then
         assertThat(result.getTotalElements()).isZero();
         assertThat(result.getContent()).isEmpty();
+    }
+
+    @Test
+    void 답글_개수는_조회자_기준_가시성으로_집계된다() {
+        // given
+        LocalDate start = LocalDate.now().minusDays(1);
+        LocalDate end = LocalDate.now().plusDays(1);
+
+        Member replyAuthorMember = memberRepository.save(
+                TestFixture.createMemberFixture("reply-author@bombom.news", "reply-author")
+        );
+        Member thirdPartyMember = memberRepository.save(
+                TestFixture.createMemberFixture("third-party@bombom.news", "third-party")
+        );
+
+        ChallengeTeam replyAuthorTeam = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 0));
+        ChallengeTeam thirdPartyTeam = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 0));
+
+        ChallengeParticipant replyAuthorParticipant = challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipantWithTeam(
+                        challenge.getId(),
+                        replyAuthorMember.getId(),
+                        replyAuthorTeam.getId(),
+                        0,
+                        0
+                )
+        );
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipantWithTeam(
+                        challenge.getId(),
+                        thirdPartyMember.getId(),
+                        thirdPartyTeam.getId(),
+                        0,
+                        0
+                )
+        );
+
+        ChallengeComment comment = challengeCommentRepository.save(
+                TestFixture.createChallengeComment(
+                        article.getNewsletterId(),
+                        participant.getId(),
+                        article.getTitle(),
+                        "quote",
+                        "답글 수 가시성 테스트용 코멘트입니다."
+                )
+        );
+
+        challengeCommentReplyRepository.save(
+                TestFixture.createChallengeCommentReply(comment.getId(), replyAuthorParticipant.getId(), "비공개1", true)
+        );
+        challengeCommentReplyRepository.save(
+                TestFixture.createChallengeCommentReply(comment.getId(), replyAuthorParticipant.getId(), "비공개2", true)
+        );
+        challengeCommentReplyRepository.save(
+                TestFixture.createChallengeCommentReply(comment.getId(), replyAuthorParticipant.getId(), "비공개3", true)
+        );
+        challengeCommentReplyRepository.save(
+                TestFixture.createChallengeCommentReply(comment.getId(), replyAuthorParticipant.getId(), "공개1", false)
+        );
+        challengeCommentReplyRepository.save(
+                TestFixture.createChallengeCommentReply(comment.getId(), replyAuthorParticipant.getId(), "공개2", false)
+        );
+
+        // when
+        Page<ChallengeCommentResponse> commentAuthorView = challengeCommentService.getChallengeComments(
+                challenge.getId(),
+                member.getId(),
+                new ChallengeCommentOptionsRequest(start, end),
+                PageRequest.of(0, 10)
+        );
+        Page<ChallengeCommentResponse> thirdPartyView = challengeCommentService.getChallengeComments(
+                challenge.getId(),
+                thirdPartyMember.getId(),
+                new ChallengeCommentOptionsRequest(start, end),
+                PageRequest.of(0, 10)
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(commentAuthorView.getContent()).hasSize(1);
+            softly.assertThat(commentAuthorView.getContent().getFirst().replyCount()).isEqualTo(5L);
+            softly.assertThat(thirdPartyView.getContent()).hasSize(1);
+            softly.assertThat(thirdPartyView.getContent().getFirst().replyCount()).isEqualTo(2L);
+        });
     }
 
     @Test


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 댓글 목록을 조회 할 때 비공개 답글 개수가 모두 노출되는 버그를 해결합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
댓글 목록 조회 시 조회자에 따라 볼 수 있는 답글 개수를 보여주어야 합니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 기존에는 댓글 엔티티에 있는 `replyCount` 컬럼을 바로 썼지만, 답글 개수를 계산하는 로직을 수정했습니다.
- 현재 댓글 목록 조회자 기준, 볼 수 있는 비공개 답글 및 공개 답글들을 총합한 개수로 계산합니다.
- count 쿼리에 대한 결과가 dto 필드로 들어감에 따라 필드 타입을 int에서 long으로 전환했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 간단해서 개수 계산 쿼리만 확인해주시면 됩니다.