### PR TITLE
[BOM-1017] feat: 유효하지 않은 토큰일 때 토큰 삭제

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMember.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMember.java
@@ -13,4 +13,6 @@ import java.lang.annotation.Target;
 public @interface LoginMember {
 
     boolean anonymous() default false;
+
+    boolean allowInvalidToken() default false;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
@@ -49,6 +50,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             WebDataBinderFactory binderFactory
     ) {
         LoginMember loginMember = parameter.getParameterAnnotation(LoginMember.class);
+        validateAnnotationOptions(loginMember);
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (isAnonymous(authentication)) {
@@ -108,7 +110,15 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     }
 
     private boolean isInvalidTokenAllowed(LoginMember loginMember) {
-        return loginMember != null && loginMember.allowInvalidToken();
+        return loginMember != null && loginMember.anonymous() && loginMember.allowInvalidToken();
+    }
+
+    private void validateAnnotationOptions(LoginMember loginMember) {
+        if (loginMember != null && loginMember.allowInvalidToken() && !loginMember.anonymous()) {
+            throw new CIllegalArgumentException(ErrorDetail.PRECONDITION_FAILED)
+                    .addContext("reason", "allow_invalid_token_requires_anonymous")
+                    .addContext("annotation", "@LoginMember");
+        }
     }
 
     private void clearInvalidSessionIfPresent(NativeWebRequest webRequest) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -55,7 +55,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
             return resolveAnonymousRequest(loginMember, webRequest);
         }
 
