### PR TITLE
[BOM-1029] fix: 챌린지 completed days 오류 해결

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/scheduler/ChallengeScheduler.java
@@ -36,7 +36,7 @@ public class ChallengeScheduler {
     @SchedulerLock(name = "check_survival", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void checkSurvival() {
         log.info("탈락 및 쉴드 사용 처리 시작");
-        LocalDate yesterday = LocalDate.now().minusDays(1);
+        LocalDate yesterday = LocalDate.now(clock).minusDays(1);
         List<Challenge> challenges = challengeService.getOngoingChallenges(yesterday);
 
         for (Challenge challenge : challenges) {
@@ -52,7 +52,7 @@ public class ChallengeScheduler {
     @SchedulerLock(name = "process_ended_challenges", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void processEndedChallenges() {
         log.info("챌린지 종료 처리 및 뱃지 발급 시작");
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(clock);
         List<Challenge> endedChallenges = challengeService.getEndedChallengesPendingBadge(today);
 
         if (endedChallenges.isEmpty()) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -6,6 +6,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -189,6 +190,9 @@ public class ChallengeService {
     }
 
     public List<Challenge> getOngoingChallenges(LocalDate date) {
+        if (isWeekend(date)) {
+            return Collections.emptyList();
+        }
         return challengeRepository.findOngoingChallenges(date);
     }
 
@@ -233,6 +237,11 @@ public class ChallengeService {
         return challengeParticipantRepository.countByChallengeIdInGroupByChallengeId(challengeIds)
                 .stream()
                 .collect(toMap(ChallengeParticipantCount::challengeId, ChallengeParticipantCount::count));
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 
     private Map<Long, List<ChallengeNewsletterResponse>> getNewslettersByChallengeId(List<Long> challengeIds) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -15,9 +15,9 @@ import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeFilter;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeStatus;
+import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.domain.EligibilityReason;
 import me.bombom.api.v1.challenge.domain.RegistrationPhase;
-import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.dto.response.ChallengeDetailResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeEligibilityResponse;
 import me.bombom.api.v1.challenge.dto.response.ChallengeInfoResponse;
@@ -937,6 +937,52 @@ class ChallengeServiceTest {
         assertThatThrownBy(() -> challengeService.getTeamList(0L, member))
                 .isInstanceOf(CIllegalArgumentException.class)
                 .hasMessage(ErrorDetail.ENTITY_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void 토요일에_진행_중인_챌린지_조회_시_빈_리스트를_반환한다() {
+        // given
+        LocalDate saturday = LocalDate.of(2025, 3, 15);
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        challengeRepository.save(TestFixture.createChallenge("진행 중 챌린지", saturday.minusDays(5), saturday.plusDays(5), 10, group.getId()));
+
+        // when
+        List<Challenge> result = challengeService.getOngoingChallenges(saturday);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 일요일에_진행_중인_챌린지_조회_시_빈_리스트를_반환한다() {
+        // given
+        LocalDate sunday = LocalDate.of(2025, 3, 16);
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        challengeRepository.save(TestFixture.createChallenge("진행 중 챌린지", sunday.minusDays(5), sunday.plusDays(5), 10, group.getId()));
+
+        // when
+        List<Challenge> result = challengeService.getOngoingChallenges(sunday);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    void 평일에_진행_중인_챌린지를_조회한다() {
+        // given
+        LocalDate monday = LocalDate.of(2025, 3, 17);
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        Challenge challenge = challengeRepository.save(TestFixture.createChallenge("진행 중 챌린지", monday.minusDays(5), monday.plusDays(5), 10, group.getId()));
+
+        // when
+        List<Challenge> result = challengeService.getOngoingChallenges(monday);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getId()).isEqualTo(challenge.getId());
     }
 
     @Test


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 진행 중 주말에 참가자의 쉴드가 차감되면서 참여 처리가 되고, 이로 인해 completedDays(누적 달성일)가 비정상적으로 증가하는 문제를 해결했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존의 생존 체크 및 진행률 계산 로직(`ChallengeScheduler`, `ChallengeProgressService`)이 주말을 고려하지 않고 매일 실행되고 있었습니다. 
이로 인해 주말에는 챌린지가 진행되지 않음에도 불구하고 주말 미수행이 결석으로 처리되어 참가자의 쉴드가 강제로 차감되면서 completedDays가 증가하고 있었습니다.
이로 인해 참여자들의 챌린지 달성률이 실제 진행 상황보다 높게 나오는 문제가 발생했습니다.

<img width="1064" height="412" alt="image" src="https://github.com/user-attachments/assets/93583cd5-e492-4333-aa8c-7bbb9d9f8ec7" />

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
`ChallengeService.getOngoingChallenges()` 메서드 내부에 `isWeekend()` 검증 로직을 추가했습니다.
이를 통해 주말(토/일)에는 `ChallengeScheduler`의 `checkSurvival(생존 체크)` 및 `resetTeamProgress(팀 진행률 초기화)` 로직이 스킵되도록 수정했습니다.


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
