### PR TITLE
[BOM-1007] feat: 둘러보기 페이지용 챌린지 조회 api

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
@@ -8,6 +8,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeLandingResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
+import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.challenge.service.ChallengeService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,8 +33,11 @@ public class ChallengeController implements ChallengeControllerApi {
 
     @Override
     @GetMapping
-    public List<ChallengeResponse> getChallenges(@LoginMember(anonymous = true) Member member) {
-        return challengeService.getChallenges(member);
+    public List<ChallengeResponse> getChallenges(
+            @RequestParam(required = false, defaultValue = "DEFAULT") ChallengeFilter view,
+            @LoginMember(anonymous = true) Member member
+    ) {
+        return challengeService.getChallenges(member, view);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
@@ -13,23 +13,29 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeLandingResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
+import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Challenge", description = "챌린지 관련 API")
 public interface ChallengeControllerApi {
 
     @Operation(
             summary = "챌린지 전체 목록 조회",
-            description = "진행중이거나 예정된 챌린지 전체 목록을 조회합니다. 로그인 시 참여 여부 및 상세 정보가 함께 반환됩니다."
+            description = "진행중이거나 예정된 챌린지 전체 목록을 조회합니다. 로그인 시 참여 여부 및 상세 정보가 함께 반환됩니다. "
+                    + "view=summary 일 때는 ONGOING이면서 참여 중인 챌린지, EARLY/LATE 신청 단계 챌린지만 조회합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "챌린지 목록 조회 성공")
     })
     @GetMapping
-    List<ChallengeResponse> getChallenges(@Parameter(hidden = true) @LoginMember Member member);
+    List<ChallengeResponse> getChallenges(
+            @Parameter(description = "summary 시 요약 목록(참여 중인 ONGOING, EARLY/LATE 신청 단계만) 조회") @RequestParam(required = false, defaultValue = "DEFAULT") ChallengeFilter view,
+            @Parameter(hidden = true) @LoginMember(anonymous = true) Member member
+    );
 
     @Operation(
             summary = "챌린지 상세 조회",

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.challenge.domain;
 
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.Set;
 
 public enum ChallengeFilter {
@@ -16,8 +17,10 @@ public enum ChallengeFilter {
         }
 
         @Override
-        public Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
-            return Comparator.comparingInt(challenge -> getSummaryOrder(challenge, today, joinedChallengeIds));
+        public Optional<Comparator<Challenge>> orderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
+            return Optional.of(
+                    Comparator.comparingInt(challenge -> getSummaryOrder(challenge, today, joinedChallengeIds))
+            );
         }
     },
     DEFAULT {
@@ -31,14 +34,14 @@ public enum ChallengeFilter {
         }
 
         @Override
-        public Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
-            return (a, b) -> 0;
+        public Optional<Comparator<Challenge>> orderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
+            return Optional.empty();
         }
     };
 
     public abstract boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined);
 
-    public abstract Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds);
+    public abstract Optional<Comparator<Challenge>> orderComparator(LocalDate today, Set<Long> joinedChallengeIds);
 
     static int getSummaryOrder(Challenge challenge, LocalDate today, Set<Long> joinedChallengeIds) {
         ChallengeStatus status = challenge.getStatus(today);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
@@ -1,6 +1,8 @@
 package me.bombom.api.v1.challenge.domain;
 
 import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.Set;
 
 public enum ChallengeFilter {
 
@@ -12,6 +14,11 @@ public enum ChallengeFilter {
             return (status == ChallengeStatus.ONGOING && isJoined)
                     || phase.isRecruiting();
         }
+
+        @Override
+        public Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
+            return Comparator.comparingInt(challenge -> getSummaryOrder(challenge, today, joinedChallengeIds));
+        }
     },
     DEFAULT {
         @Override
@@ -22,7 +29,31 @@ public enum ChallengeFilter {
                     || isJoined
                     || challenge.isLatePhase(today);
         }
+
+        @Override
+        public Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
+            return (a, b) -> 0;
+        }
     };
 
     public abstract boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined);