-        return resolveAuthenticatedRequest(parameter, authentication, webRequest);
+        return resolveAuthenticatedRequest(parameter, loginMember, authentication, webRequest);
     }
 
     private Object resolveAnonymousRequest(LoginMember loginMember, NativeWebRequest webRequest) {
@@ -70,18 +70,17 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
     private Object resolveAuthenticatedRequest(
             MethodParameter parameter,
+            LoginMember loginMember,
             Authentication authentication,
             NativeWebRequest webRequest
     ) {
         if (!(authentication.getPrincipal() instanceof CustomOAuth2User oauth2User)) {
-            clearInvalidSessionIfPresent(webRequest);
-            throw new UnauthorizedException(ErrorDetail.INVALID_TOKEN);
+            return handleInvalidAuthentication(loginMember, webRequest, ErrorDetail.INVALID_TOKEN);
         }
 
         Member member = oauth2User.getMember();
         if (member == null) {
-            clearInvalidSessionIfPresent(webRequest);
-            throw new UnauthorizedException(ErrorDetail.UNAUTHORIZED);
+            return handleInvalidAuthentication(loginMember, webRequest, ErrorDetail.UNAUTHORIZED);
         }
 
         if (parameter.getParameterType().equals(Long.class)) {
@@ -94,6 +93,22 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
         return authentication == null
                 || !authentication.isAuthenticated()
                 || authentication instanceof AnonymousAuthenticationToken;
+    }
+
+    private Object handleInvalidAuthentication(
+            LoginMember loginMember,
+            NativeWebRequest webRequest,
+            ErrorDetail errorDetail
+    ) {
+        clearInvalidSessionIfPresent(webRequest);
+        if (isInvalidTokenAllowed(loginMember)) {
+            return null;
+        }
+        throw new UnauthorizedException(errorDetail);
+    }
+
+    private boolean isInvalidTokenAllowed(LoginMember loginMember) {
+        return loginMember != null && loginMember.allowInvalidToken();
     }
 
     private void clearInvalidSessionIfPresent(NativeWebRequest webRequest) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/controller/NewsletterController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/newsletter/controller/NewsletterController.java
@@ -22,7 +22,7 @@ public class NewsletterController implements NewsletterControllerApi{
     @Override
     @GetMapping
     public NewslettersResponse getNewsletters(
-            @LoginMember(anonymous = true) Long memberId,
+            @LoginMember(anonymous = true, allowInvalidToken = true) Long memberId,
             @RequestParam(required = false, defaultValue = "false") boolean includeSuspended,
             @RequestParam(required = false) Long categoryId
     ) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -13,6 +13,7 @@ import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Map;
 import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.exception.UnauthorizedException;
 import me.bombom.api.v1.member.domain.Member;
@@ -59,6 +60,9 @@ class LoginMemberArgumentResolverTest {
         public void endpointMemberAnonymousTrueAllowInvalidToken(
                 @LoginMember(anonymous = true, allowInvalidToken = true) Member member
         ) {
+        }
+
+        public void endpointMemberAllowInvalidTokenOnly(@LoginMember(allowInvalidToken = true) Member member) {
         }
 
         public void endpointLong(@LoginMember Long memberId) {
@@ -174,6 +178,16 @@ class LoginMemberArgumentResolverTest {
         Object result = resolver.resolveArgument(paramLongAnonymousTrueAllowInvalidToken(), null, null, null);
 
         assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("allowInvalidToken=true 는 anonymous=true 없이 사용할 수 없다")
+    void resolve_WhenAllowInvalidTokenWithoutAnonymous_ThrowsIllegalArgumentException() throws Exception {
+        setAnonymousAuthentication();
+
+        assertThatThrownBy(() -> resolver.resolveArgument(paramMemberAllowInvalidTokenOnly(), null, null, null))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.PRECONDITION_FAILED);
     }
 
     @Test
@@ -305,6 +319,15 @@ class LoginMemberArgumentResolverTest {
     private MethodParameter paramMemberAnonymousTrueAllowInvalidToken() {
         try {
             Method m = StubController.class.getMethod("endpointMemberAnonymousTrueAllowInvalidToken", Member.class);
+            return new MethodParameter(m, 0);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MethodParameter paramMemberAllowInvalidTokenOnly() {
+        try {
+            Method m = StubController.class.getMethod("endpointMemberAllowInvalidTokenOnly", Member.class);
             return new MethodParameter(m, 0);
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolverTest.java
@@ -56,10 +56,20 @@ class LoginMemberArgumentResolverTest {
         public void endpointMemberAnonymousTrue(@LoginMember(anonymous = true) Member member) {
         }
 
+        public void endpointMemberAnonymousTrueAllowInvalidToken(
+                @LoginMember(anonymous = true, allowInvalidToken = true) Member member
+        ) {
+        }
+
         public void endpointLong(@LoginMember Long memberId) {
         }
 
         public void endpointLongAnonymousTrue(@LoginMember(anonymous = true) Long memberId) {
+        }
+
+        public void endpointLongAnonymousTrueAllowInvalidToken(
+                @LoginMember(anonymous = true, allowInvalidToken = true) Long memberId
+        ) {
         }
     }
 
@@ -155,6 +165,18 @@ class LoginMemberArgumentResolverTest {
     }
 
     @Test
+    @DisplayName("비정상적인 Principal 타입이어도 allowInvalidToken이면 null을 반환한다")
+    void resolve_WhenInvalidPrincipalAndAllowInvalidToken_ReturnsNull() throws Exception {
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("notCustomUser", null);
+        auth.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Object result = resolver.resolveArgument(paramLongAnonymousTrueAllowInvalidToken(), null, null, null);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
     @DisplayName("비로그인(anonymous) 요청에서 세션 쿠키가 있으면 세션/쿠키를 정리한다")
     void resolve_WhenAnonymousWithSessionCookie_ClearsInvalidSession() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest();
@@ -188,6 +210,54 @@ class LoginMemberArgumentResolverTest {
         assertThatThrownBy(() -> resolver.resolveArgument(paramMember(), null, webRequest, null))
                 .isInstanceOf(UnauthorizedException.class)
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_TOKEN);
+        verifyInvalidSessionCookie(response);
+        assertThat(request.getSession(false)).isNull();
+    }
+
+    @Test
+    @DisplayName("principal 타입이 비정상이고 allowInvalidToken이며 세션 쿠키가 있으면 null과 함께 세션/쿠키를 정리한다")
+    void resolve_WhenInvalidPrincipalWithSessionCookieAndAllowInvalidToken_ReturnsNull() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setCookies(new Cookie(SESSION_COOKIE_NAME, "session-token"));
+        request.getSession();
+        TestingAuthenticationToken auth = new TestingAuthenticationToken("notCustomUser", null);
+        auth.setAuthenticated(true);
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        NativeWebRequest webRequest = createWebRequest(request, response);
+
+        Object result = resolver.resolveArgument(paramLongAnonymousTrueAllowInvalidToken(), null, webRequest, null);
+
+        assertThat(result).isNull();
+        verifyInvalidSessionCookie(response);
+        assertThat(request.getSession(false)).isNull();
+    }
+
+    @Test
+    @DisplayName("OAuth2 유저의 member가 null이어도 allowInvalidToken이면 null을 반환한다")
+    void resolve_WhenMemberIsNullAndAllowInvalidToken_ReturnsNull() throws Exception {
+        setLoggedInAuthentication(null);
+
+        Object result = resolver.resolveArgument(paramMemberAnonymousTrueAllowInvalidToken(), null, null, null);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("OAuth2 유저의 member가 null이고 allowInvalidToken이며 세션 쿠키가 있으면 null과 함께 세션/쿠키를 정리한다")
+    void resolve_WhenMemberIsNullWithSessionCookieAndAllowInvalidToken_ReturnsNull() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.setCookies(new Cookie(SESSION_COOKIE_NAME, "session-token"));
+        request.getSession();
+        setLoggedInAuthentication(null);
+
+        NativeWebRequest webRequest = createWebRequest(request, response);
+
+        Object result = resolver.resolveArgument(paramMemberAnonymousTrueAllowInvalidToken(), null, webRequest, null);
+
+        assertThat(result).isNull();
         verifyInvalidSessionCookie(response);
         assertThat(request.getSession(false)).isNull();
     }
@@ -226,6 +296,24 @@ class LoginMemberArgumentResolverTest {
     private MethodParameter paramLong() {
         try {
             Method m = StubController.class.getMethod("endpointLong", Long.class);
+            return new MethodParameter(m, 0);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MethodParameter paramMemberAnonymousTrueAllowInvalidToken() {
+        try {
+            Method m = StubController.class.getMethod("endpointMemberAnonymousTrueAllowInvalidToken", Member.class);
+            return new MethodParameter(m, 0);
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private MethodParameter paramLongAnonymousTrueAllowInvalidToken() {
+        try {
+            Method m = StubController.class.getMethod("endpointLongAnonymousTrueAllowInvalidToken", Long.class);
             return new MethodParameter(m, 0);
         } catch (NoSuchMethodException e) {
             throw new RuntimeException(e);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/controller/NewsletterControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/newsletter/controller/NewsletterControllerTest.java
@@ -1,0 +1,99 @@
+package me.bombom.api.v1.newsletter.controller;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+import me.bombom.api.v1.common.resolver.LoginMemberArgumentResolver;
+import me.bombom.api.v1.newsletter.domain.NewsletterPublicationStatus;
+import me.bombom.api.v1.newsletter.dto.CategoryResponse;
+import me.bombom.api.v1.newsletter.dto.NewsletterResponse;
+import me.bombom.api.v1.newsletter.dto.NewslettersResponse;
+import me.bombom.api.v1.newsletter.service.NewsletterService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@WebMvcTest(controllers = NewsletterController.class)
+@Import({NewsletterController.class, NewsletterControllerTest.TestConfig.class})
+class NewsletterControllerTest {
+
+    @Configuration
+    @EnableWebSecurity
+    static class TestConfig implements WebMvcConfigurer {
+
+        @Bean
+        LoginMemberArgumentResolver loginMemberArgumentResolver() {
+            return new LoginMemberArgumentResolver("JSESSIONID", "");
+        }
+
+        @Bean
+        SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+            return http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .build();
+        }
+
+        @Override
+        public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+            resolvers.add(loginMemberArgumentResolver());
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private NewsletterService newsletterService;
+
+    @Test
+    void 유효하지_않은_토큰이어도_뉴스레터_목록을_정상_반환한다() throws Exception {
+        NewslettersResponse response = NewslettersResponse.of(
+                List.of(new CategoryResponse(10L, "테크")),
+                List.of(new NewsletterResponse(
+                        1L,
+                        "봄봄 뉴스",
+                        "https://image.url",
+                        "설명",
+                        "https://subscribe.url",
+                        10L,
+                        "테크",
+                        NewsletterPublicationStatus.ACTIVE,
+                        false
+                ))
+        );
+        TestingAuthenticationToken invalidAuth = new TestingAuthenticationToken("notCustomUser", null);
+        invalidAuth.setAuthenticated(true);
+
+        given(newsletterService.getNewsletters(eq(null), eq(false), eq(null)))
+                .willReturn(response);
+
+        mockMvc.perform(get("/api/v1/newsletters").with(authentication(invalidAuth)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.categories[0].id").value(10L))
+                .andExpect(jsonPath("$.categories[0].name").value("테크"))
+                .andExpect(jsonPath("$.newsletters[0].newsletterId").value(1L))
+                .andExpect(jsonPath("$.newsletters[0].isSubscribed").value(false));
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
유효하지 않은 토큰이더라도 설정된 옵션에 따라 정상적인 응답을 반환할 수 있도록 기능을 추가했습니다.


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
여러분 중 일부는 메인 페이지에 접속했을 때 뉴스레터 목록이 뜨지 않는 경험을 해 보셨을 겁니다.

뉴스레터 목록 조회는 비로그인 사용자도 접근 가능한 API인데, 만료되었거나 비정상적인 토큰이 함께 전달되면 기존에는 INVALID_TOKEN 또는 UNAUTHORIZED 예외가 발생해서 뉴스레터 목록이 아무것도 안 뜨는 경우가 발생합니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
<img width="467" height="244" alt="image" src="https://github.com/user-attachments/assets/457755dc-2c2f-45b5-9c71-3733b74d25a5" />

- 유효하지 않은 토큰이 들어와도 에러를 반환하지 않고 정상 응답을 내려주도록 `@LoginMember` 애너테이션에 `allowInvalidToken` 옵션을 추가했습니다.

<사용 예시>
<img width="761" height="52" alt="image" src="https://github.com/user-attachments/assets/36951ea2-8ecd-4b5d-966e-0b5df4bc66de" />

- 현재는 `/api/v1/newsletters`에 먼저 도입했습니다. 

- `/api/v1/newsletters`의 memberId 파라미터에 `@LoginMember(anonymous = true, allowInvalidToken = true)`를 적용해, 정상 토큰이면 회원 기준으로 조회하고, 비로그인 또는 유효하지 않은 토큰이면 비회원처럼 memberId = null로 조회되도록 했습니다.



## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
allowInvalidToken의 의미를 anonymous와 분리한 방식이 적절한지 봐주시면 좋겠습니다. 현재는 공개 API에서만 선택적으로 적용할 수 있도록 의도했고, invalid token을 허용하더라도 세션/쿠키 정리는 유지하도록 했습니다.