### PR TITLE
[BOM-1016] feat: 챌린지 스트릭 구현 및 코멘트 응답에 firstCompletion 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
@@ -12,6 +12,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleR
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentLikeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.service.ChallengeCommentService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
@@ -71,12 +72,12 @@ public class ChallengeCommentController implements ChallengeCommentControllerApi
     @Override
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{challengeId}/comments")
-    public void createChallengeComment(
+    public CreateCommentResponse createChallengeComment(
             @LoginMember Member member,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Valid @RequestBody ChallengeCommentRequest request
     ) {
-        challengeCommentService.createChallengeComment(member.getId(), challengeId, request);
+        return challengeCommentService.createChallengeComment(member.getId(), challengeId, request);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
@@ -17,6 +17,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleR
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentLikeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
@@ -70,7 +71,7 @@ public interface ChallengeCommentControllerApi {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 값", content = @Content),
             @ApiResponse(responseCode = "404", description = "아티클을 찾을 수 없음", content = @Content)
     })
-    void createChallengeComment(
+    CreateCommentResponse createChallengeComment(
             @Parameter(hidden = true) Member member,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Valid @RequestBody ChallengeCommentRequest request

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
@@ -6,6 +6,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
@@ -58,14 +59,14 @@ public class ChallengeDailyGuideController implements ChallengeDailyGuideControl
     @Override
     @PostMapping("/{challengeId}/daily-guides/{dayIndex}/my-comment")
     @ResponseStatus(HttpStatus.CREATED)
-    public void createDailyGuideComment(
+    public CreateCommentResponse createDailyGuideComment(
             @LoginMember Member member,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,
             @Valid @RequestBody DailyGuideCommentRequest request
     ) {
         LocalDate today = LocalDate.now(SEOUL_ZONE);
-        challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request, today);
+        return challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request, today);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
@@ -2,8 +2,6 @@ package me.bombom.api.v1.challenge.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
@@ -32,8 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/challenges")
 public class ChallengeDailyGuideController implements ChallengeDailyGuideControllerApi {
-
-    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
 
     private final ChallengeDailyGuideService challengeDailyGuideService;
 
@@ -65,8 +61,7 @@ public class ChallengeDailyGuideController implements ChallengeDailyGuideControl
             @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,
             @Valid @RequestBody DailyGuideCommentRequest request
     ) {
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
-        return challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request, today);
+        return challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
@@ -65,7 +66,7 @@ public interface ChallengeDailyGuideControllerApi {
             @ApiResponse(responseCode = "403", description = "챌린지 참여 권한 없음 또는 댓글 작성 불가", content = @Content),
             @ApiResponse(responseCode = "404", description = "챌린지 또는 데일리 가이드를 찾을 수 없음", content = @Content)
     })
-    void createDailyGuideComment(
+    CreateCommentResponse createDailyGuideComment(
             @Parameter(hidden = true) @LoginMember Member member,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(description = "일차 인덱스 (1부터 시작)") @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeParticipant.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeParticipant.java
@@ -43,6 +43,9 @@ public class ChallengeParticipant extends BaseEntity {
     @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
     private int shield = 0;
 
+    @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+    private int streak = 0;
+
     @Builder
     public ChallengeParticipant(
             Long id,
@@ -51,7 +54,8 @@ public class ChallengeParticipant extends BaseEntity {
             Long challengeTeamId,
             int completedDays,
             boolean isSurvived,
-            int shield
+            int shield,
+            int streak
     ) {
         this.id = id;
         this.challengeId = challengeId;
@@ -60,6 +64,7 @@ public class ChallengeParticipant extends BaseEntity {
         this.completedDays = completedDays;
         this.isSurvived = isSurvived;
         this.shield = shield;
+        this.streak = streak;
     }
 
     public int calculateProgress(int totalDays) {
@@ -85,5 +90,13 @@ public class ChallengeParticipant extends BaseEntity {
 
     public void increaseCompletedDays() {
         this.completedDays += 1;
+    }
+
+    public void increaseStreak() {
+        this.streak += 1;
+    }
+
+    public void resetStreak() {
+        this.streak = 0;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/ChallengeProgressFlat.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/ChallengeProgressFlat.java
@@ -8,6 +8,8 @@ public record ChallengeProgressFlat(
         int completedDays,
         boolean isSurvived,
         ChallengeTodoType todoType,
-        boolean isDone
+        boolean isDone,
+        int streak,
+        int shield
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CreateCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CreateCommentResponse.java
@@ -2,6 +2,6 @@ package me.bombom.api.v1.challenge.dto.response;
 
 public record CreateCommentResponse(
 
-        boolean firstCompletion
+        boolean isFirstCompletion
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CreateCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CreateCommentResponse.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+public record CreateCommentResponse(
+
+        boolean firstCompletion
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MemberChallengeProgressResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MemberChallengeProgressResponse.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.challenge.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import me.bombom.api.v1.challenge.dto.ChallengeProgressFlat;
@@ -11,13 +12,13 @@ public record MemberChallengeProgressResponse(
         @NotNull
         String nickname,
 
-        @Schema(required = true)
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         int totalDays,
 
-        @Schema(required = true)
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         boolean isSurvived,
 
-        @Schema(required = true)
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         int completedDays,
 
         @Schema(requiredMode = RequiredMode.REQUIRED)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MemberChallengeProgressResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MemberChallengeProgressResponse.java
@@ -20,6 +20,12 @@ public record MemberChallengeProgressResponse(
         @Schema(required = true)
         int completedDays,
 
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        int streak,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        int shield,
+
         @NotNull
         List<TodayTodoResponse> todayTodos
 ) {
@@ -36,6 +42,8 @@ public record MemberChallengeProgressResponse(
                 representative.totalDays(),
                 representative.isSurvived(),
                 representative.completedDays(),
+                representative.streak(),
+                representative.shield(),
                 todayTodos
         );
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListener.java
@@ -51,7 +51,7 @@ public class CreateChallengeCommentListener {
     private void completeDailyTodoWithComment(ChallengeParticipant participant, LocalDate today) {
         try {
             challengeTodoService.insertCommentDone(participant, today);
-            challengeTodoService.completeDailyTodo(participant, today);
+            challengeTodoService.completeDailyTodo(participant.getId(), today);
         } catch (DataIntegrityViolationException e) {
             String violated = extractConstraintName(e);
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -54,7 +54,9 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
             CASE
                 WHEN cdt.id IS NOT NULL THEN true
                 ELSE false
-            END
+            END,
+            cp.streak,
+            cp.shield
         )
         FROM ChallengeParticipant cp
         JOIN Challenge c ON cp.challengeId = c.id

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -84,7 +84,7 @@ public class ChallengeCommentService {
         ChallengeParticipant participant = getChallengeParticipant(memberId, challengeId);
 
         LocalDate today = LocalDate.now(clock);
-        boolean firstCompletion = !challengeTodoService.isCompletedToday(participant.getId(), today);
+        boolean isFirstCompletion = !challengeTodoService.isCompletedToday(participant.getId(), today);
 
         Article article = articleRepository.findById(request.articleId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
@@ -102,7 +102,7 @@ public class ChallengeCommentService {
 
         challengeCommentRepository.save(comment);
         applicationEventPublisher.publishEvent(new CreateChallengeCommentEvent(participant.getId()));
-        return new CreateCommentResponse(firstCompletion);
+        return new CreateCommentResponse(isFirstCompletion);
     }
 
     public Page<ChallengeCommentHighlightResponse> getChallengeArticleHighlights(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -16,6 +16,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleR
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentLikeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.event.CreateChallengeCommentEvent;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentLikeRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
@@ -42,6 +43,7 @@ public class ChallengeCommentService {
     private final ArticleRepository articleRepository;
     private final HighlightRepository highlightRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final ChallengeTodoService challengeTodoService;
     private final Clock clock;
 
     @Value("${challenge.highlight.truncate-ratio}")
@@ -73,13 +75,16 @@ public class ChallengeCommentService {
     }
 
     @Transactional
-    public void createChallengeComment(
+    public CreateCommentResponse createChallengeComment(
             Long memberId,
             Long challengeId,
             ChallengeCommentRequest request
     ) {
         validateCommentAvailableDay(memberId, challengeId);
         ChallengeParticipant participant = getChallengeParticipant(memberId, challengeId);
+
+        LocalDate today = LocalDate.now(clock);
+        boolean firstCompletion = !challengeTodoService.isCompletedToday(participant.getId(), today);
 
         Article article = articleRepository.findById(request.articleId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
@@ -97,6 +102,7 @@ public class ChallengeCommentService {
 
         challengeCommentRepository.save(comment);
         applicationEventPublisher.publishEvent(new CreateChallengeCommentEvent(participant.getId()));
+        return new CreateCommentResponse(firstCompletion);
     }
 
     public Page<ChallengeCommentHighlightResponse> getChallengeArticleHighlights(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -12,6 +12,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
@@ -99,7 +100,7 @@ public class ChallengeDailyGuideService {
     }
 
     @Transactional
-    public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
+    public CreateCommentResponse createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
             DailyGuideCommentRequest request, LocalDate today) {
         Challenge challenge = getChallenge(challengeId);
 
@@ -145,25 +146,24 @@ public class ChallengeDailyGuideService {
                 .build();
         challengeDailyGuideCommentRepository.save(comment);
 
+        boolean firstCompletion = false;
+
         // day1일 때만 체크리스트 자동 완료 처리
         if (dayIndex == 1) {
             // MINDSET 투두 생성 (마인드셋 댓글 작성)
             challengeTodoService.insertMindsetDone(participant, today);
-            // TODO: 과도기라서 모두 완료 처리가 필요해 보임. 추후 삭제 필요
-            // READ 투두 자동 생성 (뉴스레터 1개 읽기)
-            challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
-            // COMMENT 투두 생성 (한 줄 코멘트 작성)
-            challengeTodoService.insertCommentDone(participant, today);
 
             // 이미 완료되지 않았으면 progress 처리
             if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
                 challengeTodoService.completeDailyTodo(participant, today);
+                firstCompletion = true;
                 if (participant.getChallengeTeamId() != null) {
                     ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
                     challengeTeamService.updateTeamProgress(challengeTeam);
                 }
             }
         }
+        return new CreateCommentResponse(firstCompletion);
     }
 
     public MemberDailyCommentResponse getDailyGuideComment(Long challengeId, int dayIndex, Long memberId) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -160,7 +160,7 @@ public class ChallengeDailyGuideService {
 
             // 이미 완료되지 않았으면 progress 처리
             if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
-                challengeTodoService.completeDailyTodo(participant, today);
+                challengeTodoService.completeDailyTodo(participant.getId(), today);
                 firstCompletion = true;
                 if (participant.getChallengeTeamId() != null) {
                     ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -100,8 +100,13 @@ public class ChallengeDailyGuideService {
     }
 
     @Transactional
-    public CreateCommentResponse createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
-            DailyGuideCommentRequest request, LocalDate today) {
+    public CreateCommentResponse createDailyGuideComment(
+            Long challengeId,
+            int dayIndex,
+            Long memberId,
+            DailyGuideCommentRequest request
+    ) {
+        LocalDate today = LocalDate.now(clock);
         Challenge challenge = getChallenge(challengeId);
 
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -53,6 +53,9 @@ public class ChallengeProgressService {
         for (ChallengeParticipant absentee : absentees) {
             if (absentee.useShieldIfAvailable()) {
                 saveShieldDailyResult(absentee, yesterday);
+                // TODO: [결정 필요] 쉴드 사용 시 스트릭 정책 미정
+                //  현재: 스트릭 유지 (increaseStreak 없음, resetStreak 없음)
+                //  쉴드는 결석을 커버하는 것이지 증가 아님 vs 쉴드 = 투두 완료로 보고 증가 시켜야 한다.
                 continue;
             }
             absentee.resetStreak();

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -53,9 +53,7 @@ public class ChallengeProgressService {
         for (ChallengeParticipant absentee : absentees) {
             if (absentee.useShieldIfAvailable()) {
                 saveShieldDailyResult(absentee, yesterday);
-                // TODO: [결정 필요] 쉴드 사용 시 스트릭 정책 미정
-                //  현재: 스트릭 유지 (increaseStreak 없음, resetStreak 없음)
-                //  쉴드는 결석을 커버하는 것이지 증가 아님 vs 쉴드 = 투두 완료로 보고 증가 시켜야 한다.
+                absentee.increaseStreak();
                 continue;
             }
             absentee.resetStreak();

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -53,7 +53,6 @@ public class ChallengeProgressService {
         for (ChallengeParticipant absentee : absentees) {
             if (absentee.useShieldIfAvailable()) {
                 saveShieldDailyResult(absentee, yesterday);
-                absentee.increaseStreak();
                 continue;
             }
             absentee.resetStreak();

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -55,6 +55,7 @@ public class ChallengeProgressService {
                 saveShieldDailyResult(absentee, yesterday);
                 continue;
             }
+            absentee.resetStreak();
             checkFailure(absentee, challenge, yesterday);
         }
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
@@ -11,6 +11,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
@@ -27,6 +28,7 @@ public class ChallengeTodoService {
     private final ChallengeTodoRepository challengeTodoRepository;
     private final ChallengeDailyTodoRepository challengeDailyTodoRepository;
     private final ChallengeDailyResultRepository challengeDailyResultRepository;
+    private final ChallengeParticipantRepository challengeParticipantRepository;
 
     public boolean isCompletedToday(Long participantId, LocalDate today) {
         return challengeDailyResultRepository.existsByParticipantIdAndDate(participantId, today);
@@ -95,5 +97,6 @@ public class ChallengeTodoService {
 
         participant.increaseCompletedDays();
         participant.increaseStreak();
+        challengeParticipantRepository.save(participant);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
@@ -94,5 +94,6 @@ public class ChallengeTodoService {
         );
 
         participant.increaseCompletedDays();
+        participant.increaseStreak();
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
@@ -13,6 +13,7 @@ import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
@@ -86,10 +87,16 @@ public class ChallengeTodoService {
     }
 
     @Transactional
-    public void completeDailyTodo(ChallengeParticipant participant, LocalDate today){
+    public void completeDailyTodo(Long participantId, LocalDate today){
+        ChallengeParticipant participant = challengeParticipantRepository.findById(participantId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.OPERATION, "completeDailyTodo")
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                        .addContext(ErrorContextKeys.CHALLENGE_PARTICIPANT_ID, participantId));
+
         challengeDailyResultRepository.save(
                 ChallengeDailyResult.builder()
-                        .participantId(participant.getId())
+                        .participantId(participantId)
                         .date(today)
                         .status(ChallengeDailyStatus.COMPLETE)
                         .build()
@@ -97,6 +104,5 @@ public class ChallengeTodoService {
 
         participant.increaseCompletedDays();
         participant.increaseStreak();
-        challengeParticipantRepository.save(participant);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/ErrorContextKeys.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/ErrorContextKeys.java
@@ -25,6 +25,7 @@ public enum ErrorContextKeys {
     HIGHLIGHT_ID("highlightId"),
     CHALLENGE_ID("challengeId"),
     CHALLENGE_TEAM_ID("challengeTeamId"),
+    CHALLENGE_PARTICIPANT_ID("challengeParticipantId"),
     COMMENT_ID("commentId"),
     DETAIL("detail"),
     ;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V30.4.0__add_streak_to_challenge_participant.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V30.4.0__add_streak_to_challenge_participant.sql
@@ -3,7 +3,7 @@ ALTER TABLE challenge_participant
 
 -- 기존 참여자의 스트릭을 challenge_daily_result 기록 기반으로 계산하여 초기화
 -- challenge_daily_result에는 주말 데이터가 없으므로 금요일→월요일 간격(3일)까지 연속으로 판단
--- DAYOFWEEK: 1=일, 2=월, 7=토
+-- 오늘 미완료 여부는 결석 체크 스케줄러가 담당하므로, 마이그레이션은 과거 기록 간 간격만 판단
 UPDATE challenge_participant cp
 INNER JOIN (
     WITH consecutive_check AS (
@@ -19,15 +19,6 @@ INNER JOIN (
             participant_id,
             rn,
             CASE
-                -- 가장 최근 기록이 오늘 또는 직전 평일이 아니면 gap
-                WHEN rn = 1 AND DATEDIFF(CURDATE(), date) >
-                    CASE DAYOFWEEK(CURDATE())
-                        WHEN 1 THEN 2   -- 일요일: 직전 평일 금요일(2일 전)
-                        WHEN 2 THEN 3   -- 월요일: 직전 평일 금요일(3일 전)
-                        WHEN 7 THEN 1   -- 토요일: 직전 평일 금요일(1일 전)
-                        ELSE 1          -- 화~금: 직전 평일 어제(1일 전)
-                    END
-                THEN 1
                 -- 두 기록 간 간격이 3일 초과면 gap (금→월=3일은 연속으로 허용)
                 WHEN rn > 1 AND DATEDIFF(prev_date, date) > 3 THEN 1
                 ELSE 0

--- a/backend/bom-bom-server/src/main/resources/db/migration/V30.4.0__add_streak_to_challenge_participant.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V30.4.0__add_streak_to_challenge_participant.sql
@@ -5,13 +5,13 @@ ALTER TABLE challenge_participant
 -- challenge_daily_result에는 주말 데이터가 없으므로 금요일→월요일 간격(3일)까지 연속으로 판단
 -- 오늘 미완료 여부는 결석 체크 스케줄러가 담당하므로, 마이그레이션은 과거 기록 간 간격만 판단
 UPDATE challenge_participant cp
-INNER JOIN (
+JOIN (
     WITH consecutive_check AS (
         SELECT
             participant_id,
             date,
             ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY date DESC) AS rn,
-            LAG(date)     OVER (PARTITION BY participant_id ORDER BY date DESC) AS prev_date
+            LAG(date)    OVER (PARTITION BY participant_id ORDER BY date DESC) AS prev_date
         FROM challenge_daily_result
     ),
     gap_flags AS (

--- a/backend/bom-bom-server/src/main/resources/db/migration/V30.4.0__add_streak_to_challenge_participant.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V30.4.0__add_streak_to_challenge_participant.sql
@@ -1,0 +1,50 @@
+ALTER TABLE challenge_participant
+    ADD COLUMN streak INT NOT NULL DEFAULT 0;
+
+-- 기존 참여자의 스트릭을 challenge_daily_result 기록 기반으로 계산하여 초기화
+-- challenge_daily_result에는 주말 데이터가 없으므로 금요일→월요일 간격(3일)까지 연속으로 판단
+-- DAYOFWEEK: 1=일, 2=월, 7=토
+UPDATE challenge_participant cp
+INNER JOIN (
+    WITH consecutive_check AS (
+        SELECT
+            participant_id,
+            date,
+            ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY date DESC) AS rn,
+            LAG(date)     OVER (PARTITION BY participant_id ORDER BY date DESC) AS prev_date
+        FROM challenge_daily_result
+    ),
+    gap_flags AS (
+        SELECT
+            participant_id,
+            rn,
+            CASE
+                -- 가장 최근 기록이 오늘 또는 직전 평일이 아니면 gap
+                WHEN rn = 1 AND DATEDIFF(CURDATE(), date) >
+                    CASE DAYOFWEEK(CURDATE())
+                        WHEN 1 THEN 2   -- 일요일: 직전 평일 금요일(2일 전)
+                        WHEN 2 THEN 3   -- 월요일: 직전 평일 금요일(3일 전)
+                        WHEN 7 THEN 1   -- 토요일: 직전 평일 금요일(1일 전)
+                        ELSE 1          -- 화~금: 직전 평일 어제(1일 전)
+                    END
+                THEN 1
+                -- 두 기록 간 간격이 3일 초과면 gap (금→월=3일은 연속으로 허용)
+                WHEN rn > 1 AND DATEDIFF(prev_date, date) > 3 THEN 1
+                ELSE 0
+            END AS has_gap
+        FROM consecutive_check
+    ),
+    first_gap AS (
+        SELECT participant_id, MIN(rn) AS gap_rn
+        FROM gap_flags
+        WHERE has_gap = 1
+        GROUP BY participant_id
+    )
+    SELECT
+        gf.participant_id,
+        COALESCE(fg.gap_rn, MAX(gf.rn) + 1) - 1 AS streak
+    FROM gap_flags gf
+    LEFT JOIN first_gap fg ON gf.participant_id = fg.participant_id
+    GROUP BY gf.participant_id, fg.gap_rn
+) AS streak_data ON cp.id = streak_data.participant_id
+SET cp.streak = streak_data.streak;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -94,6 +94,8 @@ class ChallengeProgressControllerUnitTest {
                 20,
                 true,
                 5,
+                3,
+                1,
                 List.of(new TodayTodoResponse(ChallengeTodoType.READ, ChallengeTodoStatus.COMPLETE)));
 
         given(challengeProgressService.getMemberProgress(eq(challengeId), any(Member.class)))

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -235,8 +235,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 dayIndex,
                 member.getId(),
-                request,
-                today
+                request
         );
 
         // then
@@ -267,8 +266,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 dayIndex,
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -342,8 +340,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 disabledGuide.getDayIndex(),
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -357,8 +354,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 999, // 존재하지 않는 dayIndex
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -438,8 +434,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 0,
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -466,8 +461,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 0,
                 member.getId(),
-                request,
-                today
+                request
         );
 
         // then - 댓글이 생성되었는지 확인
@@ -507,29 +501,12 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 1,
                 member.getId(),
-                request,
-                weekday
+                request
         );
 
         // then - 코멘트 생성 확인
         List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
         assertThat(comments).hasSize(1);
-
-        // then - READ 투두 생성 및 완료 확인
-        boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(),
-                weekday,
-                readTodo.getId()
-        );
-        assertThat(readTodoExists).isTrue();
-
-        // then - COMMENT 투두 생성 및 완료 확인
-        boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(),
-                weekday,
-                commentTodo.getId()
-        );
-        assertThat(commentTodoExists).isTrue();
 
         // then - MINDSET 투두 생성 확인
         boolean mindsetTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
@@ -569,8 +546,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 2,
                 member.getId(),
-                request,
-                today
+                request
         );
 
         // then - 코멘트는 생성됨
@@ -639,8 +615,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 1,
                 member.getId(),
-                request,
-                weekday
+                request
         );
 
         // then - MINDSET 투두는 1개만 존재 (중복 생성 안 됨)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -147,6 +147,8 @@ class ChallengeProgressServiceTest {
             softly.assertThat(response.totalDays()).isEqualTo(10);
             softly.assertThat(response.isSurvived()).isEqualTo(true);
             softly.assertThat(response.completedDays()).isEqualTo(3);
+            softly.assertThat(response.streak()).isEqualTo(0);
+            softly.assertThat(response.shield()).isEqualTo(0);
             softly.assertThat(response.todayTodos()).hasSize(2);
 
             softly.assertThat(response.todayTodos())
@@ -179,6 +181,7 @@ class ChallengeProgressServiceTest {
                 .memberId(member.getId())
                 .completedDays(3)
                 .shield(1)
+                .streak(3)
                 .isSurvived(true)
                 .build());
 
@@ -194,6 +197,7 @@ class ChallengeProgressServiceTest {
             softly.assertThat(updatedParticipant.getCompletedDays())
                     .isEqualTo(participant.getCompletedDays() + 1);
             softly.assertThat(updatedParticipant.isSurvived()).isTrue();
+            softly.assertThat(updatedParticipant.getStreak()).isEqualTo(3); // 쉴드 사용 시 스트릭 유지
 
             List<ChallengeDailyResult> results = challengeDailyResultRepository.findAll();
             softly.assertThat(results).hasSize(1);
@@ -224,6 +228,7 @@ class ChallengeProgressServiceTest {
                 .memberId(member.getId())
                 .completedDays(3)
                 .shield(0)
+                .streak(3)
                 .isSurvived(true)
                 .build());
 
@@ -236,6 +241,7 @@ class ChallengeProgressServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(updatedParticipant.isSurvived()).isTrue();
             softly.assertThat(updatedParticipant.getCompletedDays()).isEqualTo(3);
+            softly.assertThat(updatedParticipant.getStreak()).isEqualTo(0); // 결석 시 스트릭 리셋
         });
     }
 
@@ -417,6 +423,39 @@ class ChallengeProgressServiceTest {
                 .date(date)
                 .status(status)
                 .build();
+    }
+
+    @Test
+    void 연속_참여_스트릭이_응답에_포함된다() {
+        // given
+        NewsletterGroup group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("스트릭 그룹"));
+        Challenge streakChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Streak Challenge",
+                LocalDate.now().minusDays(5),
+                LocalDate.now().plusDays(5),
+                10,
+                group.getId()));
+
+        challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .isSurvived(true)
+                .shield(2)
+                .streak(5)
+                .build());
+
+        challengeTodoRepository.save(TestFixture.createChallengeTodo(streakChallenge.getId(), ChallengeTodoType.READ));
+        challengeTodoRepository.save(TestFixture.createChallengeTodo(streakChallenge.getId(), ChallengeTodoType.COMMENT));
+
+        // when
+        MemberChallengeProgressResponse response = challengeProgressService.getMemberProgress(streakChallenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streak()).isEqualTo(5);
+            softly.assertThat(response.shield()).isEqualTo(2);
+        });
     }
 
     @Test

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -197,12 +197,46 @@ class ChallengeProgressServiceTest {
             softly.assertThat(updatedParticipant.getCompletedDays())
                     .isEqualTo(participant.getCompletedDays() + 1);
             softly.assertThat(updatedParticipant.isSurvived()).isTrue();
-            softly.assertThat(updatedParticipant.getStreak()).isEqualTo(3); // 쉴드 사용 시 스트릭 유지
+            softly.assertThat(updatedParticipant.getStreak()).isEqualTo(4); // 쉴드 사용 시 스트릭 증가
 
             List<ChallengeDailyResult> results = challengeDailyResultRepository.findAll();
             softly.assertThat(results).hasSize(1);
             softly.assertThat(results.getFirst().getStatus()).isEqualTo(ChallengeDailyStatus.SHIELD);
             softly.assertThat(results.getFirst().getDate()).isEqualTo(yesterday);
+        });
+    }
+
+    @Test
+    void 쉴드_사용_시_스트릭이_증가한다() {
+        // given
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        NewsletterGroup group = TestFixture.createNewsletterGroup("쉴드 스트릭 그룹");
+        newsletterGroupRepository.save(group);
+        Challenge streakChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Shield Streak Challenge",
+                yesterday.minusDays(4),
+                yesterday.plusDays(5),
+                10,
+                group.getId()));
+
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .shield(1)
+                .streak(5)
+                .isSurvived(true)
+                .build());
+
+        // when
+        challengeProgressService.proceedDailySurvivalCheck(streakChallenge, yesterday);
+
+        // then
+        ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(updated.getShield()).isEqualTo(0);
+            softly.assertThat(updated.getStreak()).isEqualTo(6);
         });
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -197,7 +197,7 @@ class ChallengeProgressServiceTest {
             softly.assertThat(updatedParticipant.getCompletedDays())
                     .isEqualTo(participant.getCompletedDays() + 1);
             softly.assertThat(updatedParticipant.isSurvived()).isTrue();
-            softly.assertThat(updatedParticipant.getStreak()).isEqualTo(4); // 쉴드 사용 시 스트릭 증가
+            softly.assertThat(updatedParticipant.getStreak()).isEqualTo(3); // 쉴드 사용 시 스트릭 유지
 
             List<ChallengeDailyResult> results = challengeDailyResultRepository.findAll();
             softly.assertThat(results).hasSize(1);
@@ -207,7 +207,7 @@ class ChallengeProgressServiceTest {
     }
 
     @Test
-    void 쉴드_사용_시_스트릭이_증가한다() {
+    void 쉴드_사용_시_스트릭을_유지한다() {
         // given
         LocalDate yesterday = LocalDate.now().minusDays(1);
 
@@ -236,7 +236,7 @@ class ChallengeProgressServiceTest {
         ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
         assertSoftly(softly -> {
             softly.assertThat(updated.getShield()).isEqualTo(0);
-            softly.assertThat(updated.getStreak()).isEqualTo(6);
+            softly.assertThat(updated.getStreak()).isEqualTo(5);
         });
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoServiceTest.java
@@ -80,7 +80,7 @@ class ChallengeTodoServiceTest {
     @Test
     void 일일_투두_완료_시_completedDays와_streak가_증가한다() {
         // when
-        challengeTodoService.completeDailyTodo(participant, LocalDate.now());
+        challengeTodoService.completeDailyTodo(participant.getId(), LocalDate.now());
 
         // then
         ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).orElseThrow();

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoServiceTest.java
@@ -1,0 +1,96 @@
+package me.bombom.api.v1.challenge.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterGroupRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+class ChallengeTodoServiceTest {
+
+    @Autowired
+    private ChallengeTodoService challengeTodoService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ChallengeTodoRepository challengeTodoRepository;
+
+    @Autowired
+    private ChallengeDailyTodoRepository challengeDailyTodoRepository;
+
+    @Autowired
+    private ChallengeDailyResultRepository challengeDailyResultRepository;
+
+    @Autowired
+    private NewsletterGroupRepository newsletterGroupRepository;
+
+    private ChallengeParticipant participant;
+
+    @BeforeEach
+    void setUp() {
+        challengeDailyResultRepository.deleteAllInBatch();
+        challengeDailyTodoRepository.deleteAllInBatch();
+        challengeTodoRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        newsletterGroupRepository.deleteAllInBatch();
+
+        var member = memberRepository.save(TestFixture.createUniqueMember("tester", "id"));
+        var group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("그룹"));
+        var challenge = challengeRepository.save(TestFixture.createChallenge(
+                "Challenge", LocalDate.now().minusDays(3), LocalDate.now().plusDays(7), 10, group.getId()));
+
+        challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.COMMENT));
+
+        participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(challenge.getId())
+                .memberId(member.getId())
+                .completedDays(2)
+                .streak(2)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+    }
+
+    @Test
+    void 일일_투두_완료_시_completedDays와_streak가_증가한다() {
+        // when
+        challengeTodoService.completeDailyTodo(participant, LocalDate.now());
+
+        // then
+        ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        List<ChallengeDailyResult> results = challengeDailyResultRepository.findAll();
+
+        assertSoftly(softly -> {
+            softly.assertThat(updated.getCompletedDays()).isEqualTo(3);
+            softly.assertThat(updated.getStreak()).isEqualTo(3);
+            softly.assertThat(results).hasSize(1);
+            softly.assertThat(results.getFirst().getStatus()).isEqualTo(ChallengeDailyStatus.COMPLETE);
+        });
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 연속 출석일수(스트릭)를 구현하고, 클라이언트가 스트릭 달성 애니메이션을 트리거할 수 있도록 코멘트 작성 API 응답에 `firstCompletion` 필드를 추가했습니다.


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 참여자 동기 부여를 위해 스트릭(연속 출석일수) 기능이 필요합니다.
클라이언트에서 스트릭 달성 애니메이션을 보여주려면 "이번 요청으로 오늘 처음 완료됐는지"를 알아야 하는데,                                                                                                                        
서버가 완료 여부를 판단하는 구조라 클라이언트가 이를 알 방법이 없었습니다.    

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

 **스트릭 도메인**                                         
- `ChallengeParticipant`에 `streak` 필드 추가
- 투두 완료 시 `increaseStreak()`, 결석 시 `resetStreak()`, 쉴드 사용 시 유지 (TODO: 정책 결정 필요)                                                                                                                            
- 기존 참여자 스트릭 초기화 마이그레이션 SQL 추가 (레코드 간 간격 기반, 주말 3일 허용)                                                                                                                                          
                                                                                                                                                                                                                                  
  **firstCompletion**                                                                                                                                                                                                             
- 코멘트 작성 API 응답에 `firstCompletion(boolean)` 추가                                                                                                                                                                        
- "이번 요청으로 오늘 처음 완료됐는지" 여부로, 클라이언트가 스트릭 애니메이션 트리거 조건으로 사용                                                                                                                              
- `isCompleted`가 아닌 `firstCompletion`을 사용하는 이유: 두 번째 코멘트부터 매번 애니메이션이 트리거되는 것을 방지                                                                                                             
- 한 줄 코멘트 API, 데일리 가이드 코멘트 API 모두 적용

## Figma에 적었던 결정 사항
문제 상황
- 챌린지 완료 여부는 서버가 판단 (아티클 읽기, 코멘트 작성 등 사용자 행동 기반)                                                                                             
- 클라이언트는 서버가 완료를 판단한 시점을 알아야 스트릭 애니메이션을 보여줄 수 있음
- 아티클 읽기 같은 API는 챌린지 비참여자도 호출하는 범용 API 라 챌린지 로직을 직접 넣기 어려움                                                                              
- 즉, "서버가 완료를 판단했다"는 사실을 클라이언트에게 어떻게 전달할 것인가 가 핵심   

결론
- 코멘트 작성 API 응답에 firstCompletion(boolean) 포함

다른 방안 탈락 이유
- SSE — 분산 환경으로 인해 Redis pub/sub 등 인프라 추가 필요. sse만 하나의 서버로 고정시킬 경우, 그 서버 재부팅 시에 유실 위험
- 범용 API 응답에 포함 — 챌린지 비참여자도 호출하는 API를 오염시킴
- 폴링 — 완료 시점 부정확, 불필요한 요청 다수 발생
- 완료 여부 별도 API — 클라이언트가 호출 순서·타이밍을 직접 보장해야 함. 서버 내부가 동기→비동기로 바뀌면 조용히 깨지는 구조

코멘트 API에 포함하는 이유
- 코멘트 API는 이미 챌린지 참여자 전용이라 범용 API 오염 문제 없음
- 클라이언트에서 단일 호출로 완료 여부까지 처리 가능, 호출 순서나 타이밍 의존 없음                                                                                                                     
- RESTful 원칙에서 벗어나지만, 이 트레이드오프가 타이밍 리스크보다 낫다고 판단
- 추가로 첫날의 경우에는 데일리 가이드 코멘트 작성 시 완료이기 때문에 데일리 가이드 생성 API 응답에도 동일하게 `firstCompletion`을 담았습니다!
                                                                                                                                                                              
주의할 점
- isCompleted만 반환하면 두 번째 코멘트부터 항상 true → 애니메이션 매번 트리거
  → firstCompletion 으로 "이번 코멘트로 처음 완료됐는지" 를 구분해야 함
                                                                                                                                                                                                                               
향후 전환 시점                                                                                                                                                              
- 코멘트 작성이 마지막 TODO가 아니게 되거나, 참여자 규모가 커지면 SSE 전환 검토

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
                                                                                                
- `firstCompletion` 판단 방식이 적절한지 확인 부탁드립니다.                                                                                                                                                                     
  - 챌린지 코멘트 작성 후 `@TransactionalEventListener(AFTER_COMMIT)`로 `ChallengeDailyResult`가 생성됩니다.                                                                                                                    
  - `firstCompletion`을 코멘트 생성 API의 응답에 담으려면 코멘트 생성 시점에 당일 `ChallengeDailyResult` 존재 여부를 알아야 합니다.                                                                                                               
  - 이벤트는 트랜잭션 커밋 이후 실행되므로, 이벤트 발행 전 `isCompletedToday()`로 미리 체크하는 방식으로 구현했습니다.                                                                                                          
  - "오늘 아직 완료 기록이 없다 + 코멘트 작성 = 오늘 처음 완료" 가 항상 성립한다는 전제를 가집니다. (코멘트가 마지막 TODO)