+
+    public abstract Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds);
+
+    static int getSummaryOrder(Challenge challenge, LocalDate today, Set<Long> joinedChallengeIds) {
+        ChallengeStatus status = challenge.getStatus(today);
+        RegistrationPhase phase = challenge.getRegistrationPhase(today);
+        boolean isJoined = joinedChallengeIds.contains(challenge.getId());
+
+        if (status == ChallengeStatus.ONGOING && isJoined) {
+            return 0;
+        }
+        if (phase == RegistrationPhase.LATE) {
+            return 1;
+        }
+        if (phase == RegistrationPhase.EARLY) {
+            return 2;
+        }
+        return 3;
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
@@ -1,0 +1,28 @@
+package me.bombom.api.v1.challenge.domain;
+
+import java.time.LocalDate;
+
+public enum ChallengeFilter {
+
+    SUMMARY {
+        @Override
+        public boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined) {
+            ChallengeStatus status = challenge.getStatus(today);
+            RegistrationPhase phase = challenge.getRegistrationPhase(today);
+            return (status == ChallengeStatus.ONGOING && isJoined)
+                    || phase.isRecruiting();
+        }
+    },
+    DEFAULT {
+        @Override
+        public boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined) {
+            ChallengeStatus status = challenge.getStatus(today);
+            return status == ChallengeStatus.COMING_SOON
+                    || status == ChallengeStatus.BEFORE_START
+                    || isJoined
+                    || challenge.isLatePhase(today);
+        }
+    };
+
+    public abstract boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
@@ -1,5 +1,7 @@
 package me.bombom.api.v1.challenge.domain;
 
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +16,9 @@ public class ChallengeFilterConverter implements Converter<String, ChallengeFilt
         if ("summary".equalsIgnoreCase(source)) {
             return ChallengeFilter.SUMMARY;
         }
