### PR TITLE
[BOM-1005] feat: 챌린지 코멘트 작성 가능 후보를 오늘 도착한 아티클이 아닌 오늘 읽은 아티클로

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepository.java
@@ -125,9 +125,9 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, CustomA
         FROM Article a
         JOIN Newsletter n ON n.id = a.newsletterId
         WHERE a.memberId = :memberId
-          AND a.arrivedDateTime >= :start
-          AND a.arrivedDateTime < :end
-          AND a.isRead IS TRUE 
+          AND a.updatedAt >= :start
+          AND a.updatedAt < :end
+          AND a.isRead IS TRUE
         ORDER BY a.arrivedDateTime DESC
     """)
     List<ChallengeCommentCandidateArticleResponse> findChallengeCommentCandidateArticles(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
@@ -51,7 +51,7 @@ public interface ChallengeCommentControllerApi {
 
     @Operation(
             summary = "챌린지 코멘트 후보 아티클 조회",
-            description = "지정한 날짜에 도착한 아티클들 중 읽은 아티클들을 조회합니다."
+            description = "지정한 날짜에 읽은 아티클들을 조회합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "챌린지 코멘트 후보 아티클 조회 성공")

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeCommentServiceTest.java
@@ -43,9 +43,9 @@ import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.newsletter.domain.Category;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
 import me.bombom.api.v1.newsletter.domain.NewsletterDetail;
+import me.bombom.api.v1.newsletter.domain.NewsletterGroup;
 import me.bombom.api.v1.newsletter.repository.CategoryRepository;
 import me.bombom.api.v1.newsletter.repository.NewsletterDetailRepository;
-import me.bombom.api.v1.newsletter.domain.NewsletterGroup;
 import me.bombom.api.v1.newsletter.repository.NewsletterGroupRepository;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
 import me.bombom.support.IntegrationTest;
@@ -373,7 +373,7 @@ class ChallengeCommentServiceTest {
         otherArticle.markAsRead();
         articleRepository.save(otherArticle);
 
-        LocalDate targetDate = articles.get(0).getArrivedDateTime().toLocalDate();
+        LocalDate targetDate = LocalDate.now();
 
         // when
         List<ChallengeCommentCandidateArticleResponse> result =


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 코멘트 작성 가능 후보를 오늘 도착한 아티클이 아닌 오늘 읽은 아티클로 수정했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지의 자율성을 높이기 위해서.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
원래 arrived_date_time을 기준으로 당일인지 확인했던 것을 updated_at을 기준으로 확인하도록 수정했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
