### PR TITLE
[BOM-1017] 유효하지 않은 토큰일 때 토큰 삭제

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/WebConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/WebConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.log.MDCLoggingFilter;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,6 +16,12 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 @RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+    @Value("${server.servlet.session.cookie.name:JSESSIONID_PROD}")
+    private String sessionCookieName;
+
+    @Value("${server.servlet.session.cookie.domain:}")
+    private String sessionCookieDomain;
 
     @Bean
     public FilterRegistrationBean<MDCLoggingFilter> mdcLoggingFilterRegistration() {
@@ -28,6 +35,6 @@ public class WebConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-        resolvers.add(new LoginMemberArgumentResolver());
+        resolvers.add(new LoginMemberArgumentResolver(sessionCookieName, sessionCookieDomain));
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -80,6 +80,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
         Member member = oauth2User.getMember();
         if (member == null) {
+            clearInvalidSessionIfPresent(webRequest);
             throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
         }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -1,5 +1,9 @@
 package me.bombom.api.v1.common.resolver;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
 import me.bombom.api.v1.common.exception.ErrorDetail;
@@ -9,6 +13,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -16,6 +21,21 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Slf4j
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final int INVALID_SESSION_MAX_AGE_SECONDS = 0;
+    private static final String SESSION_COOKIE_PATH = "/";
+    private static final String SESSION_COOKIE_EMPTY_VALUE = "";
+    private static final String SESSION_DOMAIN_ATTRIBUTE_PREFIX = "; Domain=";
+    private static final String SESSION_COOKIE_SECURE_FLAGS = "; Secure; HttpOnly; SameSite=None";
+    private static final String SESSION_COOKIE_HEADER_FORMAT = "%s=; Max-Age=0; Path=%s%s" + SESSION_COOKIE_SECURE_FLAGS;
+
+    private final String sessionCookieName;
+    private final String sessionCookieDomain;
+
+    public LoginMemberArgumentResolver(String sessionCookieName, String sessionCookieDomain) {
+        this.sessionCookieName = sessionCookieName;
+        this.sessionCookieDomain = sessionCookieDomain;
+    }
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -31,32 +51,120 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             WebDataBinderFactory binderFactory
     ) {
         LoginMember loginMember = parameter.getParameterAnnotation(LoginMember.class);
-        boolean isAnonymousAllowed = loginMember != null && loginMember.anonymous();
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
         if (isAnonymous(authentication)) {
-            if (isAnonymousAllowed) {
-                return null;
-            }
+            return resolveAnonymousRequest(loginMember, webRequest);
+        }
+
+        return resolveAuthenticatedRequest(parameter, authentication, webRequest);
+    }
+
+    private Object resolveAnonymousRequest(LoginMember loginMember, NativeWebRequest webRequest) {
+        clearInvalidSessionIfPresent(webRequest);
+
+        if (loginMember != null && loginMember.anonymous()) {
+            return null;
+        }
+
+        throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
+    }
+
+    private Object resolveAuthenticatedRequest(
+            MethodParameter parameter,
+            Authentication authentication,
+            NativeWebRequest webRequest
+    ) {
+        if (!(authentication.getPrincipal() instanceof CustomOAuth2User oauth2User)) {
+            clearInvalidSessionIfPresent(webRequest);
+            throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN);
+        }
+
+        Member member = oauth2User.getMember();
+        if (member == null) {
             throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
         }
 
