### PR TITLE
[BOM-990] feat: 쿠폰 조회 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/controller/CouponController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/controller/CouponController.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.coupon.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.coupon.dto.CouponIssueSummaryResponse;
+import me.bombom.api.v1.coupon.service.CouponService;
+import me.bombom.api.v1.member.domain.Member;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupon")
+public class CouponController implements CouponControllerApi {
+
+    private final CouponService couponService;
+
+    @Override
+    @GetMapping("issues/me")
+    public List<CouponIssueSummaryResponse> getIssuedCoupons(@LoginMember Member member) {
+        return couponService.getIssuedCoupons(member);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/controller/CouponController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/controller/CouponController.java
@@ -5,8 +5,6 @@ import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.coupon.dto.CouponIssueSummaryResponse;
 import me.bombom.api.v1.coupon.service.CouponService;
-import me.bombom.api.v1.member.domain.Member;
-import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,7 +18,7 @@ public class CouponController implements CouponControllerApi {
 
     @Override
     @GetMapping("issues/me")
-    public List<CouponIssueSummaryResponse> getIssuedCoupons(@LoginMember Member member) {
-        return couponService.getIssuedCoupons(member);
+    public List<CouponIssueSummaryResponse> getIssuedCoupons(@LoginMember Long memberId) {
+        return couponService.getIssuedCoupons(memberId);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/controller/CouponControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/controller/CouponControllerApi.java
@@ -1,13 +1,12 @@
 package me.bombom.api.v1.coupon.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import me.bombom.api.v1.coupon.dto.CouponIssueSummaryResponse;
-import me.bombom.api.v1.member.domain.Member;
 
 @Tag(name = "Coupon", description = "쿠폰 관련 API")
 public interface CouponControllerApi {
@@ -21,6 +20,6 @@ public interface CouponControllerApi {
             @ApiResponse(responseCode = "401", description = "인증이 필요합니다.")
     })
     List<CouponIssueSummaryResponse> getIssuedCoupons(
-            @Parameter(hidden = true) Member member
+            @Parameter(hidden = true) Long memberId
     );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/controller/CouponControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/controller/CouponControllerApi.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.coupon.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.Parameter;
+import java.util.List;
+import me.bombom.api.v1.coupon.dto.CouponIssueSummaryResponse;
+import me.bombom.api.v1.member.domain.Member;
+
+@Tag(name = "Coupon", description = "쿠폰 관련 API")
+public interface CouponControllerApi {
+
+    @Operation(
+            summary = "내가 받은 쿠폰 목록 조회",
+            description = "로그인한 사용자가 발급받은 쿠폰 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "쿠폰 목록 조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증이 필요합니다.")
+    })
+    List<CouponIssueSummaryResponse> getIssuedCoupons(
+            @Parameter(hidden = true) Member member
+    );
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/domain/CouponIssue.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/domain/CouponIssue.java
@@ -1,0 +1,60 @@
+package me.bombom.api.v1.coupon.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = {@UniqueConstraint(columnNames = {"member_id", "coupon_name"})}
+)
+public class CouponIssue extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long memberId;
+
+    @Column(nullable = false, length = 100)
+    private String couponName;
+
+    @Column(nullable = false, length = 2048)
+    private String imageUrl;
+
+    @Builder
+    public CouponIssue(Long id, Long memberId, @NonNull String couponName, @NonNull String imageUrl) {
+        this.id = id;
+        this.memberId = memberId;
+        this.couponName = couponName;
+        this.imageUrl = imageUrl;
+    }
+
+    public static CouponIssue of(Long memberId, String couponName, String imageUrl) {
+        return CouponIssue.builder()
+                .memberId(memberId)
+                .couponName(couponName)
+                .imageUrl(imageUrl)
+                .build();
+    }
+
+    public static CouponIssue preIssue(String couponName, String imageUrl) {
+        return CouponIssue.builder()
+                .memberId(null)
+                .couponName(couponName)
+                .imageUrl(imageUrl)
+                .build();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/domain/CouponIssue.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/domain/CouponIssue.java
@@ -35,7 +35,12 @@ public class CouponIssue extends BaseEntity {
     private String imageUrl;
 
     @Builder
-    public CouponIssue(Long id, Long memberId, @NonNull String couponName, @NonNull String imageUrl) {
+    public CouponIssue(
+            Long id,
+            Long memberId,
+            @NonNull String couponName,
+            @NonNull String imageUrl
+    ) {
         this.id = id;
         this.memberId = memberId;
         this.couponName = couponName;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/domain/CouponIssue.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/domain/CouponIssue.java
@@ -54,12 +54,4 @@ public class CouponIssue extends BaseEntity {
                 .imageUrl(imageUrl)
                 .build();
     }
-
-    public static CouponIssue preIssue(String couponName, String imageUrl) {
-        return CouponIssue.builder()
-                .memberId(null)
-                .couponName(couponName)
-                .imageUrl(imageUrl)
-                .build();
-    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/dto/CouponIssueSummaryResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/dto/CouponIssueSummaryResponse.java
@@ -1,0 +1,20 @@
+package me.bombom.api.v1.coupon.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record CouponIssueSummaryResponse(
+
+        @NotNull
+        String couponName,
+
+        @NotNull
+        String imageUrl,
+
+        @NotNull
+        LocalDateTime issuedAt
+) {
+    public static CouponIssueSummaryResponse of(String couponName, String imageUrl, LocalDateTime issuedAt) {
+        return new CouponIssueSummaryResponse(couponName, imageUrl, issuedAt);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/dto/CouponIssueSummaryResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/dto/CouponIssueSummaryResponse.java
@@ -2,6 +2,8 @@ package me.bombom.api.v1.coupon.dto;
 
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.List;
+import me.bombom.api.v1.coupon.domain.CouponIssue;
 
 public record CouponIssueSummaryResponse(
 
@@ -14,7 +16,17 @@ public record CouponIssueSummaryResponse(
         @NotNull
         LocalDateTime issuedAt
 ) {
-    public static CouponIssueSummaryResponse of(String couponName, String imageUrl, LocalDateTime issuedAt) {
-        return new CouponIssueSummaryResponse(couponName, imageUrl, issuedAt);
+    public static CouponIssueSummaryResponse of(CouponIssue issue) {
+        return new CouponIssueSummaryResponse(
+                issue.getCouponName(),
+                issue.getImageUrl(),
+                issue.getUpdatedAt()
+        );
+    }
+
+    public static List<CouponIssueSummaryResponse> of(List<CouponIssue> issues) {
+        return issues.stream()
+                .map(CouponIssueSummaryResponse::of)
+                .toList();
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/repository/CouponIssueRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/repository/CouponIssueRepository.java
@@ -1,0 +1,10 @@
+package me.bombom.api.v1.coupon.repository;
+
+import java.util.List;
+import me.bombom.api.v1.coupon.domain.CouponIssue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponIssueRepository extends JpaRepository<CouponIssue, Long> {
+
+    List<CouponIssue> findByMemberId(Long id);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/service/CouponService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/service/CouponService.java
@@ -1,0 +1,28 @@
+package me.bombom.api.v1.coupon.service;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.coupon.dto.CouponIssueSummaryResponse;
+import me.bombom.api.v1.coupon.repository.CouponIssueRepository;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CouponService {
+
+    private final CouponIssueRepository couponIssueRepository;
+
+    public List<CouponIssueSummaryResponse> getIssuedCoupons(Member member) {
+        return couponIssueRepository.findByMemberId(member.getId())
+                .stream()
+                .map(issue -> CouponIssueSummaryResponse.of(
+                        issue.getCouponName(),
+                        issue.getImageUrl(),
+                        issue.getUpdatedAt())
+                )
+                .toList();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/service/CouponService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/service/CouponService.java
@@ -15,13 +15,6 @@ public class CouponService {
     private final CouponIssueRepository couponIssueRepository;
 
     public List<CouponIssueSummaryResponse> getIssuedCoupons(Long memberId) {
-        return couponIssueRepository.findByMemberId(memberId)
-                .stream()
-                .map(issue -> CouponIssueSummaryResponse.of(
-                        issue.getCouponName(),
-                        issue.getImageUrl(),
-                        issue.getUpdatedAt())
-                )
-                .toList();
+        return CouponIssueSummaryResponse.of(couponIssueRepository.findByMemberId(memberId));
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/service/CouponService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/coupon/service/CouponService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.coupon.dto.CouponIssueSummaryResponse;
 import me.bombom.api.v1.coupon.repository.CouponIssueRepository;
-import me.bombom.api.v1.member.domain.Member;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,8 +14,8 @@ public class CouponService {
 
     private final CouponIssueRepository couponIssueRepository;
 
-    public List<CouponIssueSummaryResponse> getIssuedCoupons(Member member) {
-        return couponIssueRepository.findByMemberId(member.getId())
+    public List<CouponIssueSummaryResponse> getIssuedCoupons(Long memberId) {
+        return couponIssueRepository.findByMemberId(memberId)
                 .stream()
                 .map(issue -> CouponIssueSummaryResponse.of(
                         issue.getCouponName(),

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/coupon/controller/CouponControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/coupon/controller/CouponControllerTest.java
@@ -1,0 +1,107 @@
+package me.bombom.api.v1.coupon.controller;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.auth.handler.OAuth2LoginSuccessHandler;
+import me.bombom.api.v1.coupon.domain.CouponIssue;
+import me.bombom.api.v1.coupon.repository.CouponIssueRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class CouponControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CouponIssueRepository couponIssueRepository;
+
+    @MockitoBean
+    private OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+
+    private Member member;
+    private OAuth2AuthenticationToken authToken;
+
+    @BeforeEach
+    void setUp() {
+        couponIssueRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        member = TestFixture.normalMemberFixture();
+        memberRepository.save(member);
+
+        CouponIssue coupon1 = CouponIssue.of(
+                member.getId(),
+                "쿠폰A",
+                "https://cdn.bombom.me/coupon-a.png"
+        );
+        CouponIssue coupon2 = CouponIssue.of(
+                member.getId(),
+                "쿠폰B",
+                "https://cdn.bombom.me/coupon-b.png"
+        );
+        couponIssueRepository.save(coupon1);
+        couponIssueRepository.save(coupon2);
+
+        Map<String, Object> attributes = Map.of(
+                "id", member.getId().toString(),
+                "email", member.getEmail(),
+                "name", member.getNickname()
+        );
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(attributes, member, null, null);
+
+        authToken = new OAuth2AuthenticationToken(
+                customOAuth2User,
+                customOAuth2User.getAuthorities(),
+                "registrationId"
+        );
+    }
+
+    @Test
+    void 내가_받은_쿠폰_목록_조회_성공() throws Exception {
+        // when & then
+        mockMvc.perform(get("/api/v1/coupon/issues/me")
+                        .with(authentication(authToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[*].couponName").value(containsInAnyOrder("쿠폰A", "쿠폰B")))
+                .andExpect(jsonPath("$[*].imageUrl").value(containsInAnyOrder(
+                        "https://cdn.bombom.me/coupon-a.png",
+                        "https://cdn.bombom.me/coupon-b.png"
+                )))
+                .andExpect(jsonPath("$[*].issuedAt").isNotEmpty());
+    }
+
+    @Test
+    void 내가_받은_쿠폰이_없으면_빈배열_반환() throws Exception {
+        // given
+        couponIssueRepository.deleteAllInBatch();
+
+        // when & then
+        mockMvc.perform(get("/api/v1/coupon/issues/me")
+                        .with(authentication(authToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 이벤트 서버는 수요일 이후 종료되기에 이벤트 서버에있는 쿠폰 발급 내역 조회 API를 운영서버로 옮겨왔습니다.
- 이미 당첨되신 분들 쿠폰 재조회와 공유하기 이벤트 당첨되신 분들이 쿠폰을 조회하기 위해 필요합니다. 
- 위치는 마이페이지 > 선물함에 배치될 예정입니다.  

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- server-dev / PROD에는 내가 받은 쿠폰 조회 API 경로가 없었고, 도메인/저장소/서비스/컨트롤러/문서/테스트가 한 덩어리로 갖춰진 구현 단위가 필요했음

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 단순 쿠폰 조회입니다. 

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 단순 구현이라 전체를 빠르게 보실 수 있습니다. 
- 앞으로 선착순 이벤트나 경품 추첨 이벤트를 할 때 이용될 것 같습니다. 