### PR TITLE
[BOM-1004] fix: 챌린지 TODO 완료 시에도 알림이 오는 버그 해결

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -124,20 +124,15 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
         FROM ChallengeParticipant cp
         WHERE cp.challengeId = :challengeId
           AND cp.isSurvived = true
-          AND EXISTS (
-              SELECT ct
-              FROM ChallengeTodo ct
-              WHERE ct.challengeId = cp.challengeId
-                AND NOT EXISTS (
-                    SELECT cdt
-                    FROM ChallengeDailyTodo cdt
-                    WHERE cdt.participantId = cp.id
-                      AND cdt.challengeTodoId = ct.id
-                      AND cdt.todoDate = :date
-                )
+          AND NOT EXISTS (
+              SELECT cdr
+              FROM ChallengeDailyResult cdr
+              WHERE cdr.participantId = cp.id
+                AND cdr.date = :date
+                AND cdr.status = 'COMPLETE'
           )
     """)
-    List<ChallengeParticipant> findSurvivedParticipantsWithIncompleteTodosByChallengeId(
+    List<ChallengeParticipant> findSurvivedParticipantsWithoutCompleteDailyResultByChallengeId(
             @Param("challengeId") Long challengeId,
             @Param("date") LocalDate date
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoReminderNotificationService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoReminderNotificationService.java
@@ -39,7 +39,7 @@ public class ChallengeTodoReminderNotificationService {
         for (Challenge challenge : ongoingChallenges) {
             try {
                 List<ChallengeParticipant> incompleteParticipants = challengeParticipantRepository
-                        .findSurvivedParticipantsWithIncompleteTodosByChallengeId(challenge.getId(), reminderDate);
+                        .findSurvivedParticipantsWithoutCompleteDailyResultByChallengeId(challenge.getId(), reminderDate);
 
                 if (incompleteParticipants.isEmpty()) {
                     log.info("미완료 참여자가 없는 챌린지입니다. challengeId={}, reminderDate={}",

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoReminderNotificationServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoReminderNotificationServiceTest.java
@@ -7,10 +7,12 @@ import java.time.LocalDate;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderPhase;
 import me.bombom.api.v1.challenge.domain.notification.ChallengeTodoReminderNotification;
 import me.bombom.api.v1.challenge.domain.notification.NotificationStatus;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeRepository;
@@ -38,6 +40,9 @@ class ChallengeTodoReminderNotificationServiceTest {
     private ChallengeDailyTodoRepository challengeDailyTodoRepository;
 
     @Autowired
+    private ChallengeDailyResultRepository challengeDailyResultRepository;
+
+    @Autowired
     private ChallengeTodoRepository challengeTodoRepository;
 
     @Autowired
@@ -55,6 +60,7 @@ class ChallengeTodoReminderNotificationServiceTest {
     @BeforeEach
     void setUp() {
         challengeTodoReminderNotificationRepository.deleteAllInBatch();
+        challengeDailyResultRepository.deleteAllInBatch();
         challengeDailyTodoRepository.deleteAllInBatch();
         challengeParticipantRepository.deleteAllInBatch();
         challengeTodoRepository.deleteAllInBatch();
@@ -64,7 +70,7 @@ class ChallengeTodoReminderNotificationServiceTest {
     }
 
     @Test
-    void 오늘_TODO가_미완료인_참여자에게만_PENDING_알림을_생성한다() {
+    void 오늘_COMPLETE_DailyResult가_없는_참여자에게만_PENDING_알림을_생성한다() {
         // given
         LocalDate today = LocalDate.now();
         NewsletterGroup group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("group"));
@@ -82,13 +88,13 @@ class ChallengeTodoReminderNotificationServiceTest {
         var participant3 = challengeParticipantRepository.save(
                 TestFixture.createChallengeParticipant(challenge.getId(), anotherIncompleteMember.getId(), 0));
 
-        var readTodo = challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ));
-        var commentTodo = challengeTodoRepository.save(
-                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.COMMENT));
+        challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ));
 
-        challengeDailyTodoRepository.save(TestFixture.createChallengeDailyTodo(participant2.getId(), today, readTodo.getId()));
-        challengeDailyTodoRepository.save(TestFixture.createChallengeDailyTodo(participant2.getId(), today, commentTodo.getId()));
-        challengeDailyTodoRepository.save(TestFixture.createChallengeDailyTodo(participant3.getId(), today, readTodo.getId()));
+        challengeDailyResultRepository.save(TestFixture.createChallengeDailyResult(
+                participant2.getId(),
+                today,
+                ChallengeDailyStatus.COMPLETE
+        ));
 
         // when
         challengeTodoReminderNotificationService.createPendingNotificationsForIncompleteTodos(today, ChallengeTodoReminderPhase.FIRST);


### PR DESCRIPTION
#### 당장 내일부터 알림이 전송되어야 하므로 이른 새벽 내로 merge 할 예정입니다!

## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 TODO를 완료해도 알림이 오는 오류를 해결합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 기존에는 당일에 ChallengeTodo들 중 없는 것이 있는 참여자들에 한해 알림을 전송했습니다.
- 하지만 첫 날의 MINDSET이 포함되어있어, 다른 날들에는 MINDSET이 완료되지 않았다는 판정으로 아티클을 읽고 코멘트를 작성했어도 알림이 전송됐습니다.
- 그래서 챌린지 TODO 미완료 알림 스케줄러 시 ChallengeDailyResult로 판단 조건을 수정했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
