### PR TITLE
[BOM-1025] feat: 챌린지 아티클 읽기 기준 변경

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/event/MarkAsReadEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/event/MarkAsReadEvent.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.article.event;
 
 public record MarkAsReadEvent(
+
         Long memberId,
         Long articleId
 ) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentController.java
@@ -12,6 +12,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleR
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentLikeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.service.ChallengeCommentService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
@@ -71,12 +72,12 @@ public class ChallengeCommentController implements ChallengeCommentControllerApi
     @Override
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/{challengeId}/comments")
-    public void createChallengeComment(
+    public CreateCommentResponse createChallengeComment(
             @LoginMember Member member,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Valid @RequestBody ChallengeCommentRequest request
     ) {
-        challengeCommentService.createChallengeComment(member.getId(), challengeId, request);
+        return challengeCommentService.createChallengeComment(member.getId(), challengeId, request);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeCommentControllerApi.java
@@ -17,6 +17,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleR
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentLikeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
@@ -70,7 +71,7 @@ public interface ChallengeCommentControllerApi {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 값", content = @Content),
             @ApiResponse(responseCode = "404", description = "아티클을 찾을 수 없음", content = @Content)
     })
-    void createChallengeComment(
+    CreateCommentResponse createChallengeComment(
             @Parameter(hidden = true) Member member,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Valid @RequestBody ChallengeCommentRequest request

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeController.java
@@ -8,6 +8,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeLandingResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
+import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.challenge.service.ChallengeService;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,8 +33,11 @@ public class ChallengeController implements ChallengeControllerApi {
 
     @Override
     @GetMapping
-    public List<ChallengeResponse> getChallenges(@LoginMember(anonymous = true) Member member) {
-        return challengeService.getChallenges(member);
+    public List<ChallengeResponse> getChallenges(
+            @RequestParam(required = false, defaultValue = "DEFAULT") ChallengeFilter view,
+            @LoginMember(anonymous = true) Member member
+    ) {
+        return challengeService.getChallenges(member, view);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeControllerApi.java
@@ -13,23 +13,29 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeLandingResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeTeamListResponse;
+import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Challenge", description = "챌린지 관련 API")
 public interface ChallengeControllerApi {
 
     @Operation(
             summary = "챌린지 전체 목록 조회",
-            description = "진행중이거나 예정된 챌린지 전체 목록을 조회합니다. 로그인 시 참여 여부 및 상세 정보가 함께 반환됩니다."
+            description = "진행중이거나 예정된 챌린지 전체 목록을 조회합니다. 로그인 시 참여 여부 및 상세 정보가 함께 반환됩니다. "
+                    + "view=summary 일 때는 ONGOING이면서 참여 중인 챌린지, EARLY/LATE 신청 단계 챌린지만 조회합니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "챌린지 목록 조회 성공")
     })
     @GetMapping
-    List<ChallengeResponse> getChallenges(@Parameter(hidden = true) @LoginMember Member member);
+    List<ChallengeResponse> getChallenges(
+            @Parameter(description = "summary 시 요약 목록(참여 중인 ONGOING, EARLY/LATE 신청 단계만) 조회") @RequestParam(required = false, defaultValue = "DEFAULT") ChallengeFilter view,
+            @Parameter(hidden = true) @LoginMember(anonymous = true) Member member
+    );
 
     @Operation(
             summary = "챌린지 상세 조회",

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideController.java
@@ -2,10 +2,9 @@ package me.bombom.api.v1.challenge.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import java.time.LocalDate;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
@@ -32,8 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/challenges")
 public class ChallengeDailyGuideController implements ChallengeDailyGuideControllerApi {
 
-    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
-
     private final ChallengeDailyGuideService challengeDailyGuideService;
 
     @Override
@@ -58,14 +55,13 @@ public class ChallengeDailyGuideController implements ChallengeDailyGuideControl
     @Override
     @PostMapping("/{challengeId}/daily-guides/{dayIndex}/my-comment")
     @ResponseStatus(HttpStatus.CREATED)
-    public void createDailyGuideComment(
+    public CreateCommentResponse createDailyGuideComment(
             @LoginMember Member member,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,
             @Valid @RequestBody DailyGuideCommentRequest request
     ) {
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
-        challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request, today);
+        return challengeDailyGuideService.createDailyGuideComment(challengeId, dayIndex, member.getId(), request);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeDailyGuideControllerApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
@@ -65,7 +66,7 @@ public interface ChallengeDailyGuideControllerApi {
             @ApiResponse(responseCode = "403", description = "챌린지 참여 권한 없음 또는 댓글 작성 불가", content = @Content),
             @ApiResponse(responseCode = "404", description = "챌린지 또는 데일리 가이드를 찾을 수 없음", content = @Content)
     })
-    void createDailyGuideComment(
+    CreateCommentResponse createDailyGuideComment(
             @Parameter(hidden = true) @LoginMember Member member,
             @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(description = "일차 인덱스 (1부터 시작)") @PathVariable @Positive(message = "일차 인덱스는 1 이상의 값이어야 합니다.") int dayIndex,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressController.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.challenge.controller;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.dto.response.CertificationInfoResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeStreakResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
@@ -12,6 +13,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -29,6 +31,16 @@ public class ChallengeProgressController implements ChallengeProgressControllerA
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id
     ) {
         return challengeProgressService.getMemberProgress(id, member);
+    }
+
+    @Override
+    @GetMapping("/{id}/progress/me/streak")
+    public ChallengeStreakResponse getMemberStreak(
+            @LoginMember Member member,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @RequestParam(defaultValue = "5") @Positive(message = "limit는 1 이상의 값이어야 합니다.") int limit
+    ) {
+        return challengeProgressService.getMemberStreak(id, member, limit);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerApi.java
@@ -8,11 +8,13 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
 import me.bombom.api.v1.challenge.dto.response.CertificationInfoResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeStreakResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "ChallengeProgress", description = "챌린지 진행도 관련 API")
 public interface ChallengeProgressControllerApi {
@@ -27,6 +29,20 @@ public interface ChallengeProgressControllerApi {
     MemberChallengeProgressResponse getMemberProgress(
             @Parameter(hidden = true) @LoginMember Member member,
             @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id
+    );
+
+    @Operation(summary = "챌린지 스트릭 조회", description = "사용자의 현재 스트릭 값과 스트릭을 구성하는 날짜 목록(날짜, 요일, 쉴드 적용 여부)을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스트릭 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
+            @ApiResponse(responseCode = "403", description = "챌린지에 참가하지 않음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "챌린지/참가자를 찾을 수 없음", content = @Content),
+    })
+    ChallengeStreakResponse getMemberStreak(
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "챌린지 ID") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long id,
+            @Parameter(description = "조회할 스트릭 날짜 수 (기본값: 5)") @RequestParam(defaultValue = "5") @Positive(message = "limit는 1 이상의 값이어야 합니다.") int limit
     );
 
     @Operation(summary = "특정 팀 진행도 조회", description = "특정 팀의 진행도 및 팀원들의 진행 상황을 조회합니다.")

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.challenge.domain;
 
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.Set;
 
 public enum ChallengeFilter {
@@ -16,8 +17,10 @@ public enum ChallengeFilter {
         }
 
         @Override
-        public Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
-            return Comparator.comparingInt(challenge -> getSummaryOrder(challenge, today, joinedChallengeIds));
+        public Optional<Comparator<Challenge>> orderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
+            return Optional.of(
+                    Comparator.comparingInt(challenge -> getSummaryOrder(challenge, today, joinedChallengeIds))
+            );
         }
     },
     DEFAULT {
@@ -31,14 +34,14 @@ public enum ChallengeFilter {
         }
 
         @Override
-        public Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
-            return (a, b) -> 0;
+        public Optional<Comparator<Challenge>> orderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
+            return Optional.empty();
         }
     };
 
     public abstract boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined);
 
-    public abstract Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds);
+    public abstract Optional<Comparator<Challenge>> orderComparator(LocalDate today, Set<Long> joinedChallengeIds);
 
     static int getSummaryOrder(Challenge challenge, LocalDate today, Set<Long> joinedChallengeIds) {
         ChallengeStatus status = challenge.getStatus(today);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
@@ -1,6 +1,8 @@
 package me.bombom.api.v1.challenge.domain;
 
 import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.Set;
 
 public enum ChallengeFilter {
 
@@ -12,6 +14,11 @@ public enum ChallengeFilter {
             return (status == ChallengeStatus.ONGOING && isJoined)
                     || phase.isRecruiting();
         }
+
+        @Override
+        public Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
+            return Comparator.comparingInt(challenge -> getSummaryOrder(challenge, today, joinedChallengeIds));
+        }
     },
     DEFAULT {
         @Override
@@ -22,7 +29,31 @@ public enum ChallengeFilter {
                     || isJoined
                     || challenge.isLatePhase(today);
         }
+
+        @Override
+        public Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds) {
+            return (a, b) -> 0;
+        }
     };
 
     public abstract boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined);
+
+    public abstract Comparator<Challenge> summaryOrderComparator(LocalDate today, Set<Long> joinedChallengeIds);
+
+    static int getSummaryOrder(Challenge challenge, LocalDate today, Set<Long> joinedChallengeIds) {
+        ChallengeStatus status = challenge.getStatus(today);
+        RegistrationPhase phase = challenge.getRegistrationPhase(today);
+        boolean isJoined = joinedChallengeIds.contains(challenge.getId());
+
+        if (status == ChallengeStatus.ONGOING && isJoined) {
+            return 0;
+        }
+        if (phase == RegistrationPhase.LATE) {
+            return 1;
+        }
+        if (phase == RegistrationPhase.EARLY) {
+            return 2;
+        }
+        return 3;
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilter.java
@@ -1,0 +1,28 @@
+package me.bombom.api.v1.challenge.domain;
+
+import java.time.LocalDate;
+
+public enum ChallengeFilter {
+
+    SUMMARY {
+        @Override
+        public boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined) {
+            ChallengeStatus status = challenge.getStatus(today);
+            RegistrationPhase phase = challenge.getRegistrationPhase(today);
+            return (status == ChallengeStatus.ONGOING && isJoined)
+                    || phase.isRecruiting();
+        }
+    },
+    DEFAULT {
+        @Override
+        public boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined) {
+            ChallengeStatus status = challenge.getStatus(today);
+            return status == ChallengeStatus.COMING_SOON
+                    || status == ChallengeStatus.BEFORE_START
+                    || isJoined
+                    || challenge.isLatePhase(today);
+        }
+    };
+
+    public abstract boolean isVisible(Challenge challenge, LocalDate today, boolean isJoined);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
@@ -1,5 +1,7 @@
 package me.bombom.api.v1.challenge.domain;
 
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
 
@@ -14,6 +16,9 @@ public class ChallengeFilterConverter implements Converter<String, ChallengeFilt
         if ("summary".equalsIgnoreCase(source)) {
             return ChallengeFilter.SUMMARY;
         }
-        return ChallengeFilter.DEFAULT;
+        if ("default".equalsIgnoreCase(source)) {
+            return ChallengeFilter.DEFAULT;
+        }
+        throw new CIllegalArgumentException(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
@@ -4,13 +4,14 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 public class ChallengeFilterConverter implements Converter<String, ChallengeFilter> {
 
     @Override
     public ChallengeFilter convert(String source) {
-        if (source == null || source.isBlank()) {
+        if (!StringUtils.hasText(source)) {
             return ChallengeFilter.DEFAULT;
         }
         if ("summary".equalsIgnoreCase(source)) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeFilterConverter.java
@@ -1,0 +1,19 @@
+package me.bombom.api.v1.challenge.domain;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ChallengeFilterConverter implements Converter<String, ChallengeFilter> {
+
+    @Override
+    public ChallengeFilter convert(String source) {
+        if (source == null || source.isBlank()) {
+            return ChallengeFilter.DEFAULT;
+        }
+        if ("summary".equalsIgnoreCase(source)) {
+            return ChallengeFilter.SUMMARY;
+        }
+        return ChallengeFilter.DEFAULT;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeParticipant.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/ChallengeParticipant.java
@@ -43,6 +43,9 @@ public class ChallengeParticipant extends BaseEntity {
     @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
     private int shield = 0;
 
+    @Column(nullable = false, columnDefinition = "INT DEFAULT 0")
+    private int streak = 0;
+
     @Builder
     public ChallengeParticipant(
             Long id,
@@ -51,7 +54,8 @@ public class ChallengeParticipant extends BaseEntity {
             Long challengeTeamId,
             int completedDays,
             boolean isSurvived,
-            int shield
+            int shield,
+            int streak
     ) {
         this.id = id;
         this.challengeId = challengeId;
@@ -60,6 +64,7 @@ public class ChallengeParticipant extends BaseEntity {
         this.completedDays = completedDays;
         this.isSurvived = isSurvived;
         this.shield = shield;
+        this.streak = streak;
     }
 
     public int calculateProgress(int totalDays) {
@@ -85,5 +90,13 @@ public class ChallengeParticipant extends BaseEntity {
 
     public void increaseCompletedDays() {
         this.completedDays += 1;
+    }
+
+    public void increaseStreak() {
+        this.streak += 1;
+    }
+
+    public void resetStreak() {
+        this.streak = 0;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/RegistrationPhase.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/domain/RegistrationPhase.java
@@ -6,4 +6,8 @@ public enum RegistrationPhase {
     LATE,
     CLOSED,
     ;
+
+    public boolean isRecruiting() {
+        return this == EARLY || this == LATE;
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/ChallengeProgressFlat.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/ChallengeProgressFlat.java
@@ -8,6 +8,8 @@ public record ChallengeProgressFlat(
         int completedDays,
         boolean isSurvived,
         ChallengeTodoType todoType,
-        boolean isDone
+        boolean isDone,
+        int streak,
+        int shield
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeStreakResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeStreakResponse.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
+
+public record ChallengeStreakResponse(
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        int streak,
+
+        @NotNull
+        List<StreakDayResponse> streakDays
+) {
+
+    public static ChallengeStreakResponse empty() {
+        return new ChallengeStreakResponse(0, List.of());
+    }
+
+    public static ChallengeStreakResponse of(int streak, List<ChallengeDailyResult> results) {
+        List<StreakDayResponse> days = StreakDayResponse.from(results.reversed());
+        return new ChallengeStreakResponse(streak, days);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CreateCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CreateCommentResponse.java
@@ -4,4 +4,8 @@ public record CreateCommentResponse(
 
         boolean isFirstCompletion
 ) {
+
+    public static CreateCommentResponse from(boolean isFirstCompletion) {
+        return new CreateCommentResponse(isFirstCompletion);
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CreateCommentResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/CreateCommentResponse.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+public record CreateCommentResponse(
+
+        boolean isFirstCompletion
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MemberChallengeProgressResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MemberChallengeProgressResponse.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.challenge.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import me.bombom.api.v1.challenge.dto.ChallengeProgressFlat;
@@ -11,14 +12,20 @@ public record MemberChallengeProgressResponse(
         @NotNull
         String nickname,
 
-        @Schema(required = true)
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         int totalDays,
 
-        @Schema(required = true)
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         boolean isSurvived,
 
-        @Schema(required = true)
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         int completedDays,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        int streak,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        int shield,
 
         @NotNull
         List<TodayTodoResponse> todayTodos
@@ -36,6 +43,8 @@ public record MemberChallengeProgressResponse(
                 representative.totalDays(),
                 representative.isSurvived(),
                 representative.completedDays(),
+                representative.streak(),
+                representative.shield(),
                 todayTodos
         );
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/StreakDayResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/StreakDayResponse.java
@@ -1,0 +1,36 @@
+package me.bombom.api.v1.challenge.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
+
+public record StreakDayResponse(
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        LocalDate date,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        DayOfWeek dayOfWeek,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        boolean isShieldApplied
+) {
+
+    public static StreakDayResponse from(ChallengeDailyResult result) {
+        return new StreakDayResponse(
+                result.getDate(),
+                result.getDate().getDayOfWeek(),
+                result.getStatus() == ChallengeDailyStatus.SHIELD
+        );
+    }
+
+    public static List<StreakDayResponse> from(List<ChallengeDailyResult> results) {
+        return results.stream()
+                .map(StreakDayResponse::from)
+                .toList();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/ChallengeParticipantTodoListener.java
@@ -1,7 +1,5 @@
 package me.bombom.api.v1.challenge.event;
 
-import java.time.LocalDate;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.article.event.MarkAsReadEvent;
@@ -16,16 +14,13 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @RequiredArgsConstructor
 public class ChallengeParticipantTodoListener {
 
-    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
-
     private final ChallengeDailyTodoService challengeDailyTodoService;
 
     @TransactionalEventListener
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void on(MarkAsReadEvent event) {
         try {
-            LocalDate today = LocalDate.now(SEOUL_ZONE);
-            challengeDailyTodoService.updateChallengeDailyTodo(event.memberId(), event.articleId(), today);
+            challengeDailyTodoService.updateChallengeDailyTodo(event.memberId(), event.articleId());
         } catch (Exception e) {
             log.error("챌린지 데일리 투두 저장 중 오류가 발생했습니다. memberId={}", event.memberId(), e);
         }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListener.java
@@ -51,7 +51,7 @@ public class CreateChallengeCommentListener {
     private void completeDailyTodoWithComment(ChallengeParticipant participant, LocalDate today) {
         try {
             challengeTodoService.insertCommentDone(participant, today);
-            challengeTodoService.completeDailyTodo(participant, today);
+            challengeTodoService.completeDailyTodo(participant.getId(), today);
         } catch (DataIntegrityViolationException e) {
             String violated = extractConstraintName(e);
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyResultRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyResultRepository.java
@@ -1,10 +1,14 @@
 package me.bombom.api.v1.challenge.repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChallengeDailyResultRepository extends JpaRepository<ChallengeDailyResult, Long> {
 
     boolean existsByParticipantIdAndDate(Long participantId, LocalDate date);
+
+    List<ChallengeDailyResult> findByParticipantIdOrderByDateDesc(Long participantId, Pageable pageable);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
@@ -34,10 +34,12 @@ public interface ChallengeDailyTodoRepository extends JpaRepository<ChallengeDai
                         )
                   )
             """, nativeQuery = true)
-    int insertTodayReadTodoIfMissing(@Param("memberId") Long memberId,
-                                     @Param("articleId") Long articleId,
-                                     @Param("today") LocalDate today,
-                                     @Param("todoType") String todoType);
+    int insertTodayReadTodoIfMissing(
+            @Param("memberId") Long memberId,
+            @Param("articleId") Long articleId,
+            @Param("today") LocalDate today,
+            @Param("todoType") String todoType
+    );
 
     boolean existsByParticipantIdAndTodoDateAndChallengeTodoId(Long participantId, LocalDate todoDate,
                                                                Long challengeTodoId);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyTodoRepository.java
@@ -31,7 +31,6 @@ public interface ChallengeDailyTodoRepository extends JpaRepository<ChallengeDai
                             FROM article a
                             WHERE a.id = :articleId
                               AND a.member_id = cp.member_id
-                              AND DATE(a.arrived_date_time) = :today
                         )
                   )
             """, nativeQuery = true)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeParticipantRepository.java
@@ -54,7 +54,9 @@ public interface ChallengeParticipantRepository extends JpaRepository<ChallengeP
             CASE
                 WHEN cdt.id IS NOT NULL THEN true
                 ELSE false
-            END
+            END,
+            cp.streak,
+            cp.shield
         )
         FROM ChallengeParticipant cp
         JOIN Challenge c ON cp.challengeId = c.id

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -40,10 +40,10 @@ public class ChallengeCommentService {
     private final ChallengeCommentRepository challengeCommentRepository;
     private final ChallengeParticipantRepository challengeParticipantRepository;
     private final ChallengeCommentLikeRepository challengeCommentLikeRepository;
+    private final ChallengeTodoService challengeTodoService;
     private final ArticleRepository articleRepository;
     private final HighlightRepository highlightRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
-    private final ChallengeTodoService challengeTodoService;
     private final Clock clock;
 
     @Value("${challenge.highlight.truncate-ratio}")
@@ -102,7 +102,7 @@ public class ChallengeCommentService {
 
         challengeCommentRepository.save(comment);
         applicationEventPublisher.publishEvent(new CreateChallengeCommentEvent(participant.getId()));
-        return new CreateCommentResponse(isFirstCompletion);
+        return CreateCommentResponse.from(isFirstCompletion);
     }
 
     public Page<ChallengeCommentHighlightResponse> getChallengeArticleHighlights(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeCommentService.java
@@ -16,6 +16,7 @@ import me.bombom.api.v1.challenge.dto.response.ChallengeCommentCandidateArticleR
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentHighlightResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentLikeResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeCommentResponse;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.event.CreateChallengeCommentEvent;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentLikeRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeCommentRepository;
@@ -42,6 +43,7 @@ public class ChallengeCommentService {
     private final ArticleRepository articleRepository;
     private final HighlightRepository highlightRepository;
     private final ApplicationEventPublisher applicationEventPublisher;
+    private final ChallengeTodoService challengeTodoService;
     private final Clock clock;
 
     @Value("${challenge.highlight.truncate-ratio}")
@@ -73,13 +75,16 @@ public class ChallengeCommentService {
     }
 
     @Transactional
-    public void createChallengeComment(
+    public CreateCommentResponse createChallengeComment(
             Long memberId,
             Long challengeId,
             ChallengeCommentRequest request
     ) {
         validateCommentAvailableDay(memberId, challengeId);
         ChallengeParticipant participant = getChallengeParticipant(memberId, challengeId);
+
+        LocalDate today = LocalDate.now(clock);
+        boolean isFirstCompletion = !challengeTodoService.isCompletedToday(participant.getId(), today);
 
         Article article = articleRepository.findById(request.articleId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
@@ -97,6 +102,7 @@ public class ChallengeCommentService {
 
         challengeCommentRepository.save(comment);
         applicationEventPublisher.publishEvent(new CreateChallengeCommentEvent(participant.getId()));
+        return new CreateCommentResponse(isFirstCompletion);
     }
 
     public Page<ChallengeCommentHighlightResponse> getChallengeArticleHighlights(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -168,7 +168,7 @@ public class ChallengeDailyGuideService {
                 }
             }
         }
-        return new CreateCommentResponse(firstCompletion);
+        return CreateCommentResponse.from(firstCompletion);
     }
 
     public MemberDailyCommentResponse getDailyGuideComment(Long challengeId, int dayIndex, Long memberId) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -12,6 +12,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
+import me.bombom.api.v1.challenge.dto.response.CreateCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayDailyGuideResponse;
@@ -99,8 +100,13 @@ public class ChallengeDailyGuideService {
     }
 
     @Transactional
-    public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
-            DailyGuideCommentRequest request, LocalDate today) {
+    public CreateCommentResponse createDailyGuideComment(
+            Long challengeId,
+            int dayIndex,
+            Long memberId,
+            DailyGuideCommentRequest request
+    ) {
+        LocalDate today = LocalDate.now(clock);
         Challenge challenge = getChallenge(challengeId);
 
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
@@ -145,25 +151,24 @@ public class ChallengeDailyGuideService {
                 .build();
         challengeDailyGuideCommentRepository.save(comment);
 
+        boolean firstCompletion = false;
+
         // day1일 때만 체크리스트 자동 완료 처리
         if (dayIndex == 1) {
             // MINDSET 투두 생성 (마인드셋 댓글 작성)
             challengeTodoService.insertMindsetDone(participant, today);
-            // TODO: 과도기라서 모두 완료 처리가 필요해 보임. 추후 삭제 필요
-            // READ 투두 자동 생성 (뉴스레터 1개 읽기)
-            challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
-            // COMMENT 투두 생성 (한 줄 코멘트 작성)
-            challengeTodoService.insertCommentDone(participant, today);
 
             // 이미 완료되지 않았으면 progress 처리
             if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
-                challengeTodoService.completeDailyTodo(participant, today);
+                challengeTodoService.completeDailyTodo(participant.getId(), today);
+                firstCompletion = true;
                 if (participant.getChallengeTeamId() != null) {
                     ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
                     challengeTeamService.updateTeamProgress(challengeTeam);
                 }
             }
         }
+        return new CreateCommentResponse(firstCompletion);
     }
 
     public MemberDailyCommentResponse getDailyGuideComment(Long challengeId, int dayIndex, Long memberId) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoService.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.challenge.service;
 
+import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.format.TextStyle;
@@ -17,10 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ChallengeDailyTodoService {
 
+    private final Clock clock;
     private final ChallengeDailyTodoRepository challengeDailyTodoRepository;
 
     @Transactional
-    public void updateChallengeDailyTodo(Long memberId, Long articleId, LocalDate today) {
+    public void updateChallengeDailyTodo(Long memberId, Long articleId) {
+        LocalDate today = LocalDate.now(clock);
         if (isWeekend(today)) {
             log.info("오늘은 {}입니다. 주말에는 챌린지를 진행하지 않습니다.", today.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN));
             return;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -55,6 +55,7 @@ public class ChallengeProgressService {
                 saveShieldDailyResult(absentee, yesterday);
                 continue;
             }
+            absentee.resetStreak();
             checkFailure(absentee, challenge, yesterday);
         }
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -15,6 +15,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.dto.ChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.response.CertificationInfoResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeStreakResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
@@ -28,6 +29,7 @@ import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -68,6 +70,23 @@ public class ChallengeProgressService {
         validateMemberProgressDataIntegrity(id, member, progressList);
 
         return MemberChallengeProgressResponse.of(member, progressList);
+    }
+
+    public ChallengeStreakResponse getMemberStreak(Long challengeId, Member member, int limit) {
+        validateParticipation(challengeId, member);
+        ChallengeParticipant participant = getChallengeParticipant(challengeId, member.getId());
+
+        int streak = participant.getStreak();
+        int fetchCount = Math.min(limit, streak);
+        if (fetchCount == 0) {
+            return ChallengeStreakResponse.empty();
+        }
+
+        List<ChallengeDailyResult> recentDays = challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(
+                participant.getId(),
+                PageRequest.of(0, fetchCount)
+        );
+        return ChallengeStreakResponse.of(streak, recentDays);
     }
 
     public TeamChallengeProgressResponse getTeamProgressByTeamId(Long challengeId, Long teamId, Member member) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.badge.service.BadgeService;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.challenge.domain.ChallengeGrade;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
@@ -62,7 +63,7 @@ public class ChallengeService {
     private final BadgeService badgeService;
     private final Clock clock;
 
-    public List<ChallengeResponse> getChallenges(Member member) {
+    public List<ChallengeResponse> getChallenges(Member member, ChallengeFilter view) {
         List<Challenge> challenges = challengeRepository.findAll();
         if (challenges.isEmpty()) {
             return Collections.emptyList();
@@ -72,13 +73,17 @@ public class ChallengeService {
                 .map(Challenge::getId)
                 .toList();
 
+        LocalDate today = LocalDate.now(clock);
         Map<Long, Long> participantCounts = getParticipantCounts(challengeIds);
-        Map<Long, List<ChallengeNewsletterResponse>> newslettersByChallengeId = getNewslettersByChallengeId(challengeIds);
+        Map<Long, List<ChallengeNewsletterResponse>> newslettersByChallengeId =
+                getNewslettersByChallengeId(challengeIds);
         Map<Long, ChallengeParticipant> myParticipation = findMyParticipation(member, challengeIds);
 
-        LocalDate today = LocalDate.now(clock);
         return challenges.stream()
-                .filter(challenge -> isVisibleInChallengeList(challenge, today, myParticipation.containsKey(challenge.getId())))
+                .filter(challenge -> {
+                    boolean isJoined = myParticipation.containsKey(challenge.getId());
+                    return view.isVisible(challenge, today, isJoined);
+                })
                 .map(challenge -> toChallengeResponse(
                         challenge,
                         participantCounts,
@@ -215,14 +220,6 @@ public class ChallengeService {
         }
 
         return new ChallengeTeamListResponse(teams.size(), myTeamId, teamInfos);
-    }
-
-    private boolean isVisibleInChallengeList(Challenge challenge, LocalDate today, boolean isJoined) {
-        ChallengeStatus status = challenge.getStatus(today);
-        return status == ChallengeStatus.COMING_SOON
-                || status == ChallengeStatus.BEFORE_START
-                || isJoined
-                || challenge.isLatePhase(today);
     }
 
     private ChallengeResponse toChallengeResponse(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -9,9 +9,13 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.badge.service.BadgeService;
@@ -79,12 +83,14 @@ public class ChallengeService {
                 getNewslettersByChallengeId(challengeIds);
         Map<Long, ChallengeParticipant> myParticipation = findMyParticipation(member, challengeIds);
 
-        return challenges.stream()
-                .filter(challenge -> {
-                    boolean isJoined = myParticipation.containsKey(challenge.getId());
-                    return view.isVisible(challenge, today, isJoined);
-                })
-                .sorted(view.summaryOrderComparator(today, myParticipation.keySet()))
+        Stream<Challenge> challengeStream = challenges.stream()
+                .filter(challenge -> view.isVisible(
+                        challenge,
+                        today,
+                        myParticipation.containsKey(challenge.getId())
+                ));
+
+        return applySorting(challengeStream, view, today, myParticipation.keySet())
                 .map(challenge -> toChallengeResponse(
                         challenge,
                         participantCounts,
@@ -223,6 +229,44 @@ public class ChallengeService {
         return new ChallengeTeamListResponse(teams.size(), myTeamId, teamInfos);
     }
 
+    private Map<Long, Long> getParticipantCounts(List<Long> challengeIds) {
+        return challengeParticipantRepository.countByChallengeIdInGroupByChallengeId(challengeIds)
+                .stream()
+                .collect(toMap(ChallengeParticipantCount::challengeId, ChallengeParticipantCount::count));
+    }
+
+    private Map<Long, List<ChallengeNewsletterResponse>> getNewslettersByChallengeId(List<Long> challengeIds) {
+        List<ChallengeNewsletterRow> rows = newsletterGroupItemRepository.findChallengeNewsletterRowsByChallengeIds(challengeIds);
+
+        return rows.stream()
+                .collect(groupingBy(
+                        ChallengeNewsletterRow::challengeId,
+                        mapping(ChallengeNewsletterRow::response, toList())
+                ));
+    }
+
+    private Map<Long, ChallengeParticipant> findMyParticipation(Member member, List<Long> challengeIds) {
+        if (member == null) {
+            return Collections.emptyMap();
+        }
+        return challengeParticipantRepository.findByMemberIdAndChallengeIdIn(member.getId(), challengeIds)
+                .stream()
+                .collect(toMap(ChallengeParticipant::getChallengeId, p -> p));
+    }
+
+    private Stream<Challenge> applySorting(
+            Stream<Challenge> stream,
+            ChallengeFilter view,
+            LocalDate today,
+            Set<Long> joinedIds
+    ) {
+        Optional<Comparator<Challenge>> comparatorOpt = view.orderComparator(today, joinedIds);
+
+        return comparatorOpt.isPresent()
+                ? stream.sorted(comparatorOpt.get())
+                : stream;
+    }
+
     private ChallengeResponse toChallengeResponse(
             Challenge challenge,
             Map<Long, Long> participantCounts,
@@ -250,31 +294,6 @@ public class ChallengeService {
         );
     }
 
-    private Map<Long, Long> getParticipantCounts(List<Long> challengeIds) {
-        return challengeParticipantRepository.countByChallengeIdInGroupByChallengeId(challengeIds)
-                .stream()
-                .collect(toMap(ChallengeParticipantCount::challengeId, ChallengeParticipantCount::count));
-    }
-
-    private Map<Long, ChallengeParticipant> findMyParticipation(Member member, List<Long> challengeIds) {
-        if (member == null) {
-            return Collections.emptyMap();
-        }
-        return challengeParticipantRepository.findByMemberIdAndChallengeIdIn(member.getId(), challengeIds)
-                .stream()
-                .collect(toMap(ChallengeParticipant::getChallengeId, p -> p));
-    }
-
-    private Map<Long, List<ChallengeNewsletterResponse>> getNewslettersByChallengeId(List<Long> challengeIds) {
-        List<ChallengeNewsletterRow> rows = newsletterGroupItemRepository.findChallengeNewsletterRowsByChallengeIds(challengeIds);
-
-        return rows.stream()
-                .collect(groupingBy(
-                        ChallengeNewsletterRow::challengeId,
-                        mapping(ChallengeNewsletterRow::response, toList())
-                ));
-    }
-
     private ChallengeDetailResponse calculateParticipationInfo(
             Challenge challenge,
             ChallengeParticipant myParticipant,
@@ -293,6 +312,26 @@ public class ChallengeService {
             return ChallengeDetailResponse.ended(progress, isSurvived, grade);
         }
         return ChallengeDetailResponse.ongoing(progress, isSurvived);
+    }
+
+    private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
+        LocalDate today = LocalDate.now(clock);
+
+        if (challenge.isRegistrationClosed(today)) {
+            return EligibilityReason.ALREADY_STARTED;
+        }
+
+        boolean alreadyApplied = challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId);
+        if (alreadyApplied) {
+            return EligibilityReason.ALREADY_APPLIED;
+        }
+
+        boolean hasSubscribedNewsletter = newsletterGroupItemRepository.existsSubscribedNewsletter(challengeId, memberId);
+        if (!hasSubscribedNewsletter) {
+            return EligibilityReason.NOT_SUBSCRIBED;
+        }
+
+        return EligibilityReason.ELIGIBLE;
     }
 
     private RuntimeException createApplyException(Long challengeId, Member member, EligibilityReason reason) {
@@ -316,25 +355,5 @@ public class ChallengeService {
                 .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                 .addContext(ErrorContextKeys.OPERATION, "applyChallenge")
                 .addContext("reason", "ELIGIBLE 상태에서는 예외를 생성할 수 없습니다.");
-    }
-
-    private EligibilityReason validateEligibility(Challenge challenge, Long challengeId, Long memberId) {
-        LocalDate today = LocalDate.now(clock);
-
-        if (challenge.isRegistrationClosed(today)) {
-            return EligibilityReason.ALREADY_STARTED;
-        }
-
-        boolean alreadyApplied = challengeParticipantRepository.existsByChallengeIdAndMemberId(challengeId, memberId);
-        if (alreadyApplied) {
-            return EligibilityReason.ALREADY_APPLIED;
-        }
-
-        boolean hasSubscribedNewsletter = newsletterGroupItemRepository.existsSubscribedNewsletter(challengeId, memberId);
-        if (!hasSubscribedNewsletter) {
-            return EligibilityReason.NOT_SUBSCRIBED;
-        }
-
-        return EligibilityReason.ELIGIBLE;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -84,6 +84,7 @@ public class ChallengeService {
                     boolean isJoined = myParticipation.containsKey(challenge.getId());
                     return view.isVisible(challenge, today, isJoined);
                 })
+                .sorted(view.summaryOrderComparator(today, myParticipation.keySet()))
                 .map(challenge -> toChallengeResponse(
                         challenge,
                         participantCounts,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeTodoService.java
@@ -11,7 +11,9 @@ import me.bombom.api.v1.challenge.domain.ChallengeTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
 import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.CServerErrorException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
@@ -27,6 +29,7 @@ public class ChallengeTodoService {
     private final ChallengeTodoRepository challengeTodoRepository;
     private final ChallengeDailyTodoRepository challengeDailyTodoRepository;
     private final ChallengeDailyResultRepository challengeDailyResultRepository;
+    private final ChallengeParticipantRepository challengeParticipantRepository;
 
     public boolean isCompletedToday(Long participantId, LocalDate today) {
         return challengeDailyResultRepository.existsByParticipantIdAndDate(participantId, today);
@@ -84,15 +87,22 @@ public class ChallengeTodoService {
     }
 
     @Transactional
-    public void completeDailyTodo(ChallengeParticipant participant, LocalDate today){
+    public void completeDailyTodo(Long participantId, LocalDate today){
+        ChallengeParticipant participant = challengeParticipantRepository.findById(participantId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.OPERATION, "completeDailyTodo")
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                        .addContext(ErrorContextKeys.CHALLENGE_PARTICIPANT_ID, participantId));
+
         challengeDailyResultRepository.save(
                 ChallengeDailyResult.builder()
-                        .participantId(participant.getId())
+                        .participantId(participantId)
                         .date(today)
                         .status(ChallengeDailyStatus.COMPLETE)
                         .build()
         );
 
         participant.increaseCompletedDays();
+        participant.increaseStreak();
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/ErrorContextKeys.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/ErrorContextKeys.java
@@ -25,6 +25,7 @@ public enum ErrorContextKeys {
     HIGHLIGHT_ID("highlightId"),
     CHALLENGE_ID("challengeId"),
     CHALLENGE_TEAM_ID("challengeTeamId"),
+    CHALLENGE_PARTICIPANT_ID("challengeParticipantId"),
     COMMENT_ID("commentId"),
     DETAIL("detail"),
     ;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/exception/GlobalExceptionHandler.java
@@ -7,9 +7,9 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
-import jakarta.validation.ConstraintViolationException;
 
 @Slf4j
 @RestControllerAdvice
@@ -24,6 +24,33 @@ public class GlobalExceptionHandler {
         }
         return ResponseEntity.status(e.getHttpStatus())
                 .body(ErrorResponse.from(e.getErrorDetail()));
+    }
+
+    @ExceptionHandler(ConversionFailedException.class)
+    public ResponseEntity<ErrorResponse> handleConversionFailedException(ConversionFailedException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof CIllegalArgumentException illegalArg) {
+            return handleIllegalArgumentException(illegalArg);
+        }
+        log.info("Conversion failed: ", e);
+        return ResponseEntity.status(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION.getStatus())
+                .body(ErrorResponse.from(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e
+    ) {
+        Throwable cause = e.getCause();
+        if (cause instanceof ConversionFailedException conversionFailed) {
+            return handleConversionFailedException(conversionFailed);
+        }
+        if (cause instanceof CIllegalArgumentException illegalArg) {
+            return handleIllegalArgumentException(illegalArg);
+        }
+        log.info("Method argument type mismatch: ", e);
+        return ResponseEntity.status(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION.getStatus())
+                .body(ErrorResponse.from(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION));
     }
 
     @ExceptionHandler(UnauthorizedException.class)

--- a/backend/bom-bom-server/src/main/resources/db/migration/V30.4.0__add_streak_to_challenge_participant.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V30.4.0__add_streak_to_challenge_participant.sql
@@ -1,0 +1,41 @@
+ALTER TABLE challenge_participant
+    ADD COLUMN streak INT NOT NULL DEFAULT 0;
+
+-- 기존 참여자의 스트릭을 challenge_daily_result 기록 기반으로 계산하여 초기화
+-- challenge_daily_result에는 주말 데이터가 없으므로 금요일→월요일 간격(3일)까지 연속으로 판단
+-- 오늘 미완료 여부는 결석 체크 스케줄러가 담당하므로, 마이그레이션은 과거 기록 간 간격만 판단
+UPDATE challenge_participant cp
+JOIN (
+    WITH consecutive_check AS (
+        SELECT
+            participant_id,
+            date,
+            ROW_NUMBER() OVER (PARTITION BY participant_id ORDER BY date DESC) AS rn,
+            LAG(date)    OVER (PARTITION BY participant_id ORDER BY date DESC) AS prev_date
+        FROM challenge_daily_result
+    ),
+    gap_flags AS (
+        SELECT
+            participant_id,
+            rn,
+            CASE
+                -- 두 기록 간 간격이 3일 초과면 gap (금→월=3일은 연속으로 허용)
+                WHEN rn > 1 AND DATEDIFF(prev_date, date) > 3 THEN 1
+                ELSE 0
+            END AS has_gap
+        FROM consecutive_check
+    ),
+    first_gap AS (
+        SELECT participant_id, MIN(rn) AS gap_rn
+        FROM gap_flags
+        WHERE has_gap = 1
+        GROUP BY participant_id
+    )
+    SELECT
+        gf.participant_id,
+        COALESCE(fg.gap_rn, MAX(gf.rn) + 1) - 1 AS streak
+    FROM gap_flags gf
+    LEFT JOIN first_gap fg ON gf.participant_id = fg.participant_id
+    GROUP BY gf.participant_id, fg.gap_rn
+) AS streak_data ON cp.id = streak_data.participant_id
+SET cp.streak = streak_data.streak;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
@@ -173,5 +173,22 @@ class ChallengeControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isEmpty());
     }
+
+    @Test
+    void view_summary_파라미터로_요약_목록_조회() throws Exception {
+        // given: EARLY 챌린지 하나
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        Challenge challenge = TestFixture.createChallenge("챌린지", 1, today.plusDays(5), today.plusDays(15), group.getId());
+        challengeRepository.save(challenge);
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(challenge.getNewsletterGroupId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges").param("view", "summary"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$[0].id").value(challenge.getId()));
+    }
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeControllerTest.java
@@ -190,5 +190,11 @@ class ChallengeControllerTest {
                 .andExpect(jsonPath("$").isArray())
                 .andExpect(jsonPath("$[0].id").value(challenge.getId()));
     }
+
+    @Test
+    void view_허용되지_않은_값이면_400_반환() throws Exception {
+        mockMvc.perform(get("/api/v1/challenges").param("view", "invalid"))
+                .andExpect(status().isBadRequest());
+    }
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -20,7 +20,9 @@ import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.dto.TeamChallengeProgressFlat;
 import me.bombom.api.v1.challenge.dto.response.CertificationInfoResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeStreakResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
+import me.bombom.api.v1.challenge.dto.response.StreakDayResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
 import me.bombom.api.v1.challenge.service.ChallengeProgressService;
@@ -219,6 +221,79 @@ class ChallengeProgressControllerUnitTest {
 
         // when & then
         mockMvc.perform(get("/api/v1/challenges/{id}/progress/teams/{teamId}", challengeId, invalidTeamId)
+                        .with(authentication(authentication)))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    void 챌린지_스트릭_조회_성공() throws Exception {
+        // given
+        Long challengeId = 1L;
+        LocalDate today = LocalDate.now();
+        ChallengeStreakResponse response = new ChallengeStreakResponse(
+                3,
+                List.of(
+                        new StreakDayResponse(today.minusDays(2), today.minusDays(2).getDayOfWeek(), false),
+                        new StreakDayResponse(today.minusDays(1), today.minusDays(1).getDayOfWeek(), true),
+                        new StreakDayResponse(today, today.getDayOfWeek(), false)
+                )
+        );
+
+        given(challengeProgressService.getMemberStreak(eq(challengeId), any(Member.class), eq(5)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/progress/me/streak", challengeId)
+                        .with(authentication(authentication)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.streak").value(3))
+                .andExpect(jsonPath("$.streakDays").isArray())
+                .andExpect(jsonPath("$.streakDays.length()").value(3))
+                .andExpect(jsonPath("$.streakDays[0].date").value(today.minusDays(2).toString()))
+                .andExpect(jsonPath("$.streakDays[0].dayOfWeek").value(today.minusDays(2).getDayOfWeek().toString()))
+                .andExpect(jsonPath("$.streakDays[0].isShieldApplied").value(false))
+                .andExpect(jsonPath("$.streakDays[1].isShieldApplied").value(true))
+                .andDo(print());
+    }
+
+    @Test
+    void 챌린지_스트릭_조회_성공_limit_파라미터_적용() throws Exception {
+        // given
+        Long challengeId = 1L;
+        ChallengeStreakResponse response = new ChallengeStreakResponse(10, List.of());
+
+        given(challengeProgressService.getMemberStreak(eq(challengeId), any(Member.class), eq(3)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/progress/me/streak", challengeId)
+                        .param("limit", "3")
+                        .with(authentication(authentication)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    void 챌린지_스트릭_조회_실패_ID가_양수가_아님() throws Exception {
+        // given
+        Long invalidId = -1L;
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/progress/me/streak", invalidId)
+                        .with(authentication(authentication)))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    void 챌린지_스트릭_조회_실패_limit가_양수가_아님() throws Exception {
+        // given
+        Long challengeId = 1L;
+
+        // when & then
+        mockMvc.perform(get("/api/v1/challenges/{id}/progress/me/streak", challengeId)
+                        .param("limit", "0")
                         .with(authentication(authentication)))
                 .andExpect(status().isBadRequest())
                 .andDo(print());

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -129,6 +129,8 @@ class ChallengeProgressControllerUnitTest {
                 20,
                 true,
                 5,
+                3,
+                1,
                 List.of(new TodayTodoResponse(ChallengeTodoType.READ, ChallengeTodoStatus.COMPLETE)));
 
         given(challengeProgressService.getMemberProgress(eq(challengeId), any(Member.class)))

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -235,8 +235,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 dayIndex,
                 member.getId(),
-                request,
-                today
+                request
         );
 
         // then
@@ -267,8 +266,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 dayIndex,
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -342,8 +340,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 disabledGuide.getDayIndex(),
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -357,8 +354,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 999, // 존재하지 않는 dayIndex
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -438,8 +434,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 0,
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 
@@ -466,8 +461,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 0,
                 member.getId(),
-                request,
-                today
+                request
         );
 
         // then - 댓글이 생성되었는지 확인
@@ -507,29 +501,12 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 1,
                 member.getId(),
-                request,
-                weekday
+                request
         );
 
         // then - 코멘트 생성 확인
         List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
         assertThat(comments).hasSize(1);
-
-        // then - READ 투두 생성 및 완료 확인
-        boolean readTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(),
-                weekday,
-                readTodo.getId()
-        );
-        assertThat(readTodoExists).isTrue();
-
-        // then - COMMENT 투두 생성 및 완료 확인
-        boolean commentTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
-                participant.getId(),
-                weekday,
-                commentTodo.getId()
-        );
-        assertThat(commentTodoExists).isTrue();
 
         // then - MINDSET 투두 생성 확인
         boolean mindsetTodoExists = challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
@@ -569,8 +546,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 2,
                 member.getId(),
-                request,
-                today
+                request
         );
 
         // then - 코멘트는 생성됨
@@ -639,8 +615,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 1,
                 member.getId(),
-                request,
-                weekday
+                request
         );
 
         // then - MINDSET 투두는 1개만 존재 (중복 생성 안 됨)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyTodoServiceTest.java
@@ -2,8 +2,9 @@ package me.bombom.api.v1.challenge.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
-import java.time.DayOfWeek;
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.transaction.TestTransaction;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,15 @@ import org.springframework.transaction.annotation.Transactional;
 class ChallengeDailyTodoServiceTest {
 
     private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    // 테스트용 고정 평일 (2025-03-10 월요일)
+    private static final LocalDate FIXED_WEEKDAY = LocalDate.of(2025, 3, 10);
+    // 테스트용 고정 토요일 (2025-03-08)
+    private static final LocalDate FIXED_SATURDAY = LocalDate.of(2025, 3, 8);
+    // 테스트용 고정 일요일 (2025-03-09)
+    private static final LocalDate FIXED_SUNDAY = LocalDate.of(2025, 3, 9);
+
+    @MockitoBean
+    private Clock clock;
 
     @Autowired
     private ApplicationEventPublisher eventPublisher;
@@ -68,11 +79,11 @@ class ChallengeDailyTodoServiceTest {
     private Member member;
     private Challenge challenge;
     private ChallengeTodo readTodo;
-    private Article todayArticle;
-    private LocalDate today;
 
     @BeforeEach
     void setUp() {
+        fixClockTo(FIXED_WEEKDAY);
+
         challengeDailyTodoRepository.deleteAllInBatch();
         articleRepository.deleteAllInBatch();
         challengeTodoRepository.deleteAllInBatch();
@@ -82,20 +93,13 @@ class ChallengeDailyTodoServiceTest {
 
         member = memberRepository.save(TestFixture.createUniqueMember("tester", "12345"));
 
-        // 평일로 고정 (주말 체크 로직 때문에)
-        LocalDate now = LocalDate.now(SEOUL_ZONE);
-        while (now.getDayOfWeek() == DayOfWeek.SATURDAY || now.getDayOfWeek() == DayOfWeek.SUNDAY) {
-            now = now.plusDays(1);
-        }
-        today = now;
-        
         NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
         newsletterGroupRepository.save(group);
-        
+
         challenge = challengeRepository.save(TestFixture.createChallenge(
                 "테스트 챌린지",
-                today.minusDays(5),
-                today.plusDays(5),
+                FIXED_WEEKDAY.minusDays(5),
+                FIXED_WEEKDAY.plusDays(5),
                 10,
                 group.getId()
         ));
@@ -111,60 +115,18 @@ class ChallengeDailyTodoServiceTest {
         readTodo = challengeTodoRepository.save(
                 TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
         );
-
-        todayArticle = articleRepository.save(
-                TestFixture.createArticle(
-                        "오늘 뉴스레터",
-                        member.getId(),
-                        1L,
-                        LocalDateTime.of(today, java.time.LocalTime.now(SEOUL_ZONE))
-                )
-        );
     }
 
     @Test
     @Transactional
-    void 아티클_읽기시_챌린지_투두_업데이트() {
-        // given - 실제 오늘이 주말이 아니어야 함 (ChallengeParticipantTodoListener가 실제 날짜 사용)
-        LocalDate actualToday = LocalDate.now(SEOUL_ZONE);
-        if (actualToday.getDayOfWeek() == DayOfWeek.SATURDAY || actualToday.getDayOfWeek() == DayOfWeek.SUNDAY) {
-            // 주말이면 todo가 생성되지 않으므로 테스트 스킵
-            return;
-        }
-
-        // 실제 오늘 날짜에 맞는 데이터 재생성
-        challengeDailyTodoRepository.deleteAllInBatch();
-        articleRepository.deleteAllInBatch();
-        
-        NewsletterGroup group2 = TestFixture.createNewsletterGroup("그룹2");
-        newsletterGroupRepository.save(group2);
-        
-        challenge = challengeRepository.save(TestFixture.createChallenge(
-                "테스트 챌린지",
-                actualToday.minusDays(5),
-                actualToday.plusDays(5),
-                10,
-                group2.getId()
-        ));
-        
-        challengeParticipantRepository.save(
-                TestFixture.createChallengeParticipant(
-                        challenge.getId(),
-                        member.getId(),
-                        0
-                )
-        );
-
-        readTodo = challengeTodoRepository.save(
-                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
-        );
-
-        todayArticle = articleRepository.save(
+    void 오늘_도착한_아티클_읽기시_챌린지_투두_업데이트() {
+        // given
+        Article todayArticle = articleRepository.save(
                 TestFixture.createArticle(
                         "오늘 뉴스레터",
                         member.getId(),
                         1L,
-                        LocalDateTime.of(actualToday, java.time.LocalTime.now(SEOUL_ZONE))
+                        LocalDateTime.of(FIXED_WEEKDAY, java.time.LocalTime.of(9, 0))
                 )
         );
 
@@ -176,18 +138,54 @@ class ChallengeDailyTodoServiceTest {
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
-        // then - 특정 멤버와 챌린지에 대한 todo만 확인
+        // then
         List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
                 .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
-                .filter(todo -> todo.getTodoDate().equals(actualToday))
+                .filter(todo -> todo.getTodoDate().equals(FIXED_WEEKDAY))
                 .toList();
 
         assertSoftly(softly -> {
             softly.assertThat(dailyTodos).hasSize(1);
             softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
             softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
-            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(actualToday);
+            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(FIXED_WEEKDAY);
+        });
+    }
+
+    @Test
+    @Transactional
+    void 과거_도착한_아티클_읽기시_챌린지_투두_업데이트() {
+        // given - 3일 전에 도착한 아티클
+        Article pastArticle = articleRepository.save(
+                TestFixture.createArticle(
+                        "과거 뉴스레터",
+                        member.getId(),
+                        1L,
+                        LocalDateTime.of(FIXED_WEEKDAY.minusDays(3), java.time.LocalTime.of(9, 0))
+                )
+        );
+
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                challenge.getId(), member.getId()).orElseThrow();
+
+        // when
+        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), pastArticle.getId()));
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then - 과거 도착 아티클이어도 오늘 투두가 생성되어야 함
+        List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
+                .filter(todo -> todo.getParticipantId().equals(participant.getId()))
+                .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
+                .filter(todo -> todo.getTodoDate().equals(FIXED_WEEKDAY))
+                .toList();
+
+        assertSoftly(softly -> {
+            softly.assertThat(dailyTodos).hasSize(1);
+            softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
+            softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
+            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(FIXED_WEEKDAY);
         });
     }
 
@@ -195,82 +193,58 @@ class ChallengeDailyTodoServiceTest {
     @Transactional
     void 이미_존재하는_챌린지_투두_중복_생성_안함() {
         // given
+        Article article = articleRepository.save(
+                TestFixture.createArticle(
+                        "뉴스레터",
+                        member.getId(),
+                        1L,
+                        LocalDateTime.of(FIXED_WEEKDAY, java.time.LocalTime.of(9, 0))
+                )
+        );
+
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                 challenge.getId(), member.getId()).orElseThrow();
 
-        // 기존 todo 생성
         challengeDailyTodoRepository.save(
                 TestFixture.createChallengeDailyTodo(
                         participant.getId(),
-                        today,
+                        FIXED_WEEKDAY,
                         readTodo.getId()
                 )
         );
 
         // when
-        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), todayArticle.getId()));
+        eventPublisher.publishEvent(new MarkAsReadEvent(member.getId(), article.getId()));
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
-        // then - 특정 멤버와 챌린지에 대한 todo만 확인
+        // then
         List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
                 .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
-                .filter(todo -> todo.getTodoDate().equals(today))
+                .filter(todo -> todo.getTodoDate().equals(FIXED_WEEKDAY))
                 .toList();
 
-        assertSoftly(softly -> {
-            softly.assertThat(dailyTodos).hasSize(1);
-            softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
-            softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
-            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(today);
-        });
+        assertThat(dailyTodos).hasSize(1);
     }
 
     @Test
     @Transactional
-    void 주말_토요일에는_투두_생성되지_않음() {
+    void 토요일에는_투두_생성되지_않음() {
         // given
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
-        LocalDate tempSaturday = today;
-        
-        // 토요일로 조정
-        while (tempSaturday.getDayOfWeek() != DayOfWeek.SATURDAY) {
-            tempSaturday = tempSaturday.plusDays(1);
-        }
-        final LocalDate saturday = tempSaturday;
-        
-        // 챌린지 기간에 포함되도록 조정
-        NewsletterGroup saturdayGroup = TestFixture.createNewsletterGroup("토요일 그룹");
-        newsletterGroupRepository.save(saturdayGroup);
-        challenge = challengeRepository.save(TestFixture.createChallenge(
-                "주말 테스트 챌린지",
-                saturday.minusDays(5),
-                saturday.plusDays(5),
-                10,
-                saturdayGroup.getId()
-        ));
-        
-        challengeParticipantRepository.save(
-                TestFixture.createChallengeParticipant(
-                        challenge.getId(),
-                        member.getId(),
-                        0
-                )
-        );
+        fixClockTo(FIXED_SATURDAY);
 
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                 challenge.getId(), member.getId()).orElseThrow();
 
         // when
-        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null, saturday);
+        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null);
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
-        // then - todo가 생성되지 않아야 함
+        // then
         List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
-                .filter(todo -> todo.getTodoDate().equals(saturday))
                 .toList();
 
         assertThat(dailyTodos).isEmpty();
@@ -278,48 +252,21 @@ class ChallengeDailyTodoServiceTest {
 
     @Test
     @Transactional
-    void 주말_일요일에는_투두_생성되지_않음() {
+    void 일요일에는_투두_생성되지_않음() {
         // given
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
-        LocalDate tempSunday = today;
-        
-        // 일요일로 조정
-        while (tempSunday.getDayOfWeek() != DayOfWeek.SUNDAY) {
-            tempSunday = tempSunday.plusDays(1);
-        }
-        final LocalDate sunday = tempSunday;
-        
-        // 챌린지 기간에 포함되도록 조정
-        NewsletterGroup sundayGroup = TestFixture.createNewsletterGroup("일요일 그룹");
-        newsletterGroupRepository.save(sundayGroup);
-        challenge = challengeRepository.save(TestFixture.createChallenge(
-                "주말 테스트 챌린지",
-                sunday.minusDays(5),
-                sunday.plusDays(5),
-                10,
-                sundayGroup.getId()
-        ));
-        
-        challengeParticipantRepository.save(
-                TestFixture.createChallengeParticipant(
-                        challenge.getId(),
-                        member.getId(),
-                        0
-                )
-        );
+        fixClockTo(FIXED_SUNDAY);
 
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                 challenge.getId(), member.getId()).orElseThrow();
 
         // when
-        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null, sunday);
+        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null);
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
-        // then - todo가 생성되지 않아야 함
+        // then
         List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
-                .filter(todo -> todo.getTodoDate().equals(sunday))
                 .toList();
 
         assertThat(dailyTodos).isEmpty();
@@ -328,59 +275,32 @@ class ChallengeDailyTodoServiceTest {
     @Test
     @Transactional
     void 평일에는_정상적으로_투두_생성됨() {
-        // given
-        LocalDate today = LocalDate.now(SEOUL_ZONE);
-        LocalDate tempWeekday = today;
-        
-        // 평일로 조정 (월요일~금요일)
-        while (tempWeekday.getDayOfWeek() == DayOfWeek.SATURDAY || tempWeekday.getDayOfWeek() == DayOfWeek.SUNDAY) {
-            tempWeekday = tempWeekday.plusDays(1);
-        }
-        final LocalDate weekday = tempWeekday;
-        
-        // 챌린지 기간에 포함되도록 조정
-        NewsletterGroup weekdayGroup = TestFixture.createNewsletterGroup("평일 그룹");
-        newsletterGroupRepository.save(weekdayGroup);
-        challenge = challengeRepository.save(TestFixture.createChallenge(
-                "평일 테스트 챌린지",
-                weekday.minusDays(5),
-                weekday.plusDays(5),
-                10,
-                weekdayGroup.getId()
-        ));
-        
-        challengeParticipantRepository.save(
-                TestFixture.createChallengeParticipant(
-                        challenge.getId(),
-                        member.getId(),
-                        0
-                )
-        );
-
-        readTodo = challengeTodoRepository.save(
-                TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.READ)
-        );
-
+        // given - clock은 setUp에서 이미 FIXED_WEEKDAY로 고정됨
         ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
                 challenge.getId(), member.getId()).orElseThrow();
 
         // when
-        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null, weekday);
+        challengeDailyTodoService.updateChallengeDailyTodo(member.getId(), null);
         TestTransaction.flagForCommit();
         TestTransaction.end();
 
-        // then - todo가 정상적으로 생성되어야 함
+        // then
         List<ChallengeDailyTodo> dailyTodos = challengeDailyTodoRepository.findAll().stream()
                 .filter(todo -> todo.getParticipantId().equals(participant.getId()))
                 .filter(todo -> todo.getChallengeTodoId().equals(readTodo.getId()))
-                .filter(todo -> todo.getTodoDate().equals(weekday))
+                .filter(todo -> todo.getTodoDate().equals(FIXED_WEEKDAY))
                 .toList();
 
         assertSoftly(softly -> {
             softly.assertThat(dailyTodos).hasSize(1);
             softly.assertThat(dailyTodos.get(0).getParticipantId()).isEqualTo(participant.getId());
             softly.assertThat(dailyTodos.get(0).getChallengeTodoId()).isEqualTo(readTodo.getId());
-            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(weekday);
+            softly.assertThat(dailyTodos.get(0).getTodoDate()).isEqualTo(FIXED_WEEKDAY);
         });
+    }
+
+    private void fixClockTo(LocalDate date) {
+        given(clock.instant()).willReturn(date.atStartOfDay(SEOUL_ZONE).toInstant());
+        given(clock.getZone()).willReturn(SEOUL_ZONE);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -24,6 +24,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeTodo;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
 import me.bombom.api.v1.challenge.dto.response.CertificationInfoResponse;
+import me.bombom.api.v1.challenge.dto.response.ChallengeStreakResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TeamChallengeProgressResponse;
 import me.bombom.api.v1.challenge.dto.response.TodayTodoResponse;
@@ -431,32 +432,192 @@ class ChallengeProgressServiceTest {
                 });
     }
 
-    private ChallengeParticipant createTeamParticipant(Long challengeId, Long memberId, Long teamId,
-                                                       int completedDays, boolean isSurvived) {
-        return ChallengeParticipant.builder()
-                .challengeId(challengeId)
-                .memberId(memberId)
-                .challengeTeamId(teamId)
-                .completedDays(completedDays)
-                .isSurvived(isSurvived)
+    @Test
+    void 스트릭이_0이면_빈_배열을_반환한다() {
+        // given - streak=0인 참여자 (daily result 없음)
+        Challenge streakChallenge = createStreakChallenge("스트릭 0 챌린지");
+        challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(0)
+                .streak(0)
                 .shield(0)
-                .build();
+                .isSurvived(true)
+                .build());
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streak()).isEqualTo(0);
+            softly.assertThat(response.streakDays()).isEmpty();
+        });
     }
 
-    private ChallengeTeam createChallengeTeam(Long challengeId, int progress) {
-        return ChallengeTeam.builder()
-                .challengeId(challengeId)
-                .progress(progress)
-                .build();
+    @Test
+    void limit보다_스트릭이_작으면_스트릭_수만큼만_반환한다() {
+        // given - streak=3, limit=5
+        Challenge streakChallenge = createStreakChallenge("스트릭 3 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .streak(3)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        challengeDailyResultRepository.saveAll(List.of(
+                createChallengeDailyResult(participant.getId(), LocalDate.now().minusDays(2), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), LocalDate.now().minusDays(1), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), LocalDate.now(), ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streak()).isEqualTo(3);
+            softly.assertThat(response.streakDays()).hasSize(3);
+        });
     }
 
-    private ChallengeDailyResult createChallengeDailyResult(Long participantId, LocalDate date,
-                                                            ChallengeDailyStatus status) {
-        return ChallengeDailyResult.builder()
-                .participantId(participantId)
-                .date(date)
-                .status(status)
-                .build();
+    @Test
+    void limit가_스트릭보다_작으면_limit만큼만_반환한다() {
+        // given - streak=7, limit=3
+        Challenge streakChallenge = createStreakChallenge("스트릭 7 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(7)
+                .streak(7)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        for (int i = 6; i >= 0; i--) {
+            challengeDailyResultRepository.save(
+                    createChallengeDailyResult(participant.getId(), LocalDate.now().minusDays(i), ChallengeDailyStatus.COMPLETE));
+        }
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 3);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streak()).isEqualTo(7);
+            softly.assertThat(response.streakDays()).hasSize(3);
+        });
+    }
+
+    @Test
+    void 스트릭_날짜는_오름차순으로_반환한다() {
+        // given
+        Challenge streakChallenge = createStreakChallenge("날짜 정렬 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .streak(3)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        LocalDate today = LocalDate.now();
+        challengeDailyResultRepository.saveAll(List.of(
+                createChallengeDailyResult(participant.getId(), today.minusDays(2), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), today.minusDays(1), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), today, ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertThat(response.streakDays())
+                .extracting("date")
+                .containsExactly(today.minusDays(2), today.minusDays(1), today);
+    }
+
+    @Test
+    void 쉴드_사용_날은_isShieldApplied가_true다() {
+        // given
+        Challenge streakChallenge = createStreakChallenge("쉴드 확인 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(2)
+                .streak(2)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        LocalDate today = LocalDate.now();
+        challengeDailyResultRepository.saveAll(List.of(
+                createChallengeDailyResult(participant.getId(), today.minusDays(1), ChallengeDailyStatus.SHIELD),
+                createChallengeDailyResult(participant.getId(), today, ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streakDays().get(0).isShieldApplied()).isTrue();   // yesterday: SHIELD
+            softly.assertThat(response.streakDays().get(1).isShieldApplied()).isFalse();  // today: COMPLETE
+        });
+    }
+
+    @Test
+    void 주말을_사이에_둔_금요일과_월요일도_연속_스트릭으로_조회된다() {
+        // given
+        // 금→(토일)→월 구간이 포함된 스트릭 (gap 3일 이하 = 연속)
+        LocalDate monday = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
+        LocalDate friday = monday.minusDays(3); // 직전 금요일
+
+        Challenge streakChallenge = createStreakChallenge("주말 낀 스트릭 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(2)
+                .streak(2)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        challengeDailyResultRepository.saveAll(List.of(
+                createChallengeDailyResult(participant.getId(), friday, ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), monday, ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streak()).isEqualTo(2);
+            softly.assertThat(response.streakDays()).hasSize(2);
+            softly.assertThat(response.streakDays().get(0).date()).isEqualTo(friday);
+            softly.assertThat(response.streakDays().get(0).dayOfWeek()).isEqualTo(java.time.DayOfWeek.FRIDAY);
+            softly.assertThat(response.streakDays().get(1).date()).isEqualTo(monday);
+            softly.assertThat(response.streakDays().get(1).dayOfWeek()).isEqualTo(java.time.DayOfWeek.MONDAY);
+        });
+    }
+
+    @Test
+    void 참가하지_않은_챌린지_스트릭_조회시_예외_발생() {
+        // given
+        Member nonParticipant = memberRepository.save(TestFixture.createUniqueMember("nonParticipant", UUID.randomUUID().toString()));
+
+        // when & then
+        assertThatThrownBy(() -> challengeProgressService.getMemberStreak(challenge.getId(), nonParticipant, 5))
+                .isInstanceOf(UnauthorizedException.class)
+                .satisfies(e -> {
+                    UnauthorizedException exception = (UnauthorizedException) e;
+                    assertThat(exception.getErrorDetail()).isEqualTo(ErrorDetail.FORBIDDEN_RESOURCE);
+                });
     }
 
     @Test
@@ -786,5 +947,43 @@ class ChallengeProgressServiceTest {
                 .containsExactlyInAnyOrder(ChallengeTodoType.READ, ChallengeTodoType.COMMENT);
         assertThat(response.todayTodos()).extracting("challengeTodoType")
                 .doesNotContain(ChallengeTodoType.MINDSET);
+    }
+
+    private ChallengeParticipant createTeamParticipant(Long challengeId, Long memberId, Long teamId,
+                                                       int completedDays, boolean isSurvived) {
+        return ChallengeParticipant.builder()
+                .challengeId(challengeId)
+                .memberId(memberId)
+                .challengeTeamId(teamId)
+                .completedDays(completedDays)
+                .isSurvived(isSurvived)
+                .shield(0)
+                .build();
+    }
+
+    private ChallengeTeam createChallengeTeam(Long challengeId, int progress) {
+        return ChallengeTeam.builder()
+                .challengeId(challengeId)
+                .progress(progress)
+                .build();
+    }
+
+    private ChallengeDailyResult createChallengeDailyResult(Long participantId, LocalDate date,
+                                                            ChallengeDailyStatus status) {
+        return ChallengeDailyResult.builder()
+                .participantId(participantId)
+                .date(date)
+                .status(status)
+                .build();
+    }
+
+    private Challenge createStreakChallenge(String name) {
+        NewsletterGroup group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup(name + " 그룹"));
+        return challengeRepository.save(TestFixture.createChallenge(
+                name,
+                LocalDate.now().minusDays(10),
+                LocalDate.now().plusDays(10),
+                10,
+                group.getId()));
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -147,6 +147,8 @@ class ChallengeProgressServiceTest {
             softly.assertThat(response.totalDays()).isEqualTo(10);
             softly.assertThat(response.isSurvived()).isEqualTo(true);
             softly.assertThat(response.completedDays()).isEqualTo(3);
+            softly.assertThat(response.streak()).isEqualTo(0);
+            softly.assertThat(response.shield()).isEqualTo(0);
             softly.assertThat(response.todayTodos()).hasSize(2);
 
             softly.assertThat(response.todayTodos())
@@ -179,6 +181,7 @@ class ChallengeProgressServiceTest {
                 .memberId(member.getId())
                 .completedDays(3)
                 .shield(1)
+                .streak(3)
                 .isSurvived(true)
                 .build());
 
@@ -194,11 +197,46 @@ class ChallengeProgressServiceTest {
             softly.assertThat(updatedParticipant.getCompletedDays())
                     .isEqualTo(participant.getCompletedDays() + 1);
             softly.assertThat(updatedParticipant.isSurvived()).isTrue();
+            softly.assertThat(updatedParticipant.getStreak()).isEqualTo(3); // 쉴드 사용 시 스트릭 유지
 
             List<ChallengeDailyResult> results = challengeDailyResultRepository.findAll();
             softly.assertThat(results).hasSize(1);
             softly.assertThat(results.getFirst().getStatus()).isEqualTo(ChallengeDailyStatus.SHIELD);
             softly.assertThat(results.getFirst().getDate()).isEqualTo(yesterday);
+        });
+    }
+
+    @Test
+    void 쉴드_사용_시_스트릭을_유지한다() {
+        // given
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+
+        NewsletterGroup group = TestFixture.createNewsletterGroup("쉴드 스트릭 그룹");
+        newsletterGroupRepository.save(group);
+        Challenge streakChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Shield Streak Challenge",
+                yesterday.minusDays(4),
+                yesterday.plusDays(5),
+                10,
+                group.getId()));
+
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .shield(1)
+                .streak(5)
+                .isSurvived(true)
+                .build());
+
+        // when
+        challengeProgressService.proceedDailySurvivalCheck(streakChallenge, yesterday);
+
+        // then
+        ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(updated.getShield()).isEqualTo(0);
+            softly.assertThat(updated.getStreak()).isEqualTo(5);
         });
     }
 
@@ -224,6 +262,7 @@ class ChallengeProgressServiceTest {
                 .memberId(member.getId())
                 .completedDays(3)
                 .shield(0)
+                .streak(3)
                 .isSurvived(true)
                 .build());
 
@@ -236,6 +275,7 @@ class ChallengeProgressServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(updatedParticipant.isSurvived()).isTrue();
             softly.assertThat(updatedParticipant.getCompletedDays()).isEqualTo(3);
+            softly.assertThat(updatedParticipant.getStreak()).isEqualTo(0); // 결석 시 스트릭 리셋
         });
     }
 
@@ -417,6 +457,39 @@ class ChallengeProgressServiceTest {
                 .date(date)
                 .status(status)
                 .build();
+    }
+
+    @Test
+    void 연속_참여_스트릭이_응답에_포함된다() {
+        // given
+        NewsletterGroup group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("스트릭 그룹"));
+        Challenge streakChallenge = challengeRepository.save(TestFixture.createChallenge(
+                "Streak Challenge",
+                LocalDate.now().minusDays(5),
+                LocalDate.now().plusDays(5),
+                10,
+                group.getId()));
+
+        challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .isSurvived(true)
+                .shield(2)
+                .streak(5)
+                .build());
+
+        challengeTodoRepository.save(TestFixture.createChallengeTodo(streakChallenge.getId(), ChallengeTodoType.READ));
+        challengeTodoRepository.save(TestFixture.createChallengeTodo(streakChallenge.getId(), ChallengeTodoType.COMMENT));
+
+        // when
+        MemberChallengeProgressResponse response = challengeProgressService.getMemberProgress(streakChallenge.getId(), member);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streak()).isEqualTo(5);
+            softly.assertThat(response.shield()).isEqualTo(2);
+        });
     }
 
     @Test

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -8,6 +8,7 @@ import java.time.LocalDate;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
 import me.bombom.api.v1.challenge.domain.EligibilityReason;
@@ -127,7 +128,7 @@ class ChallengeServiceTest {
         newsletterGroupItemRepository.saveAll(List.of(item1, item2));
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then - 시작전 챌린지만 반환되어야 함 (challenge2만)
         assertSoftly(softly -> {
@@ -163,7 +164,7 @@ class ChallengeServiceTest {
         newsletterGroupItemRepository.saveAll(List.of(item1, item2));
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then
         assertSoftly(softly -> {
@@ -204,7 +205,7 @@ class ChallengeServiceTest {
         newsletterGroupItemRepository.save(item);
 
         // when: 참여하지 않은 member로 목록 조회
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then: 추가 신청 기간 내이므로 목록에 포함되어야 함
         assertSoftly(softly -> {
@@ -218,10 +219,62 @@ class ChallengeServiceTest {
     @Test
     void 챌린지가_없을_때_빈_리스트_반환() {
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    void view_summary_일_때_참여_중인_ONGOING_EARLY_LATE_챌린지만_조회된다() {
+        // given: EARLY(시작 전), LATE(진행 중 추가신청), ONGOING+참여, ONGOING+미참여(CLOSED)
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+
+        Challenge early = TestFixture.createChallenge("EARLY", 1, today.plusDays(5), today.plusDays(25), group.getId());
+        Challenge late = TestFixture.createChallenge(
+                "LATE",
+                today.minusDays(5),
+                today.plusDays(20),
+                21,
+                group.getId()
+        );
+        Challenge ongoingJoined = TestFixture.createChallenge(
+                "ONGOING_JOINED",
+                today.minusDays(10),
+                today.plusDays(10),
+                20,
+                group.getId()
+        );
+        Challenge ongoingNotJoined = TestFixture.createChallenge(
+                "ONGOING_NOT_JOINED",
+                today.minusDays(10),
+                today.plusDays(10),
+                20,
+                group.getId()
+        );
+        challengeRepository.saveAll(List.of(early, late, ongoingJoined, ongoingNotJoined));
+
+        challengeParticipantRepository.save(
+                TestFixture.createChallengeParticipant(ongoingJoined.getId(), member.getId(), 5, true)
+        );
+
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(group.getId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+
+        // when
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.SUMMARY);
+
+        // then: EARLY, LATE, ONGOING+참여 3건만 포함. ONGOING+미참여(CLOSED) 제외
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(3);
+            softly.assertThat(result)
+                    .extracting(ChallengeResponse::id)
+                    .containsExactlyInAnyOrder(early.getId(), late.getId(), ongoingJoined.getId());
+            softly.assertThat(result)
+                    .extracting(ChallengeResponse::id)
+                    .doesNotContain(ongoingNotJoined.getId());
+        });
     }
 
     @Test
@@ -241,7 +294,7 @@ class ChallengeServiceTest {
         challengeParticipantRepository.saveAll(List.of(participant1, participant2));
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then - 시작전 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
@@ -263,7 +316,7 @@ class ChallengeServiceTest {
         newsletterGroupItemRepository.saveAll(List.of(item1, item2));
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then - 시작전 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
@@ -292,7 +345,7 @@ class ChallengeServiceTest {
         challengeParticipantRepository.save(participant);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then - 참여한 진행중 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
@@ -318,7 +371,7 @@ class ChallengeServiceTest {
         challengeParticipantRepository.save(participant);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then - 참여한 종료된 챌린지이므로 반환되어야 함
         assertSoftly(softly -> {
@@ -336,7 +389,7 @@ class ChallengeServiceTest {
         challengeRepository.save(challenge);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(null);
+        List<ChallengeResponse> result = challengeService.getChallenges(null, ChallengeFilter.DEFAULT);
 
         // then
         assertSoftly(softly -> {
@@ -362,7 +415,7 @@ class ChallengeServiceTest {
         challengeParticipantRepository.save(participant);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then
         ChallengeDetailResponse participationInfo = result.get(0).participationInfo();
@@ -384,7 +437,7 @@ class ChallengeServiceTest {
         challengeRepository.save(challenge);
 
         // when
-        List<ChallengeResponse> result = challengeService.getChallenges(member);
+        List<ChallengeResponse> result = challengeService.getChallenges(member, ChallengeFilter.DEFAULT);
 
         // then - 시작전 챌린지이므로 반환되어야 함
         ChallengeDetailResponse participationInfo = result.get(0).participationInfo();

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -3,8 +3,12 @@ package me.bombom.api.v1.challenge.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
 
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
@@ -42,6 +46,7 @@ import me.bombom.support.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 @IntegrationTest
 class ChallengeServiceTest {
@@ -79,6 +84,9 @@ class ChallengeServiceTest {
     @Autowired
     private ChallengeTeamRepository challengeTeamRepository;
 
+    @MockitoBean
+    private Clock clock;
+
     private Member member;
     private List<Category> categories;
     private List<Newsletter> newsletters;
@@ -109,7 +117,11 @@ class ChallengeServiceTest {
         newsletters = TestFixture.createNewslettersWithDetails(categories, newsletterDetails);
         newsletterRepository.saveAll(newsletters);
 
-        today = LocalDate.now();
+        ZoneId seoul = ZoneId.of("Asia/Seoul");
+        Instant fixedInstant = LocalDate.of(2025, 3, 15).atStartOfDay(seoul).toInstant();
+        given(clock.instant()).willReturn(fixedInstant);
+        given(clock.getZone()).willReturn(seoul);
+        today = LocalDate.now(clock);
     }
 
     @Test
@@ -234,7 +246,7 @@ class ChallengeServiceTest {
         Challenge early = TestFixture.createChallenge("EARLY", 1, today.plusDays(5), today.plusDays(25), group.getId());
         Challenge late = TestFixture.createChallenge(
                 "LATE",
-                today.minusDays(5),
+                today.minusDays(1),
                 today.plusDays(20),
                 21,
                 group.getId()

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -282,7 +282,11 @@ class ChallengeServiceTest {
             softly.assertThat(result).hasSize(3);
             softly.assertThat(result)
                     .extracting(ChallengeResponse::id)
-                    .containsExactlyInAnyOrder(early.getId(), late.getId(), ongoingJoined.getId());
+                    .containsExactly(
+                            ongoingJoined.getId(), // ONGOING + 참여
+                            late.getId(),          // LATE
+                            early.getId()          // EARLY
+                    );
             softly.assertThat(result)
                     .extracting(ChallengeResponse::id)
                     .doesNotContain(ongoingNotJoined.getId());

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeTodoServiceTest.java
@@ -1,0 +1,96 @@
+package me.bombom.api.v1.challenge.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.util.List;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+import me.bombom.api.v1.challenge.domain.ChallengeTodoType;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyResultRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeDailyTodoRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeParticipantRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeRepository;
+import me.bombom.api.v1.challenge.repository.ChallengeTodoRepository;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.repository.NewsletterGroupRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@IntegrationTest
+class ChallengeTodoServiceTest {
+
+    @Autowired
+    private ChallengeTodoService challengeTodoService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private ChallengeParticipantRepository challengeParticipantRepository;
+
+    @Autowired
+    private ChallengeTodoRepository challengeTodoRepository;
+
+    @Autowired
+    private ChallengeDailyTodoRepository challengeDailyTodoRepository;
+
+    @Autowired
+    private ChallengeDailyResultRepository challengeDailyResultRepository;
+
+    @Autowired
+    private NewsletterGroupRepository newsletterGroupRepository;
+
+    private ChallengeParticipant participant;
+
+    @BeforeEach
+    void setUp() {
+        challengeDailyResultRepository.deleteAllInBatch();
+        challengeDailyTodoRepository.deleteAllInBatch();
+        challengeTodoRepository.deleteAllInBatch();
+        challengeParticipantRepository.deleteAllInBatch();
+        challengeRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+        newsletterGroupRepository.deleteAllInBatch();
+
+        var member = memberRepository.save(TestFixture.createUniqueMember("tester", "id"));
+        var group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("그룹"));
+        var challenge = challengeRepository.save(TestFixture.createChallenge(
+                "Challenge", LocalDate.now().minusDays(3), LocalDate.now().plusDays(7), 10, group.getId()));
+
+        challengeTodoRepository.save(TestFixture.createChallengeTodo(challenge.getId(), ChallengeTodoType.COMMENT));
+
+        participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(challenge.getId())
+                .memberId(member.getId())
+                .completedDays(2)
+                .streak(2)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+    }
+
+    @Test
+    void 일일_투두_완료_시_completedDays와_streak가_증가한다() {
+        // when
+        challengeTodoService.completeDailyTodo(participant.getId(), LocalDate.now());
+
+        // then
+        ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        List<ChallengeDailyResult> results = challengeDailyResultRepository.findAll();
+
+        assertSoftly(softly -> {
+            softly.assertThat(updated.getCompletedDays()).isEqualTo(3);
+            softly.assertThat(updated.getStreak()).isEqualTo(3);
+            softly.assertThat(results).hasSize(1);
+            softly.assertThat(results.getFirst().getStatus()).isEqualTo(ChallengeDailyStatus.COMPLETE);
+        });
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 아티클 읽기 기준을 변경했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 기준을 완화하기 위해. 코멘트는 이전 아티클에 대해 작성해도 상관이 없는데, 아티클에 대한 기준은 변경하지 않아서.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
 - ChallengeDailyTodoRepository의 insertTodayReadTodoIfMissing 쿼리에서 AND DATE(a.arrived_date_time) = :today 조건 제거
    - 기존: 오늘 도착한 아티클을 읽어야만 챌린지 투두 생성
    - 변경: 본인 소유 아티클이면 도착 날짜 무관하게 읽음 처리 시 투두 생성

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