-        Object principal = authentication.getPrincipal();
-        if (principal instanceof CustomOAuth2User) {
-            Member member = ((CustomOAuth2User) principal).getMember();
-            if (member == null) {
-                throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
-            }
-            if (parameter.getParameterType().equals(Long.class)) {
-                return member.getId();
-            }
-            return member;
+        if (parameter.getParameterType().equals(Long.class)) {
+            return member.getId();
         }
-        throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN);
+        return member;
     }
 
     private boolean isAnonymous(Authentication authentication) {
         return authentication == null
                 || !authentication.isAuthenticated()
                 || authentication instanceof AnonymousAuthenticationToken;
+    }
+
+    private void clearInvalidSessionIfPresent(NativeWebRequest webRequest) {
+        if (webRequest == null) {
+            return;
+        }
+
+        HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
+        HttpServletResponse response = webRequest.getNativeResponse(HttpServletResponse.class);
+        if (!hasSessionRequestContext(request, response)) {
+            return;
+        }
+
+        invalidateSessionIfPresent(request);
+        SecurityContextHolder.clearContext();
+        expireSessionCookie(response);
+    }
+
+    private boolean hasSessionRequestContext(HttpServletRequest request, HttpServletResponse response) {
+        return request != null
+                && response != null
+                && hasSessionCookie(request);
+    }
+
+    private void invalidateSessionIfPresent(HttpServletRequest request) {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            session.invalidate();
+        }
+    }
+
+    private boolean hasSessionCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return false;
+        }
+
+        for (Cookie cookie : cookies) {
+            if (isSessionCookie(cookie)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isSessionCookie(Cookie cookie) {
+        return sessionCookieName.equals(cookie.getName()) && StringUtils.hasText(cookie.getValue());
+    }
+
+    private void expireSessionCookie(HttpServletResponse response) {
+        response.addCookie(buildExpiredSessionCookie());
+        response.addHeader("Set-Cookie", buildExpiredSessionCookieHeader());
+    }
+
+    private Cookie buildExpiredSessionCookie() {
+        Cookie expiredSessionCookie = new Cookie(sessionCookieName, SESSION_COOKIE_EMPTY_VALUE);
+        expiredSessionCookie.setMaxAge(INVALID_SESSION_MAX_AGE_SECONDS);
+        expiredSessionCookie.setPath(SESSION_COOKIE_PATH);
+        expiredSessionCookie.setHttpOnly(true);
+        expiredSessionCookie.setSecure(true);
+        if (StringUtils.hasText(sessionCookieDomain)) {
+            expiredSessionCookie.setDomain(sessionCookieDomain);
+        }
+        return expiredSessionCookie;
+    }
+
+    private String buildExpiredSessionCookieHeader() {
+        String domainAttribute = StringUtils.hasText(sessionCookieDomain)
+                ? SESSION_DOMAIN_ATTRIBUTE_PREFIX + sessionCookieDomain
+                : "";
+        return String.format(SESSION_COOKIE_HEADER_FORMAT, sessionCookieName, SESSION_COOKIE_PATH, domainAttribute);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -22,9 +22,7 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 @Slf4j
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
-    private static final int INVALID_SESSION_MAX_AGE_SECONDS = 0;
     private static final String SESSION_COOKIE_PATH = "/";
-    private static final String SESSION_COOKIE_EMPTY_VALUE = "";
     private static final String SESSION_DOMAIN_ATTRIBUTE_PREFIX = "; Domain=";
     private static final String SESSION_COOKIE_SECURE_FLAGS = "; Secure; HttpOnly; SameSite=None";
     private static final String SESSION_COOKIE_HEADER_FORMAT = "%s=; Max-Age=0; Path=%s%s" + SESSION_COOKIE_SECURE_FLAGS;
@@ -145,20 +143,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     private void expireSessionCookie(HttpServletResponse response) {
-        response.addCookie(buildExpiredSessionCookie());
         response.addHeader("Set-Cookie", buildExpiredSessionCookieHeader());
-    }
-
-    private Cookie buildExpiredSessionCookie() {
-        Cookie expiredSessionCookie = new Cookie(sessionCookieName, SESSION_COOKIE_EMPTY_VALUE);
-        expiredSessionCookie.setMaxAge(INVALID_SESSION_MAX_AGE_SECONDS);
-        expiredSessionCookie.setPath(SESSION_COOKIE_PATH);
-        expiredSessionCookie.setHttpOnly(true);
-        expiredSessionCookie.setSecure(true);
-        if (StringUtils.hasText(sessionCookieDomain)) {
-            expiredSessionCookie.setDomain(sessionCookieDomain);
-        }
-        return expiredSessionCookie;
     }
 
     private String buildExpiredSessionCookieHeader() {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -24,7 +24,7 @@ import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
-import me.bombom.api.v1.common.config.WebConfig;
+import me.bombom.api.v1.common.exception.GlobalExceptionHandler;
 import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
@@ -33,18 +33,53 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @AutoConfigureMockMvc
-@Import({ WebConfig.class, LoginMemberArgumentResolver.class })
-@WebMvcTest(ChallengeProgressController.class)
+@Import({
+        ChallengeProgressController.class,
+        GlobalExceptionHandler.class,
+        ChallengeProgressControllerUnitTest.TestConfig.class
+})
+@WebMvcTest(value = ChallengeProgressController.class, properties = "LOG_PATH=build/logs")
 class ChallengeProgressControllerUnitTest {
+
+    @Configuration
+    @EnableWebSecurity
+    static class TestConfig implements WebMvcConfigurer {
+
+        @Bean
+        LoginMemberArgumentResolver loginMemberArgumentResolver() {
+            return new LoginMemberArgumentResolver("JSESSIONID", "");
+        }
+
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
+
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(loginMemberArgumentResolver());
+        }
+    }
 
     @Autowired
     private MockMvc mockMvc;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -6,6 +6,9 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
@@ -24,20 +27,27 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
 class LoginMemberArgumentResolverTest {
+
+    private static final String SESSION_COOKIE_NAME = "JSESSIONID_TEST";
+    private static final String SESSION_COOKIE_DOMAIN = "example.com";
 
     private LoginMemberArgumentResolver resolver;
 
     @BeforeEach
     void setUp() {
-        resolver = new LoginMemberArgumentResolver();
+        resolver = new LoginMemberArgumentResolver(SESSION_COOKIE_NAME, SESSION_COOKIE_DOMAIN);
     }
 
     @AfterEach
     void tearDown() {
         SecurityContextHolder.clearContext();
     }
+
 
     static class StubController {
         public void endpointMember(@LoginMember Member member) {
@@ -126,6 +136,44 @@ class LoginMemberArgumentResolverTest {
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_TOKEN);
     }
 
+    @Test
+    @DisplayName("비로그인(anonymous) 요청에서 세션 쿠키가 있으면 세션/쿠키를 정리한다")
+    void resolve_WhenAnonymousWithSessionCookie_ClearsInvalidSession() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setCookies(new Cookie(SESSION_COOKIE_NAME, "session-token"));
+        request.getSession();
+
+        setAnonymousAuthentication();
+        NativeWebRequest webRequest = createWebRequest(request, response);
+
+        Object result = resolver.resolveArgument(paramMemberAnonymousTrue(), null, webRequest, null);
+
+        assertThat(result).isNull();
+        verifyInvalidSessionCookie(response);
+        assertThat(request.getSession(false)).isNull();
+    }
+
+    @Test
+    @DisplayName("principal 타입이 비정상이고 세션 쿠키가 있으면 INVALID_TOKEN 예외와 함께 세션/쿠키를 정리한다")
+    void resolve_WhenInvalidPrincipalWithSessionCookie_ClearsInvalidSession() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setCookies(new Cookie(SESSION_COOKIE_NAME, "session-token"));
+        request.getSession();
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("notCustomUser", null);
+        auth.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        NativeWebRequest webRequest = createWebRequest(request, response);
+
+        assertThatThrownBy(() -> resolver.resolveArgument(paramMember(), null, webRequest, null))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_TOKEN);
+        verifyInvalidSessionCookie(response);
+        assertThat(request.getSession(false)).isNull();
+    }
+
     private void setAnonymousAuthentication() {
         Authentication anonymous = new AnonymousAuthenticationToken(
                 "key", "anonymousUser", List.of(new SimpleGrantedAuthority("ROLE_ANONYMOUS")));
@@ -164,5 +212,18 @@ class LoginMemberArgumentResolverTest {
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private NativeWebRequest createWebRequest(MockHttpServletRequest request, MockHttpServletResponse response) {
+        NativeWebRequest webRequest = mock(NativeWebRequest.class);
+        given(webRequest.getNativeRequest(HttpServletRequest.class)).willReturn(request);
+        given(webRequest.getNativeResponse(HttpServletResponse.class)).willReturn(response);
+        return webRequest;
+    }
+
+    private void verifyInvalidSessionCookie(MockHttpServletResponse response) {
+        assertThat(response.getCookie(SESSION_COOKIE_NAME)).isNotNull();
+        assertThat(response.getCookie(SESSION_COOKIE_NAME).getMaxAge()).isEqualTo(0);
+        assertThat(response.getCookie(SESSION_COOKIE_NAME).getPath()).isEqualTo("/");
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -125,6 +125,24 @@ class LoginMemberArgumentResolverTest {
     }
 
     @Test
+    @DisplayName("principal 타입은 정상이지만 member가 null이고 세션 쿠키가 있으면 UNAUTHORIZED 예외와 함께 세션/쿠키를 정리한다")
+    void resolve_WhenMemberIsNullWithSessionCookie_ClearsInvalidSession() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setCookies(new Cookie(SESSION_COOKIE_NAME, "session-token"));
+        request.getSession();
+        setLoggedInAuthentication(null);
+
+        NativeWebRequest webRequest = createWebRequest(request, response);
+
+        assertThatThrownBy(() -> resolver.resolveArgument(paramMember(), null, webRequest, null))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.UNAUTHORIZED);
+        verifyInvalidSessionCookie(response);
+        assertThat(request.getSession(false)).isNull();
+    }
+
+    @Test
     @DisplayName("비정상적인 Principal 타입이면 INVALID_TOKEN 예외를 던진다")
     void resolve_WhenInvalidPrincipal_ThrowsException() throws Exception {
         TestingAuthenticationToken auth = new TestingAuthenticationToken("notCustomUser", null);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/controller/SubscribeControllerTest.java
@@ -54,7 +54,7 @@ class SubscribeControllerTest {
 
         @Bean
         public LoginMemberArgumentResolver loginMemberArgumentResolver() {
-            return new LoginMemberArgumentResolver();
+            return new LoginMemberArgumentResolver("JSESSIONID", "");
         }
 
         @Bean
@@ -71,7 +71,7 @@ class SubscribeControllerTest {
 
         @Override
         public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-            resolvers.add(new LoginMemberArgumentResolver());
+            resolvers.add(new LoginMemberArgumentResolver("JSESSIONID", ""));
 
         }
     }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- `@LoginMember` 기반 인증 처리에서 잘못된 세션 토큰이 붙은 요청이 들어왔을 때 API 응답만 예외 처리되던 문제를 보완해, 브라우저 세션 쿠키 정리 로직을 추가했습니다. 
- `newsletter` 관련 동작을 포함한 기존 인증/인가 정책(anonymous 허용/예외 타입)은 유지하면서, 잘못된/죽은 세션은 바로 정리하도록 개선했습니다.
- `resolveArgument` 메서드 가독성을 위해 리팩토링을 진행했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

### 유저 피드백
<img width="259" height="445" alt="image" src="https://github.com/user-attachments/assets/f6675e18-3504-4534-b416-8ffd45b0d5c1" />

### 고민
`/api/v1/newsletters`(및 `@LoginMember` 공통 처리 경로)에서 토큰이 만료되거나 깨진 상태일 때 클라이언트가 계속 같은 쿠키를 유지하면, 다음 요청마다 반복 실패가 발생할 수 있었습니다. 

이번 작업은 잘못된 세션 쿠키를 즉시 정리해 사용자 경험을 회복 가능한 상태로 돌리고, 비정상 인증 상태를 다음 요청에서 빠르게 종료하도록 하기 위해 수행했습니다.

왜냐하면 만료되거나 문제가 있는 쿠기를 계속 브라우저가 가지고 있을 이유가 없기 때문입니다.  



다음 PR에서 유효하지 않는 토큰이라도 특정 API에서는 올바른 값이 나오도록 하는 기능을 추가할 예정입니다.



## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

- `@LoginMember`를 처리하는 공통 리졸버에서 인증 실패 경로를 정리했습니다.
  - 익명 처리/비정상 인증/invalid 토큰 경로에서 invalidate 로직 실행
  - 현재 세션이 있으면 서버 세션 무효화
  - SecurityContext도 정리
  - Set-Cookie로 Max-Age=0(삭제) 응답을 내려 브라우저에서 쿠키 제거
    - 에러 응답 헤더에 넣음  
  - 기존 인증/인가 결과(UNAUTHORIZED, INVALID_TOKEN) 동작은 유지
 
- 기존 anonymous 정책/예외 타입(UNAUTHORIZED, INVALID_TOKEN) 동작은 변경 없이 유지했습니다.

#### 로직 플로우
<img width="794" height="781" alt="image" src="https://github.com/user-attachments/assets/92129175-e619-4e10-afc9-dd196c52960f" />


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 제가 확인을 했지만 혹시 모르니 기존 로직에 영향이 없는지 확인해주시면 감사합니다.