### PR TITLE
[BOM-992] chore: 비동기 스레드풀 모니터링 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/AsyncConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/AsyncConfig.java
@@ -11,11 +11,11 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class AsyncConfig {
 
     @Bean(name = "taskExecutor")
-    public Executor taskExecutor() {
+    public Executor taskExecutor(AsyncExecutorProperties props) {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
-        executor.setCorePoolSize(1); // 기본 1개
-        executor.setMaxPoolSize(3); // 최대 3개
-        executor.setQueueCapacity(50); // 큐 50개
+        executor.setCorePoolSize(props.getCorePoolSize());
+        executor.setMaxPoolSize(props.getMaxPoolSize());
+        executor.setQueueCapacity(props.getQueueCapacity());
         executor.setThreadNamePrefix("async-");
         executor.setWaitForTasksToCompleteOnShutdown(true);
         executor.setAwaitTerminationSeconds(60);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/AsyncExecutorProperties.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/AsyncExecutorProperties.java
@@ -1,0 +1,17 @@
+package me.bombom.api.v1.common.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties("async.executor")
+public class AsyncExecutorProperties {
+
+    private int corePoolSize = 1; // 유지할 기본 스레드 수
+    private int maxPoolSize = 3;  // 큐 초과 시 늘어날 최대 스레드 수
+    private int queueCapacity = 50; // 대기 큐 용량 (작업이 쌓일 수 있는 개수)
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/ExecutorMetricsBinder.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/ExecutorMetricsBinder.java
@@ -1,0 +1,25 @@
+package me.bombom.api.v1.common.config;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.jvm.ExecutorServiceMetrics;
+import java.util.concurrent.Executor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExecutorMetricsBinder implements MeterBinder {
+
+    private final ThreadPoolTaskExecutor taskExecutor;
+
+    public ExecutorMetricsBinder(@Qualifier("taskExecutor") Executor taskExecutor) {
+        this.taskExecutor = (ThreadPoolTaskExecutor) taskExecutor;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        ExecutorServiceMetrics.monitor(registry, taskExecutor.getThreadPoolExecutor(), "defaultAsync", Tags.empty());
+    }
+}


### PR DESCRIPTION
## 📌 What
- 비동기 스레드풀(`taskExecutor`) 설정값을 코드에서 분리해 설정 파일(`async.executor.*`)로 관리하도록 변경
- Micrometer를 활용해 비동기 스레드풀 메트릭을 Prometheus/Actuator에 노출

## ❓ Why
- 스레드풀 설정(corePoolSize, maxPoolSize, queueCapacity)이 하드코딩되어 있어 환경별로 유연하게 조정하기 어려웠음
- 스레드풀 상태(활성 스레드 수, 큐 적재량 등)를 모니터링할 수 없어 장애 대응 및 성능 튜닝이 어려웠음

## 🔧 How
- `AsyncExecutorProperties` 클래스를 추가해 `@ConfigurationProperties("async.executor")`로 설정값 바인딩
- `AsyncConfig`에서 하드코딩된 값 대신 `AsyncExecutorProperties`를 주입받아 스레드풀 구성
- `ExecutorMetricsBinder` 컴포넌트를 추가해 `ExecutorServiceMetrics.monitor()`로 `defaultAsync` 이름의 메트릭 등록

## 👀 Review Point (Optional)