### PR TITLE
[BOM-995] feat: 팀 평균 달성률을 전체 기간 단위에서 하루 단위로 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/TeamTodayProgressCount.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/TeamTodayProgressCount.java
@@ -1,0 +1,8 @@
+package me.bombom.api.v1.challenge.dto;
+
+public record TeamTodayProgressCount(
+
+        long survivedCount,
+        long completedTodayCount
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListener.java
@@ -10,7 +10,6 @@ import me.bombom.api.v1.challenge.service.ChallengeTeamService;
 import me.bombom.api.v1.challenge.service.ChallengeTodoService;
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,7 +40,7 @@ public class CreateChallengeCommentListener {
         ChallengeParticipant participant = challengeParticipantService.getParticipant(event.participantId());
         completeDailyTodoWithComment(participant, today);
 
-        ChallengeTeam challengeTeam = challengeTeamService.getChallengeTeamByParticipant(participant);
+        ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
         challengeTeamService.updateTeamProgress(challengeTeam);
 
         log.info("챌린지 코멘트 작성 후 출석 처리 완료");

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -3,10 +3,12 @@ package me.bombom.api.v1.challenge.repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.dto.ChallengeParticipantCount;
 import me.bombom.api.v1.challenge.dto.ChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
+import me.bombom.api.v1.challenge.dto.TeamTodayProgressCount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,7 +19,23 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
     
     Optional<ChallengeParticipant> findByChallengeIdAndMemberId(Long challengeId, Long memberId);
 
-    List<ChallengeParticipant> findAllByChallengeTeamId(Long challengeTeamId);
+    @Query("""
+        SELECT new me.bombom.api.v1.challenge.dto.TeamTodayProgressCount(
+            COUNT(cp.id),
+            COUNT(cdr.id)
+        )
+        FROM ChallengeParticipant cp
+        LEFT JOIN ChallengeDailyResult cdr ON cdr.participantId = cp.id
+            AND cdr.date = :today
+            AND cdr.status = :status
+        WHERE cp.challengeTeamId = :teamId
+            AND cp.isSurvived = true
+    """)
+    TeamTodayProgressCount findTeamTodayProgressCount(
+            @Param("teamId") Long teamId,
+            @Param("today") LocalDate today,
+            @Param("status") ChallengeDailyStatus status
+    );
 
     @Query("""
         SELECT new me.bombom.api.v1.challenge.dto.ChallengeParticipantCount(p.challengeId, COUNT(p.id))

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
@@ -15,7 +15,7 @@ public interface ChallengeTeamRepository extends JpaRepository<ChallengeTeam, Lo
         WHERE ct.challengeId = :challengeId
         ORDER BY ct.id
     """)
-    List<ChallengeTeam> findAllByChallengeIdOrderByIdAsc(@Param("challengeId") Long challengeId);
+    List<ChallengeTeam> findAllByChallengeIdOrderById(@Param("challengeId") Long challengeId);
 
     @Modifying
     @Query("""

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.challenge.repository;
 import java.util.List;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,4 +16,12 @@ public interface ChallengeTeamRepository extends JpaRepository<ChallengeTeam, Lo
         ORDER BY ct.id
     """)
     List<ChallengeTeam> findAllByChallengeIdOrderByIdAsc(@Param("challengeId") Long challengeId);
+
+    @Modifying
+    @Query("""
+        UPDATE ChallengeTeam ct
+        SET ct.progress = 0
+        WHERE ct.challengeId IN :challengeIds
+    """)
+    void resetProgressByChallengeIdIn(@Param("challengeIds") List<Long> challengeIds);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
@@ -10,6 +10,7 @@ import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderPhase
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
 import me.bombom.api.v1.challenge.service.ChallengeService;
 import me.bombom.api.v1.challenge.service.ChallengeStartNotificationService;
+import me.bombom.api.v1.challenge.service.ChallengeTeamService;
 import me.bombom.api.v1.challenge.service.ChallengeTodoReminderNotificationService;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -26,6 +27,7 @@ public class ChallengeScheduler {
     private final Clock clock;
     private final ChallengeService challengeService;
     private final ChallengeProgressService challengeProgressService;
+    private final ChallengeTeamService challengeTeamService;
     private final ChallengeStartNotificationService challengeStartNotificationService;
     private final ChallengeTodoReminderNotificationService challengeTodoReminderNotificationService;
 
@@ -66,6 +68,20 @@ public class ChallengeScheduler {
         }
 
         log.info("챌린지 종료 처리 및 뱃지 발급 완료");
+    }
+
+    @Scheduled(cron = DAILY_CRON, zone = "Asia/Seoul")
+    @SchedulerLock(name = "reset_team_progress", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
+    public void resetTeamProgress() {
+        LocalDate today = LocalDate.now(clock);
+        log.info("팀 평균 달성률 초기화 시작 - date={}", today);
+        List<Challenge> ongoingChallenges = challengeService.getOngoingChallenges(today);
+
+        try {
+            challengeTeamService.resetTeamsProgress(ongoingChallenges);
+        } catch (Exception e) {
+            log.error("팀 평균 달성률 초기화 중 오류 발생 - date={}", today, e);
+        }
     }
 
     @Scheduled(cron = CHALLENGE_START_NOTIFICATION_CRON, zone = "Asia/Seoul")

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
@@ -23,6 +23,7 @@ public class ChallengeScheduler {
 
     private static final String DAILY_CRON = "0 0 0 * * *";
     private static final String CHALLENGE_START_NOTIFICATION_CRON = "0 10 3 * * *";
+    private static final String SEOUL_TIMEZONE = "Asia/Seoul";
 
     private final Clock clock;
     private final ChallengeService challengeService;
@@ -31,7 +32,7 @@ public class ChallengeScheduler {
     private final ChallengeStartNotificationService challengeStartNotificationService;
     private final ChallengeTodoReminderNotificationService challengeTodoReminderNotificationService;
 
-    @Scheduled(cron = DAILY_CRON)
+    @Scheduled(cron = DAILY_CRON, zone = SEOUL_TIMEZONE)
     @SchedulerLock(name = "check_survival", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void checkSurvival() {
         log.info("탈락 및 쉴드 사용 처리 시작");
@@ -47,7 +48,7 @@ public class ChallengeScheduler {
         }
     }
 
-    @Scheduled(cron = DAILY_CRON)
+    @Scheduled(cron = DAILY_CRON, zone = SEOUL_TIMEZONE)
     @SchedulerLock(name = "process_ended_challenges", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void processEndedChallenges() {
         log.info("챌린지 종료 처리 및 뱃지 발급 시작");
@@ -70,7 +71,7 @@ public class ChallengeScheduler {
         log.info("챌린지 종료 처리 및 뱃지 발급 완료");
     }
 
-    @Scheduled(cron = DAILY_CRON, zone = "Asia/Seoul")
+    @Scheduled(cron = DAILY_CRON, zone = SEOUL_TIMEZONE)
     @SchedulerLock(name = "reset_team_progress", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void resetTeamProgress() {
         LocalDate today = LocalDate.now(clock);
@@ -84,7 +85,7 @@ public class ChallengeScheduler {
         }
     }
 
-    @Scheduled(cron = CHALLENGE_START_NOTIFICATION_CRON, zone = "Asia/Seoul")
+    @Scheduled(cron = CHALLENGE_START_NOTIFICATION_CRON, zone = SEOUL_TIMEZONE)
     @SchedulerLock(name = "create_challenge_start_notifications", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void createChallengeStartNotifications() {
         LocalDate today = LocalDate.now(clock);
@@ -97,7 +98,7 @@ public class ChallengeScheduler {
         }
     }
 
-    @Scheduled(cron = "${challenge.scheduler.todo-reminder-first-cron}", zone = "Asia/Seoul")
+    @Scheduled(cron = "${challenge.scheduler.todo-reminder-first-cron}", zone = SEOUL_TIMEZONE)
     @SchedulerLock(name = "create_challenge_todo_reminder_notifications_first", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void createChallengeTodoReminderNotificationsFirst() {
         LocalDate today = LocalDate.now(clock);
@@ -111,7 +112,7 @@ public class ChallengeScheduler {
         }
     }
 
-    @Scheduled(cron = "${challenge.scheduler.todo-reminder-second-cron}", zone = "Asia/Seoul")
+    @Scheduled(cron = "${challenge.scheduler.todo-reminder-second-cron}", zone = SEOUL_TIMEZONE)
     @SchedulerLock(name = "create_challenge_todo_reminder_notifications_second", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void createChallengeTodoReminderNotificationsSecond() {
         LocalDate today = LocalDate.now(clock);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -159,7 +159,7 @@ public class ChallengeDailyGuideService {
             if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
                 challengeTodoService.completeDailyTodo(participant, today);
                 if (participant.getChallengeTeamId() != null) {
-                    ChallengeTeam challengeTeam = challengeTeamService.getChallengeTeamByParticipant(participant);
+                    ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
                     challengeTeamService.updateTeamProgress(challengeTeam);
                 }
             }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -18,10 +18,10 @@ import me.bombom.api.v1.badge.service.BadgeService;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeGrade;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
-import me.bombom.api.v1.challenge.domain.RegistrationPhase;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.domain.EligibilityReason;
+import me.bombom.api.v1.challenge.domain.RegistrationPhase;
 import me.bombom.api.v1.challenge.dto.ChallengeNewsletterRow;
 import me.bombom.api.v1.challenge.dto.ChallengeParticipantCount;
 import me.bombom.api.v1.challenge.dto.response.ChallengeDetailResponse;
@@ -35,13 +35,13 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeTeamRepository;
-import me.bombom.api.v1.newsletter.repository.NewsletterGroupItemRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.newsletter.repository.NewsletterGroupItemRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -203,7 +203,7 @@ public class ChallengeService {
                 .map(ChallengeParticipant::getChallengeTeamId)
                 .orElse(null);
 
-        List<ChallengeTeam> teams = challengeTeamRepository.findAllByChallengeIdOrderByIdAsc(challengeId);
+        List<ChallengeTeam> teams = challengeTeamRepository.findAllByChallengeIdOrderById(challengeId);
 
         List<ChallengeTeamListResponse.TeamInfoResponse> teamInfos = new ArrayList<>(teams.size());
         int teamNumber = 1;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
@@ -37,6 +37,7 @@ public class ChallengeTeamService {
 
         int averageProgress = calculateTodayAverageProgress(progressCount);
         challengeTeam.updateProgress(averageProgress);
+        challengeTeamRepository.save(challengeTeam);
     }
 
     public ChallengeTeam getChallengeTeamByParticipant(ChallengeParticipant participant){

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
@@ -49,6 +49,10 @@ public class ChallengeTeamService {
 
     @Transactional
     public void resetTeamsProgress(List<Challenge> ongoingChallenges) {
+        if (ongoingChallenges.isEmpty()) {
+            return;
+        }
+
         List<Long> challengeIds = ongoingChallenges.stream()
                 .map(Challenge::getId)
                 .toList();

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
@@ -3,7 +3,9 @@ package me.bombom.api.v1.challenge.service;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
@@ -43,6 +45,14 @@ public class ChallengeTeamService {
                         .addContext(ErrorContextKeys.CHALLENGE_TEAM_ID, participant.getChallengeTeamId())
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeTeam")
                         .addContext(ErrorContextKeys.OPERATION, "findById"));
+    }
+
+    @Transactional
+    public void resetTeamsProgress(List<Challenge> ongoingChallenges) {
+        List<Long> challengeIds = ongoingChallenges.stream()
+                .map(Challenge::getId)
+                .toList();
+        challengeTeamRepository.resetProgressByChallengeIdIn(challengeIds);
     }
 
     private int calculateTodayAverageProgress(TeamTodayProgressCount progressCount) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
@@ -1,13 +1,14 @@
 package me.bombom.api.v1.challenge.service;
 
 
-import java.util.List;
+import java.time.Clock;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
+import me.bombom.api.v1.challenge.dto.TeamTodayProgressCount;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
-import me.bombom.api.v1.challenge.repository.ChallengeRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeTeamRepository;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
@@ -20,24 +21,19 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ChallengeTeamService {
 
-    private final ChallengeRepository challengeRepository;
     private final ChallengeTeamRepository challengeTeamRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
+    private final Clock clock;
 
     @Transactional
     public void updateTeamProgress(ChallengeTeam challengeTeam) {
-        Challenge challenge = challengeRepository.findById(challengeTeam.getChallengeId())
-                .orElseThrow(() -> new CServerErrorException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeTeam.getChallengeId()));
+        TeamTodayProgressCount progressCount = challengeParticipantRepository.findTeamTodayProgressCount(
+                challengeTeam.getId(),
+                LocalDate.now(clock),
+                ChallengeDailyStatus.COMPLETE
+        );
 
-        List<ChallengeParticipant> teamParticipants = challengeParticipantRepository.findAllByChallengeTeamId(challengeTeam.getId());
-        if (teamParticipants.isEmpty()) {
-            throw new CServerErrorException(ErrorDetail.ENTITY_NOT_FOUND)
-                    .addContext(ErrorContextKeys.CHALLENGE_TEAM_ID, challengeTeam.getId())
-                    .addContext(ErrorContextKeys.OPERATION, "findAllByChallengeTeamId");
-        }
-
-        int averageProgress = calculateAverageProgress(teamParticipants, challenge.getTotalDays());
+        int averageProgress = calculateTodayAverageProgress(progressCount);
         challengeTeam.updateProgress(averageProgress);
     }
 
@@ -49,10 +45,11 @@ public class ChallengeTeamService {
                         .addContext(ErrorContextKeys.OPERATION, "findById"));
     }
 
-    private int calculateAverageProgress(List<ChallengeParticipant> participants, int totalDays) {
-        int totalProgress = participants.stream()
-                .mapToInt(teamMember -> teamMember.calculateProgress(totalDays))
-                .sum();
-        return totalProgress / participants.size();
+    private int calculateTodayAverageProgress(TeamTodayProgressCount progressCount) {
+        if (progressCount.survivedCount() == 0) {
+            return 0;
+        }
+
+        return (int) (progressCount.completedTodayCount() * 100 / progressCount.survivedCount());
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTeamService.java
@@ -40,7 +40,7 @@ public class ChallengeTeamService {
         challengeTeamRepository.save(challengeTeam);
     }
 
-    public ChallengeTeam getChallengeTeamByParticipant(ChallengeParticipant participant){
+    public ChallengeTeam getByParticipant(ChallengeParticipant participant){
         return challengeTeamRepository.findById(participant.getChallengeTeamId())
                 .orElseThrow(() -> new CServerErrorException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.CHALLENGE_TEAM_ID, participant.getChallengeTeamId())

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -10,6 +10,8 @@ import me.bombom.api.v1.challenge.domain.ChallengeComment;
 import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
@@ -661,6 +663,39 @@ public final class TestFixture {
                 .challengeTeamId(challengeTeamId)
                 .completedDays(completedDays)
                 .shield(shield)
+                .build();
+    }
+
+    public static ChallengeParticipant createChallengeParticipantWithTeam(
+            Long challengeId,
+            Long memberId,
+            Long challengeTeamId,
+            int completedDays,
+            int shield,
+            boolean isSurvived
+    ) {
+        return ChallengeParticipant.builder()
+                .challengeId(challengeId)
+                .memberId(memberId)
+                .challengeTeamId(challengeTeamId)
+                .completedDays(completedDays)
+                .shield(shield)
+                .isSurvived(isSurvived)
+                .build();
+    }
+
+    /**
+     * ChallengeDailyResult
+     */
+    public static ChallengeDailyResult createChallengeDailyResult(
+            Long participantId,
+            LocalDate date,
+            ChallengeDailyStatus status
+    ) {
+        return ChallengeDailyResult.builder()
+                .participantId(participantId)
+                .date(date)
+                .status(status)
                 .build();
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -663,6 +663,7 @@ public final class TestFixture {
                 .challengeTeamId(challengeTeamId)
                 .completedDays(completedDays)
                 .shield(shield)
+                .isSurvived(true)
                 .build();
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListenerTest.java
@@ -133,7 +133,7 @@ class CreateChallengeCommentListenerTest {
                     today
             )).isTrue();
             softly.assertThat(updated.getCompletedDays()).isEqualTo(1);
-            softly.assertThat(updatedTeam.getProgress()).isEqualTo(30); // (1/10*100 + 5/10*100) / 2 = 30
+            softly.assertThat(updatedTeam.getProgress()).isEqualTo(50); // 오늘 COMPLETE 1명 / 생존자 2명 * 100 = 50
         });
     }
 
@@ -162,7 +162,7 @@ class CreateChallengeCommentListenerTest {
                     today
             )).isTrue();
             softly.assertThat(updated.getCompletedDays()).isEqualTo(completedDays);
-            softly.assertThat(updatedTeam.getProgress()).isEqualTo(30);
+            softly.assertThat(updatedTeam.getProgress()).isEqualTo(50); // 두 번째 호출은 early return → 첫 번째 결과(50) 유지
         });
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTeamServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTeamServiceTest.java
@@ -1,0 +1,208 @@
+package me.bombom.api.v1.challenge.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.ChallengeTeam;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeTeamRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterGroupRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+class ChallengeTeamServiceTest {
+
+    @Autowired
+    private ChallengeTeamService challengeTeamService;
+
+    @Autowired
+    private ChallengeTeamRepository challengeTeamRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ChallengeDailyResultRepository challengeDailyResultRepository;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private NewsletterGroupRepository newsletterGroupRepository;
+
+    private Challenge challenge;
+    private ChallengeTeam team;
+
+    @BeforeEach
+    void setUp() {
+        challengeDailyResultRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeTeamRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        newsletterGroupRepository.deleteAllInBatch();
+
+        var group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("테스트 그룹"));
+        challenge = challengeRepository.save(TestFixture.createChallenge(
+                "테스트 챌린지",
+                LocalDate.now().minusDays(5),
+                LocalDate.now().plusDays(5),
+                10,
+                group.getId()
+        ));
+        team = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 0));
+    }
+
+    @Test
+    void 오늘_COMPLETE_인증자_비율로_팀_평균_달성률을_계산한다() {
+        // given: 생존자 3명 중 2명이 오늘 COMPLETE
+        LocalDate today = LocalDate.now();
+        ChallengeParticipant p1 = challengeParticipantRepository.save(createSurvivedParticipant());
+        ChallengeParticipant p2 = challengeParticipantRepository.save(createSurvivedParticipant());
+        ChallengeParticipant p3 = challengeParticipantRepository.save(createSurvivedParticipant());
+
+        challengeDailyResultRepository.saveAll(List.of(
+                TestFixture.createChallengeDailyResult(p1.getId(), today, ChallengeDailyStatus.COMPLETE),
+                TestFixture.createChallengeDailyResult(p2.getId(), today, ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when
+        challengeTeamService.updateTeamProgress(team);
+
+        // then: 2/3 * 100 = 66
+        ChallengeTeam updated = challengeTeamRepository.findById(team.getId()).orElseThrow();
+        assertThat(updated.getProgress()).isEqualTo(66);
+    }
+
+    @Test
+    void 탈락자는_팀_평균_달성률_계산에서_제외된다() {
+        // given: 생존자 2명 + 탈락자 1명, 생존자 중 1명만 오늘 COMPLETE
+        LocalDate today = LocalDate.now();
+        ChallengeParticipant survived1 = challengeParticipantRepository.save(createSurvivedParticipant());
+        ChallengeParticipant survived2 = challengeParticipantRepository.save(createSurvivedParticipant());
+        challengeParticipantRepository.save(createEliminatedParticipant());
+
+        challengeDailyResultRepository.save(TestFixture.createChallengeDailyResult(survived1.getId(), today, ChallengeDailyStatus.COMPLETE));
+
+        // when
+        challengeTeamService.updateTeamProgress(team);
+
+        // then: 1/2 * 100 = 50 (탈락자 제외)
+        ChallengeTeam updated = challengeTeamRepository.findById(team.getId()).orElseThrow();
+        assertThat(updated.getProgress()).isEqualTo(50);
+    }
+
+    @Test
+    void SHIELD_인증은_팀_평균_달성률에_포함되지_않는다() {
+        // given: 생존자 2명, 1명 COMPLETE, 1명 SHIELD
+        LocalDate today = LocalDate.now();
+        ChallengeParticipant p1 = challengeParticipantRepository.save(createSurvivedParticipant());
+        ChallengeParticipant p2 = challengeParticipantRepository.save(createSurvivedParticipant());
+
+        challengeDailyResultRepository.saveAll(List.of(
+                TestFixture.createChallengeDailyResult(p1.getId(), today, ChallengeDailyStatus.COMPLETE),
+                TestFixture.createChallengeDailyResult(p2.getId(), today, ChallengeDailyStatus.SHIELD)
+        ));
+
+        // when
+        challengeTeamService.updateTeamProgress(team);
+
+        // then: 1/2 * 100 = 50
+        ChallengeTeam updated = challengeTeamRepository.findById(team.getId()).orElseThrow();
+        assertThat(updated.getProgress()).isEqualTo(50);
+    }
+
+    @Test
+    void 생존자가_없으면_팀_평균_달성률은_0이다() {
+        // given: 전원 탈락
+        challengeParticipantRepository.save(createEliminatedParticipant());
+        challengeParticipantRepository.save(createEliminatedParticipant());
+
+        // when
+        challengeTeamService.updateTeamProgress(team);
+
+        // then
+        ChallengeTeam updated = challengeTeamRepository.findById(team.getId()).orElseThrow();
+        assertThat(updated.getProgress()).isEqualTo(0);
+    }
+
+    @Test
+    void 진행_중인_챌린지_팀의_달성률을_0으로_초기화한다() {
+        // given
+        ChallengeTeam team1 = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 100));
+        ChallengeTeam team2 = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 75));
+
+        // when
+        challengeTeamService.resetTeamsProgress(List.of(challenge));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(challengeTeamRepository.findById(team1.getId()).orElseThrow().getProgress()).isEqualTo(0);
+            softly.assertThat(challengeTeamRepository.findById(team2.getId()).orElseThrow().getProgress()).isEqualTo(0);
+        });
+    }
+
+    @Test
+    void 진행_중인_챌린지가_없으면_초기화를_건너뛴다() {
+        // given
+        ChallengeTeam existingTeam = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 50));
+
+        // when
+        challengeTeamService.resetTeamsProgress(List.of());
+
+        // then
+        ChallengeTeam unchanged = challengeTeamRepository.findById(existingTeam.getId()).orElseThrow();
+        assertThat(unchanged.getProgress()).isEqualTo(50);
+    }
+
+    private ChallengeParticipant createSurvivedParticipant() {
+        Member member = memberRepository.save(
+                TestFixture.createUniqueMember(
+                        UUID.randomUUID().toString().substring(0, 8),
+                        UUID.randomUUID().toString()
+                )
+        );
+        return TestFixture.createChallengeParticipantWithTeam(
+                challenge.getId(),
+                member.getId(),
+                team.getId(),
+                0,
+                0,
+                true
+        );
+    }
+
+    private ChallengeParticipant createEliminatedParticipant() {
+        Member member = memberRepository.save(
+                TestFixture.createUniqueMember(
+                        UUID.randomUUID().toString().substring(0, 8),
+                        UUID.randomUUID().toString()
+                )
+        );
+        return TestFixture.createChallengeParticipantWithTeam(
+                challenge.getId(),
+                member.getId(),
+                team.getId(),
+                0,
+                0,
+                false
+        );
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
팀 평균 달성률을 전체 기간 단위에서 하루 단위로 수정했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존 팀 평균 달성률은 전체 기간 대비 누적 완료일수 평균`(completedDays / totalDays * 100)`으로 계산되어, 팀원들이 오늘 얼마나 인증했는지를 직관적으로 파악하기 어려웠습니다. 또한, 탈락자로 인해 실질적으로 참고할만한 데이터가 아니라 판단했습니다.
하루 단위로 리셋되는 "오늘의 팀 달성률" 지표가  사용자 경험에 더 적합하다고 판단했습니다.  

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
-달성률 계산 방식 변경
  - 기존: `sum(completedDays) / (팀원 수 * totalDays) * 100`
  - 변경: `오늘 COMPLETE 완료 수 / 생존자 수 * 100 (탈락자 제외)`
- LEFT JOIN을 활용해 생존자 수와 오늘 COMPLETE 수를 한 번에 집계 (1회 쿼리)하도록 했습니다.
  자정 초기화 스케줄러 추가
  - 매일 자정 진행 중인 챌린지의 팀 평균 달성률을 0으로 초기화

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
