### PR TITLE
[BOM-1027] refactor: 데일리 가이드 코멘트 생성 로직 분리 및 구조 개선

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/DailyGuideCommentContext.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/DailyGuideCommentContext.java
@@ -1,0 +1,14 @@
+package me.bombom.api.v1.challenge.dto;
+
+import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
+import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
+
+public record DailyGuideCommentContext(
+
+        Long challengeId,
+        int dayIndex,
+        Long memberId,
+        ChallengeParticipant participant,
+        ChallengeDailyGuide guide
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/DailyGuideCommentContext.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/DailyGuideCommentContext.java
@@ -11,4 +11,13 @@ public record DailyGuideCommentContext(
         ChallengeParticipant participant,
         ChallengeDailyGuide guide
 ) {
+    public static DailyGuideCommentContext of(
+            Long challengeId,
+            int dayIndex,
+            Long memberId,
+            ChallengeParticipant participant,
+            ChallengeDailyGuide guide
+    ) {
+        return new DailyGuideCommentContext(challengeId, dayIndex, memberId, participant, guide);
+    }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeDailyGuideCommentRepository.java
@@ -1,6 +1,5 @@
 package me.bombom.api.v1.challenge.repository;
 
-import java.util.Optional;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
@@ -12,7 +11,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChallengeDailyGuideCommentRepository extends JpaRepository<ChallengeDailyGuideComment, Long> {
 
-    Optional<ChallengeDailyGuideComment> findByGuideIdAndParticipantId(Long guideId, Long participantId);
+    boolean existsByGuideIdAndParticipantId(Long guideId, Long participantId);
 
     @Query("""
             SELECT new me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -188,7 +188,7 @@ public class ChallengeDailyGuideService {
         ChallengeParticipant participant = getChallengeParticipant(challengeId, memberId);
         validateDayIndex(challengeId, dayIndex, challenge);
         ChallengeDailyGuide guide = getChallengeDailyGuide(challengeId, dayIndex);
-        return new DailyGuideCommentContext(challengeId, dayIndex, memberId, participant, guide);
+        return DailyGuideCommentContext.of(challengeId, dayIndex, memberId, participant, guide);
     }
 
     private ChallengeParticipant getChallengeParticipant(Long challengeId, Long memberId) {
@@ -228,11 +228,10 @@ public class ChallengeDailyGuideService {
             ChallengeDailyGuide guide,
             ChallengeParticipant participant
     ) {
-        ChallengeDailyGuideComment existingComment = challengeDailyGuideCommentRepository
-                .findByGuideIdAndParticipantId(guide.getId(), participant.getId())
-                .orElse(null);
+        boolean commentExists = challengeDailyGuideCommentRepository
+                .existsByGuideIdAndParticipantId(guide.getId(), participant.getId());
 
-        if (existingComment != null) {
+        if (commentExists) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuideComment")
                     .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -101,17 +101,17 @@ public class ChallengeDailyGuideService {
     }
 
     @Transactional
-    public void createDailyGuideComment(
+    public CreateCommentResponse createDailyGuideComment(
             Long challengeId,
             int dayIndex,
             Long memberId,
-            DailyGuideCommentRequest request,
-            LocalDate today
+            DailyGuideCommentRequest request
     ) {
+        LocalDate today = LocalDate.now(clock);
         DailyGuideCommentContext context = loadCommentCreationContext(challengeId, dayIndex, memberId);
         validateCommentCreation(context);
         saveDailyGuideComment(context.participant(), context.guide(), request);
-        handleFirstDay(context.participant(), memberId, dayIndex, today);
+        return CreateCommentResponse.from(handleFirstDay(context.participant(), memberId, dayIndex, today));
     }
 
     public MemberDailyCommentResponse getDailyGuideComment(Long challengeId, int dayIndex, Long memberId) {
@@ -253,29 +253,32 @@ public class ChallengeDailyGuideService {
         challengeDailyGuideCommentRepository.save(comment);
     }
 
-    private void handleFirstDay(
+    private boolean handleFirstDay(
             ChallengeParticipant participant,
             Long memberId,
             int dayIndex,
             LocalDate today
     ) {
         if (dayIndex != FIRST_DAY_INDEX) {
-            return;
+            return false;
         }
 
         challengeTodoService.insertMindsetDone(participant, today);
         // READ 투두 자동 생성 (뉴스레터 1개 읽기)
-        challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
+        challengeDailyTodoService.updateChallengeDailyTodo(memberId, null);
         // COMMENT 투두 생성 (한 줄 코멘트 작성)
         challengeTodoService.insertCommentDone(participant, today);
 
         // 이미 완료되지 않았으면 progress 처리
-        if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
-            challengeTodoService.completeDailyTodo(participant, today);
-            if (participant.getChallengeTeamId() != null) {
-                ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
-                challengeTeamService.updateTeamProgress(challengeTeam);
-            }
+        if (challengeTodoService.isCompletedToday(participant.getId(), today)) {
+            return false;
         }
+
+        challengeTodoService.completeDailyTodo(participant.getId(), today);
+        if (participant.getChallengeTeamId() != null) {
+            ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
+            challengeTeamService.updateTeamProgress(challengeTeam);
+        }
+        return true;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -11,6 +11,7 @@ import me.bombom.api.v1.challenge.domain.ChallengeDailyGuide;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyGuideComment;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
+import me.bombom.api.v1.challenge.dto.DailyGuideCommentContext;
 import me.bombom.api.v1.challenge.dto.request.DailyGuideCommentRequest;
 import me.bombom.api.v1.challenge.dto.response.DailyGuideCommentResponse;
 import me.bombom.api.v1.challenge.dto.response.MemberDailyCommentResponse;
@@ -34,6 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ChallengeDailyGuideService {
 
+    private static final int FIRST_DAY_INDEX = 1;
     private final Clock clock;
 
     private final ChallengeRepository challengeRepository;
@@ -59,7 +61,7 @@ public class ChallengeDailyGuideService {
 
         int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
         TodayDailyGuideRow row = challengeDailyGuideRepository.findTodayGuide(
-                challengeId, memberId, dayIndex)
+                        challengeId, memberId, dayIndex)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
@@ -75,13 +77,17 @@ public class ChallengeDailyGuideService {
                 myComment);
     }
 
-    public Page<DailyGuideCommentResponse> getTotalComments(Long challengeId, int dayIndex, Long memberId,
-            Pageable pageable) {
+    public Page<DailyGuideCommentResponse> getTotalComments(
+            Long challengeId,
+            int dayIndex,
+            Long memberId,
+            Pageable pageable
+    ) {
         Challenge challenge = getChallenge(challengeId);
 
         validateChallengeParticipant(challengeId, memberId);
 
-        if (dayIndex != 0 && (dayIndex < 1 || dayIndex > challenge.getTotalDays())) {
+        if (dayIndex != 0 && (dayIndex < FIRST_DAY_INDEX || dayIndex > challenge.getTotalDays())) {
             throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
                     .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
                     .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
@@ -89,81 +95,23 @@ public class ChallengeDailyGuideService {
                     .addContext("reason", "유효하지 않은 일차 인덱스입니다.");
         }
 
-        ChallengeDailyGuide guide = challengeDailyGuideRepository.findByChallengeIdAndDayIndex(challengeId, dayIndex)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
-                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
-                        .addContext("dayIndex", dayIndex));
+        ChallengeDailyGuide guide = getChallengeDailyGuide(challengeId, dayIndex);
 
         return challengeDailyGuideCommentRepository.findByGuideId(guide.getId(), pageable);
     }
 
     @Transactional
-    public void createDailyGuideComment(Long challengeId, int dayIndex, Long memberId,
-            DailyGuideCommentRequest request, LocalDate today) {
-        Challenge challenge = getChallenge(challengeId);
-
-        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
-                challengeId, memberId)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
-                        .addContext(ErrorContextKeys.MEMBER_ID, memberId)
-                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
-
-        validateDayIndex(challengeId, dayIndex, challenge);
-
-        ChallengeDailyGuide guide = challengeDailyGuideRepository.findByChallengeIdAndDayIndex(challengeId, dayIndex)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
-                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
-                        .addContext("dayIndex", dayIndex));
-
-        if (!guide.isCommentEnabled()) {
-            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
-                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
-                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
-                    .addContext("dayIndex", dayIndex)
-                    .addContext("reason", "댓글 작성이 불가능한 가이드입니다.");
-        }
-
-        ChallengeDailyGuideComment existingComment = challengeDailyGuideCommentRepository
-                .findByGuideIdAndParticipantId(guide.getId(), participant.getId())
-                .orElse(null);
-
-        if (existingComment != null) {
-            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
-                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuideComment")
-                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
-                    .addContext("dayIndex", dayIndex)
-                    .addContext("reason", "이미 댓글이 존재합니다.");
-        }
-
-        ChallengeDailyGuideComment comment = ChallengeDailyGuideComment.builder()
-                .guideId(guide.getId())
-                .participantId(participant.getId())
-                .content(request.content())
-                .build();
-        challengeDailyGuideCommentRepository.save(comment);
-
-        // day1일 때만 체크리스트 자동 완료 처리
-        if (dayIndex == 1) {
-            // MINDSET 투두 생성 (마인드셋 댓글 작성)
-            challengeTodoService.insertMindsetDone(participant, today);
-            // TODO: 과도기라서 모두 완료 처리가 필요해 보임. 추후 삭제 필요
-            // READ 투두 자동 생성 (뉴스레터 1개 읽기)
-            challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
-            // COMMENT 투두 생성 (한 줄 코멘트 작성)
-            challengeTodoService.insertCommentDone(participant, today);
-
-            // 이미 완료되지 않았으면 progress 처리
-            if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
-                challengeTodoService.completeDailyTodo(participant, today);
-                if (participant.getChallengeTeamId() != null) {
-                    ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
-                    challengeTeamService.updateTeamProgress(challengeTeam);
-                }
-            }
-        }
+    public void createDailyGuideComment(
+            Long challengeId,
+            int dayIndex,
+            Long memberId,
+            DailyGuideCommentRequest request,
+            LocalDate today
+    ) {
+        DailyGuideCommentContext context = loadCommentCreationContext(challengeId, dayIndex, memberId);
+        validateCommentCreation(context);
+        saveDailyGuideComment(context.participant(), context.guide(), request);
+        handleFirstDay(context.participant(), memberId, dayIndex, today);
     }
 
     public MemberDailyCommentResponse getDailyGuideComment(Long challengeId, int dayIndex, Long memberId) {
@@ -210,16 +158,16 @@ public class ChallengeDailyGuideService {
         if (isWeekend(today)) {
             return 0;
         }
-        return (int) DAYS.between(startDate, today) + 1;
+        return (int) DAYS.between(startDate, today) + FIRST_DAY_INDEX;
     }
 
     private int calculateMaxAllowedDayIndex(LocalDate startDate, LocalDate today) {
         LocalDate targetDate = today;
         // 오늘이 주말이면 직전 금요일까지의 컨텐츠는 볼 수 있어야 함
         while (isWeekend(targetDate) && !targetDate.isBefore(startDate)) {
-            targetDate = targetDate.minusDays(1);
+            targetDate = targetDate.minusDays(FIRST_DAY_INDEX);
         }
-        return (int) DAYS.between(startDate, targetDate) + 1;
+        return (int) DAYS.between(startDate, targetDate) + FIRST_DAY_INDEX;
     }
 
     private boolean isWeekend(LocalDate date) {
@@ -228,10 +176,107 @@ public class ChallengeDailyGuideService {
     }
 
     private MyCommentResponse createMyCommentResponse(TodayDailyGuideRow row) {
-        boolean exists = row.getMyCommentExists() == 1;
+        boolean exists = row.getMyCommentExists() == FIRST_DAY_INDEX;
         return new MyCommentResponse(
                 exists,
                 exists ? row.getMyCommentContent() : null,
                 exists ? row.getMyCommentCreatedAt() : null);
+    }
+
+    private DailyGuideCommentContext loadCommentCreationContext(Long challengeId, int dayIndex, Long memberId) {
+        Challenge challenge = getChallenge(challengeId);
+        ChallengeParticipant participant = getChallengeParticipant(challengeId, memberId);
+        validateDayIndex(challengeId, dayIndex, challenge);
+        ChallengeDailyGuide guide = getChallengeDailyGuide(challengeId, dayIndex);
+        return new DailyGuideCommentContext(challengeId, dayIndex, memberId, participant, guide);
+    }
+
+    private ChallengeParticipant getChallengeParticipant(Long challengeId, Long memberId) {
+        return challengeParticipantRepository.findByChallengeIdAndMemberId(challengeId, memberId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeParticipant")
+                        .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId));
+    }
+
+    private ChallengeDailyGuide getChallengeDailyGuide(Long challengeId, int dayIndex) {
+        return challengeDailyGuideRepository.findByChallengeIdAndDayIndex(challengeId, dayIndex)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                        .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                        .addContext("dayIndex", dayIndex));
+    }
+
+    private void validateCommentCreation(DailyGuideCommentContext context) {
+        validateCommentEnabled(context.challengeId(), context.dayIndex(), context.guide());
+        validateNoExistingComment(context.challengeId(), context.dayIndex(), context.guide(), context.participant());
+    }
+
+    private void validateCommentEnabled(Long challengeId, int dayIndex, ChallengeDailyGuide guide) {
+        if (!guide.isCommentEnabled()) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext("dayIndex", dayIndex)
+                    .addContext("reason", "댓글 작성이 불가능한 가이드입니다.");
+        }
+    }
+
+    private void validateNoExistingComment(
+            Long challengeId,
+            int dayIndex,
+            ChallengeDailyGuide guide,
+            ChallengeParticipant participant
+    ) {
+        ChallengeDailyGuideComment existingComment = challengeDailyGuideCommentRepository
+                .findByGuideIdAndParticipantId(guide.getId(), participant.getId())
+                .orElse(null);
+
+        if (existingComment != null) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_INPUT_VALUE)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuideComment")
+                    .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)
+                    .addContext("dayIndex", dayIndex)
+                    .addContext("reason", "이미 댓글이 존재합니다.");
+        }
+    }
+
+    private void saveDailyGuideComment(
+            ChallengeParticipant participant,
+            ChallengeDailyGuide guide,
+            DailyGuideCommentRequest request
+    ) {
+        ChallengeDailyGuideComment comment = ChallengeDailyGuideComment.builder()
+                .guideId(guide.getId())
+                .participantId(participant.getId())
+                .content(request.content())
+                .build();
+        challengeDailyGuideCommentRepository.save(comment);
+    }
+
+    private void handleFirstDay(
+            ChallengeParticipant participant,
+            Long memberId,
+            int dayIndex,
+            LocalDate today
+    ) {
+        if (dayIndex != FIRST_DAY_INDEX) {
+            return;
+        }
+
+        challengeTodoService.insertMindsetDone(participant, today);
+        // READ 투두 자동 생성 (뉴스레터 1개 읽기)
+        challengeDailyTodoService.updateChallengeDailyTodo(memberId, null, today);
+        // COMMENT 투두 생성 (한 줄 코멘트 작성)
+        challengeTodoService.insertCommentDone(participant, today);
+
+        // 이미 완료되지 않았으면 progress 처리
+        if (!challengeTodoService.isCompletedToday(participant.getId(), today)) {
+            challengeTodoService.completeDailyTodo(participant, today);
+            if (participant.getChallengeTeamId() != null) {
+                ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
+                challengeTeamService.updateTeamProgress(challengeTeam);
+            }
+        }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideService.java
@@ -60,8 +60,7 @@ public class ChallengeDailyGuideService {
         }
 
         int dayIndex = calculateDayIndex(challenge.getStartDate(), today);
-        TodayDailyGuideRow row = challengeDailyGuideRepository.findTodayGuide(
-                        challengeId, memberId, dayIndex)
+        TodayDailyGuideRow row = challengeDailyGuideRepository.findTodayGuide(challengeId, memberId, dayIndex)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeDailyGuide")
                         .addContext(ErrorContextKeys.CHALLENGE_ID, challengeId)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -653,8 +653,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 1,
                 member.getId(),
-                request,
-                weekday
+                request
         );
 
         // then
@@ -686,14 +685,14 @@ class ChallengeDailyGuideServiceTest {
         );
         DailyGuideCommentRequest request = new DailyGuideCommentRequest("주말 첫날 코멘트");
         LocalDate saturday = LocalDate.of(2026, 1, 31);
+        given(clock.instant()).willReturn(saturday.atStartOfDay(SEOUL_ZONE).toInstant());
 
         // when
         challengeDailyGuideService.createDailyGuideComment(
                 challenge.getId(),
                 1,
                 member.getId(),
-                request,
-                saturday
+                request
         );
 
         // then
@@ -732,8 +731,7 @@ class ChallengeDailyGuideServiceTest {
                 challenge.getId(),
                 futureDayIndex,
                 member.getId(),
-                request,
-                today
+                request
         )).isInstanceOf(CIllegalArgumentException.class);
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeDailyGuideServiceTest.java
@@ -653,6 +653,116 @@ class ChallengeDailyGuideServiceTest {
     }
 
     @Test
+    void day1에_이미_출석완료된_경우_dailyResult와_completedDays를_중복_반영하지_않음() {
+        // given
+        challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        1,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day01.webp",
+                        "첫날 가이드",
+                        true
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("첫날 코멘트");
+        LocalDate weekday = today;
+
+        challengeDailyResultRepository.save(
+                TestFixture.createChallengeDailyResult(participant.getId(), weekday,
+                        me.bombom.api.v1.challenge.domain.ChallengeDailyStatus.COMPLETE)
+        );
+
+        // when
+        challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                1,
+                member.getId(),
+                request,
+                weekday
+        );
+
+        // then
+        List<ChallengeDailyGuideComment> comments = challengeDailyGuideCommentRepository.findAll();
+        ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(comments).hasSize(1);
+            softly.assertThat(challengeDailyResultRepository.count()).isEqualTo(1);
+            softly.assertThat(updatedParticipant.getCompletedDays()).isEqualTo(0);
+            softly.assertThat(challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                    participant.getId(), weekday, commentTodo.getId())).isTrue();
+            softly.assertThat(challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                    participant.getId(), weekday, mindsetTodo.getId())).isTrue();
+        });
+    }
+
+    @Test
+    void day1에_주말_날짜로_코멘트_작성시_READ_todo만_생성되지_않는다() {
+        // given
+        challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        1,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/day01.webp",
+                        "첫날 가이드",
+                        true
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("주말 첫날 코멘트");
+        LocalDate saturday = LocalDate.of(2026, 1, 31);
+
+        // when
+        challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                1,
+                member.getId(),
+                request,
+                saturday
+        );
+
+        // then
+        ChallengeParticipant updatedParticipant = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                    participant.getId(), saturday, readTodo.getId())).isFalse();
+            softly.assertThat(challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                    participant.getId(), saturday, commentTodo.getId())).isTrue();
+            softly.assertThat(challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                    participant.getId(), saturday, mindsetTodo.getId())).isTrue();
+            softly.assertThat(challengeDailyResultRepository.existsByParticipantIdAndDate(
+                    participant.getId(), saturday)).isTrue();
+            softly.assertThat(updatedParticipant.getCompletedDays()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void 아직_열리지_않은_미래_dayIndex로_댓글_작성시_예외_발생() {
+        // given
+        int futureDayIndex = calculateDayIndex(challenge.getStartDate(), today) + 1;
+        challengeDailyGuideRepository.save(
+                TestFixture.createChallengeDailyGuide(
+                        challenge.getId(),
+                        futureDayIndex,
+                        DailyGuideType.COMMENT,
+                        "https://example.com/future.webp",
+                        "미래 가이드",
+                        true
+                )
+        );
+        DailyGuideCommentRequest request = new DailyGuideCommentRequest("미래 댓글 작성 시도");
+
+        // when & then
+        assertThatThrownBy(() -> challengeDailyGuideService.createDailyGuideComment(
+                challenge.getId(),
+                futureDayIndex,
+                member.getId(),
+                request,
+                today
+        )).isInstanceOf(CIllegalArgumentException.class);
+    }
+
+    @Test
     void 데일리_가이드_코멘트_목록_조회_성공() {
         // given
         Member member2 = TestFixture.createUniqueMember("member2", "member2");


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
`createDailyGuideComment()` 메서드 리팩터링

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
`createDailyGuideComment` 메서드 길이가 65줄을 넘어가서 극악의 가독성을 가지고 있어서 개선의 필요성을 느낌

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

- createDailyGuideComment() 메서드의 책임을 단계별로 분리했습니다.
- 댓글 생성 흐름이 컨텍스트 조회 -> 생성 가능 여부 검증 -> 댓글 저장 -> day1 후처리로 드러나도록 정리했습니다.
- 댓글 생성에 필요한 값을 묶는 DailyGuideCommentContext를 도입했습니다.
- 조회/검증 로직을 별도 private 메서드로 추출해 본문 가독성을 높였습니다.
- 매직넘버를 상수화했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 다른 부분도 리팩터링 하면 좋지만 일단은 조금씩 개선해나갈 생각입니다. 
- 리팩터링은 계속 진행할꺼라 현재 변경 범위안에서만 리뷰해주시면 감사합니다.