-        return ChallengeFilter.DEFAULT;
+        if ("default".equalsIgnoreCase(source)) {
+            return ChallengeFilter.DEFAULT;
+        }
+        throw new CIllegalArgumentException(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
@@ -4,13 +4,14 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 public class ChallengeFilterConverter implements Converter<String, ChallengeFilter> {
 
     @Override
     public ChallengeFilter convert(String source) {
-        if (source == null || source.isBlank()) {
+        if (!StringUtils.hasText(source)) {
             return ChallengeFilter.DEFAULT;
         }
         if ("summary".equalsIgnoreCase(source)) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
@@ -1,0 +1,19 @@
+package me.bombom.api.v1.challenge.domain;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChallengeFilterConverter implements Converter<String, ChallengeFilter> {
+
+    @Override
+    public ChallengeFilter convert(String source) {
+        if (source == null || source.isBlank()) {
+            return ChallengeFilter.DEFAULT;
+        }
+        if ("summary".equalsIgnoreCase(source)) {
+            return ChallengeFilter.SUMMARY;
+        }
+        return ChallengeFilter.DEFAULT;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/RegistrationPhase.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/RegistrationPhase.java
@@ -6,4 +6,8 @@ public enum RegistrationPhase {
     LATE,
     CLOSED,
     ;
+
+    public boolean isRecruiting() {
+        return this == EARLY || this == LATE;
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.badge.service.BadgeService;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.challenge.domain.ChallengeGrade;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
@@ -62,7 +63,7 @@ public class ChallengeService {
     private final BadgeService badgeService;
     private final Clock clock;
 
-    public List<ChallengeResponse> getChallenges(Member member) {
+    public List<ChallengeResponse> getChallenges(Member member, ChallengeFilter view) {
         List<Challenge> challenges = challengeRepository.findAll();
         if (challenges.isEmpty()) {
             return Collections.emptyList();
@@ -72,13 +73,17 @@ public class ChallengeService {
                 .map(Challenge::getId)
                 .toList();
 
+        LocalDate today = LocalDate.now(clock);
         Map<Long, Long> participantCounts = getParticipantCounts(challengeIds);
-        Map<Long, List<ChallengeNewsletterResponse>> newslettersByChallengeId = getNewslettersByChallengeId(challengeIds);
+        Map<Long, List<ChallengeNewsletterResponse>> newslettersByChallengeId =
+                getNewslettersByChallengeId(challengeIds);
         Map<Long, ChallengeParticipant> myParticipation = findMyParticipation(member, challengeIds);
 
-        LocalDate today = LocalDate.now(clock);
         return challenges.stream()
-                .filter(challenge -> isVisibleInChallengeList(challenge, today, myParticipation.containsKey(challenge.getId())))
+                .filter(challenge -> {
+                    boolean isJoined = myParticipation.containsKey(challenge.getId());
+                    return view.isVisible(challenge, today, isJoined);
+                })
                 .map(challenge -> toChallengeResponse(
                         challenge,
                         participantCounts,
@@ -215,14 +220,6 @@ public class ChallengeService {
         }
 
         return new ChallengeTeamListResponse(teams.size(), myTeamId, teamInfos);
-    }
-
-    private boolean isVisibleInChallengeList(Challenge challenge, LocalDate today, boolean isJoined) {
-        ChallengeStatus status = challenge.getStatus(today);
-        return status == ChallengeStatus.COMING_SOON
-                || status == ChallengeStatus.BEFORE_START
-                || isJoined
-                || challenge.isLatePhase(today);
     }
 
     private ChallengeResponse toChallengeResponse(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -9,9 +9,13 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.badge.service.BadgeService;
@@ -79,12 +83,14 @@ public class ChallengeService {
                 getNewslettersByChallengeId(challengeIds);
         Map<Long, ChallengeParticipant> myParticipation = findMyParticipation(member, challengeIds);
 
-        return challenges.stream()
-                .filter(challenge -> {
-                    boolean isJoined = myParticipation.containsKey(challenge.getId());
-                    return view.isVisible(challenge, today, isJoined);
-                })
-                .sorted(view.summaryOrderComparator(today, myParticipation.keySet()))
+        Stream<Challenge> challengeStream = challenges.stream()
+                .filter(challenge -> view.isVisible(
+                        challenge,
+                        today,
+                        myParticipation.containsKey(challenge.getId())
+                ));
+
+        return applySorting(challengeStream, view, today, myParticipation.keySet())
                 .map(challenge -> toChallengeResponse(
                         challenge,
                         participantCounts,
@@ -223,6 +229,44 @@ public class ChallengeService {
         return new ChallengeTeamListResponse(teams.size(), myTeamId, teamInfos);
     }
 
+    private Map<Long, Long> getParticipantCounts(List<Long> challengeIds) {
+        return challengeParticipantRepository.countByChallengeIdInGroupByChallengeId(challengeIds)
+                .stream()
+                .collect(toMap(ChallengeParticipantCount::challengeId, ChallengeParticipantCount::count));
+    }
+
+    private Map<Long, List<ChallengeNewsletterResponse>> getNewslettersByChallengeId(List<Long> challengeIds) {
+        List<ChallengeNewsletterRow> rows = newsletterGroupItemRepository.findChallengeNewsletterRowsByChallengeIds(challengeIds);
+
+        return rows.stream()
+                .collect(groupingBy(
+                        ChallengeNewsletterRow::challengeId,
+                        mapping(ChallengeNewsletterRow::response, toList())
+                ));
+    }
+
+    private Map<Long, ChallengeParticipant> findMyParticipation(Member member, List<Long> challengeIds) {
+        if (member == null) {
+            return Collections.emptyMap();
+        }
+        return challengeParticipantRepository.findByMemberIdAndChallengeIdIn(member.getId(), challengeIds)
+                .stream()
+                .collect(toMap(ChallengeParticipant::getChallengeId, p -> p));
+    }
+
+    private Stream<Challenge> applySorting(
+            Stream<Challenge> stream,
+            ChallengeFilter view,
+            LocalDate today,
+            Set<Long> joinedIds
+    ) {
+        Optional<Comparator<Challenge>> comparatorOpt = view.orderComparator(today, joinedIds);
+
+        return comparatorOpt.isPresent()
+                ? stream.sorted(comparatorOpt.get())
+                : stream;
+    }
+
     private ChallengeResponse toChallengeResponse(
             Challenge challenge,
             Map<Long, Long> participantCounts,
@@ -250,31 +294,6 @@ public class ChallengeService {
         );
     }
 
-    private Map<Long, Long> getParticipantCounts(List<Long> challengeIds) {
-        return challengeParticipantRepository.countByChallengeIdInGroupByChallengeId(challengeIds)
-                .stream()
-                .collect(toMap(ChallengeParticipantCount::challengeId, ChallengeParticipantCount::count));
-    }
-
-    private Map<Long, ChallengeParticipant> findMyParticipation(Member member, List<Long> challengeIds) {
-        if (member == null) {
-            return Collections.emptyMap();
-        }
-        return challengeParticipantRepository.findByMemberIdAndChallengeIdIn(member.getId(), challengeIds)
-                .stream()
-                .collect(toMap(ChallengeParticipant::getChallengeId, p -> p));
-    }
-
-    private Map<Long, List<ChallengeNewsletterResponse>> getNewslettersByChallengeId(List<Long> challengeIds) {
-        List<ChallengeNewsletterRow> rows = newsletterGroupItemRepository.findChallengeNewsletterRowsByChallengeIds(challengeIds);
-
-        return rows.stream()
-                .collect(groupingBy(
-                        ChallengeNewsletterRow::challengeId,
-                        mapping(ChallengeNewsletterRow::response, toList())
-                ));
-    }
-
     private ChallengeDetailResponse calculateParticipationInfo(
             Challenge challenge,
             ChallengeParticipant myParticipant,
@@ -293,6 +312,26 @@ public class ChallengeService {
             return ChallengeDetailResponse.ended(progress, isSurvived, grade);
         }
         return ChallengeDetailResponse.ongoing(progress, isSurvived);
+    }
+
+    private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
+        LocalDate today = LocalDate.now(clock);
+
+        if (challenge.isRegistrationClosed(today)) {
+            return EligibilityReason.ALREADY_STARTED;
+        }
+
+        boolean alreadyApplied = challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId);
+        if (alreadyApplied) {
+            return EligibilityReason.ALREADY_APPLIED;
+        }
+
+        boolean hasSubscribedNewsletter = newsletterGroupItemRepository.existsSubscribedNewsletter(challengeId, memberId);
+        if (!hasSubscribedNewsletter) {
+            return EligibilityReason.NOT_SUBSCRIBED;
+        }
+
+        return EligibilityReason.ELIGIBLE;
     }
 
     private RuntimeException createApplyException(Long challengeId, Member member, EligibilityReason reason) {
@@ -316,25 +355,5 @@ public class ChallengeService {
                 .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                 .addContext(ErrorContextKeys.OPERATION, "applyChallenge")
                 .addContext("reason", "ELIGIBLE 상태에서는 예외를 생성할 수 없습니다.");
-    }
-
-    private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
-        LocalDate today = LocalDate.now(clock);
-
-        if (challenge.isRegistrationClosed(today)) {
-            return EligibilityReason.ALREADY_STARTED;
-        }
-
-        boolean alreadyApplied = challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId);
-        if (alreadyApplied) {
-            return EligibilityReason.ALREADY_APPLIED;
-        }
-
-        boolean hasSubscribedNewsletter = newsletterGroupItemRepository.existsSubscribedNewsletter(challengeId, memberId);
-        if (!hasSubscribedNewsletter) {
-            return EligibilityReason.NOT_SUBSCRIBED;
-        }
-
-        return EligibilityReason.ELIGIBLE;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -84,6 +84,7 @@ public class ChallengeService {
                     boolean isJoined = myParticipation.containsKey(challenge.getId());
                     return view.isVisible(challenge, today, isJoined);
                 })
+                .sorted(view.summaryOrderComparator(today, myParticipation.keySet()))
                 .map(challenge -> toChallengeResponse(
                         challenge,
                         participantCounts,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
@@ -7,9 +7,9 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
-import jakarta.validation.ConstraintViolationException;
 
 @Slf4j
 @RestControllerAdvice
@@ -24,6 +24,33 @@ public class GlobalExceptionHandler {
         }
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getErrorDetail()));
+    }
+
+    @ExceptionHandler(ConversionFailedException.class)
+    public ResponseEntity<ErrorResponse> handleConversionFailedException(ConversionFailedException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof CIllegalArgumentException illegalArg) {
+            return handleIllegalArgumentException(illegalArg);
+        }
+        log.info("Conversion failed: ", e);
+        return ResponseEntity.status(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION.getStatus())
+                .body(ErrorResponse.from(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e
+    ) {
+        Throwable cause = e.getCause();
+        if (cause instanceof ConversionFailedException conversionFailed) {
+            return handleConversionFailedException(conversionFailed);
+        }
+        if (cause instanceof CIllegalArgumentException illegalArg) {
+            return handleIllegalArgumentException(illegalArg);
+        }
+        log.info("Method argument type mismatch: ", e);
+        return ResponseEntity.status(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION.getStatus())
+                .body(ErrorResponse.from(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION));
     }
 
     @ExceptionHandler(UnauthorizedException.class)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
@@ -173,5 +173,22 @@ class ChallengeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isEmpty());
     }
+
+    @Test
+    void view_summary_파라미터로_요약_목록_조회() throws Exception {
+        // given: EARLY 챌린지 하나
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15), group.getId());
+        challengeRepository.save(challenge);
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(challenge.getNewsletterGroupId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges").param("view", "summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(challenge.getId()));
+    }
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
@@ -190,5 +190,11 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$[0].id").value(challenge.getId()));
     }
+
+    @Test
+    void view_허용되지_않은_값이면_400_반환() throws Exception {
+        mockMvc.perform(get("/api/v1/challenges").param("view", "invalid"))
+                .andExpect(status().isBadRequest());
+    }
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
 import me.bombom.api.v1.challenge.domain.EligibilityReason;
@@ -127,7 +128,7 @@ class ChallengeServiceTest {
         newsletterGroupItemRepository.saveAll(List.of(item1, item2));
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then - 시작전 챌린지만 반환되어야 함 (challenge2만)
         assertSoftly(softly -> {
@@ -163,7 +164,7 @@ class ChallengeServiceTest {
         newsletterGroupItemRepository.saveAll(List.of(item1, item2));
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then
         assertSoftly(softly -> {
@@ -204,7 +205,7 @@ class ChallengeServiceTest {
         newsletterGroupItemRepository.save(item);
 
         // when: 참여하지 않은 member로 목록 조회
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then: 추가 신청 기간 내이므로 목록에 포함되어야 함
         assertSoftly(softly -> {
@@ -218,10 +219,62 @@ class ChallengeServiceTest {
     @Test
     void 챌린지가_없을_때_빈_리스트_반환() {
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void view_summary_일_때_참여_중인_ONGOING_EARLY_LATE_챌린지만_조회된다() {
+        // given: EARLY(시작 전), LATE(진행 중 추가신청), ONGOING+참여, ONGOING+미참여(CLOSED)
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+
+        Challenge early = TestFixture.createChallenge("EARLY", 1, today.plusDays(5), today.plusDays(25), group.getId());
+        Challenge late = TestFixture.createChallenge(
+                "LATE",
+                today.minusDays(5),
+                today.plusDays(20),
+                21,
+                group.getId()
+        );
+        Challenge ongoingJoined = TestFixture.createChallenge(
+                "ONGOING_JOINED",
+                today.minusDays(10),
+                today.plusDays(10),
+                20,
+                group.getId()
+        );
+        Challenge ongoingNotJoined = TestFixture.createChallenge(
+                "ONGOING_NOT_JOINED",
+                today.minusDays(10),
+                today.plusDays(10),
+                20,
+                group.getId()
+        );
+        challengeRepository.saveAll(List.of(early, late, ongoingJoined, ongoingNotJoined));
+
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(ongoingJoined.getId(), member.getId(), 5, true)
+        );
+
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(group.getId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+
+        // when
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.SUMMARY);
+
+        // then: EARLY, LATE, ONGOING+참여 3건만 포함. ONGOING+미참여(CLOSED) 제외
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(3);
+            softly.assertThat(result)
+                    .extracting(ChallengeResponse::id)
+                    .containsExactlyInAnyOrder(early.getId(), late.getId(), ongoingJoined.getId());
+            softly.assertThat(result)
+                    .extracting(ChallengeResponse::id)
+                    .doesNotContain(ongoingNotJoined.getId());
+        });
     }
 
     @Test
@@ -241,7 +294,7 @@ class ChallengeServiceTest {
         challengeParticipantRepository.saveAll(List.of(participant1, participant2));
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then - 시작전 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
@@ -263,7 +316,7 @@ class ChallengeServiceTest {
         newsletterGroupItemRepository.saveAll(List.of(item1, item2));
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then - 시작전 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
@@ -292,7 +345,7 @@ class ChallengeServiceTest {
         challengeParticipantRepository.save(participant);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then - 참여한 진행중 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
@@ -318,7 +371,7 @@ class ChallengeServiceTest {
         challengeParticipantRepository.save(participant);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then - 참여한 종료된 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
@@ -336,7 +389,7 @@ class ChallengeServiceTest {
         challengeRepository.save(challenge);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then
         assertSoftly(softly -> {
@@ -362,7 +415,7 @@ class ChallengeServiceTest {
         challengeParticipantRepository.save(participant);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then
         ChallengeDetailResponse participationInfo = result.get(0).participationInfo();
@@ -384,7 +437,7 @@ class ChallengeServiceTest {
         challengeRepository.save(challenge);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then - 시작전 챌린지이므로 반환되어야 함
         ChallengeDetailResponse participationInfo = result.get(0).participationInfo();

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -3,8 +3,12 @@ package me.bombom.api.v1.challenge.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
@@ -42,6 +46,7 @@ import me.bombom.support.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 class ChallengeServiceTest {
@@ -79,6 +84,9 @@ class ChallengeServiceTest {
     @Autowired
     private ChallengeTeamRepository challengeTeamRepository;
 
+    @MockitoBean
+    private Clock clock;
+
     private Member member;
     private List<Category> categories;
     private List<Newsletter> newsletters;
@@ -109,7 +117,11 @@ class ChallengeServiceTest {
         newsletters = TestFixture.createNewslettersWithDetails(categories, newsletterDetails);
         newsletterRepository.saveAll(newsletters);
 
-        today = LocalDate.now();
+        ZoneId seoul = ZoneId.of("Asia/Seoul");
+        Instant fixedInstant = LocalDate.of(2025, 3, 15).atStartOfDay(seoul).toInstant();
+        given(clock.instant()).willReturn(fixedInstant);
+        given(clock.getZone()).willReturn(seoul);
+        today = LocalDate.now(clock);
     }
 
     @Test
@@ -234,7 +246,7 @@ class ChallengeServiceTest {
         Challenge early = TestFixture.createChallenge("EARLY", 1, today.plusDays(5), today.plusDays(25), group.getId());
         Challenge late = TestFixture.createChallenge(
                 "LATE",
-                today.minusDays(5),
+                today.minusDays(1),
                 today.plusDays(20),
                 21,
                 group.getId()

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -282,7 +282,11 @@ class ChallengeServiceTest {
             softly.assertThat(result).hasSize(3);
             softly.assertThat(result)
                     .extracting(ChallengeResponse::id)
-                    .containsExactlyInAnyOrder(early.getId(), late.getId(), ongoingJoined.getId());
+                    .containsExactly(
+                            ongoingJoined.getId(), // ONGOING + 참여
+                            late.getId(),          // LATE
+                            early.getId()          // EARLY
+                    );
             softly.assertThat(result)
                     .extracting(ChallengeResponse::id)
                     .doesNotContain(ongoingNotJoined.getId());


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- GET /api/v1/challenges?view=summary 쿼리 파라미터로 챌린지 요약 목록을 조회할 수 있도록 기능을 추가했습니다.
- 기존 전체 목록 조회는 그대로 두고, view=summary 인 경우에만 별도의 필터링 규칙을 적용합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 챌린지 탭과 달리 둘러보기 페이지에서는 신청할 챌린지 + 현재 진행중인 챌린지만 보여주는 것이 의미가 있기에

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
### SUMMARRY 뷰
노출 대상 및 정렬 순위
1. ONGOING + 내가 참여 중인 챌린지
2. LATE (추가 모집 기간)
3. EARLY (정규 모집 기간)

### 구조 변경
ChallengeFilter(Enum)
- DEFAULT, SUMMARY(둘러보기탭)
- isVisible() -> 노출 여부 판단
- summaryOrderComparator() -> 정렬 우선순위

Converter
- RequestParam에 적절한 ChallengeFilter 선택

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- SUMMARY의 우선 순위가 적절하고, 해당 네이밍 보다 적절한 거 있는지
- ChallengeFilter로 노출 여부+정렬 에 대한 책임을 위임했는데, 더 나은 구조가 있을지