### PR TITLE
[BOM-1030] feat: 블로그 관련 entity 세팅

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogCategory.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogCategory.java
@@ -1,0 +1,35 @@
+package me.bombom.api.v1.blog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlogCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    @Builder
+    public BlogCategory(
+            Long id,
+            @NonNull String name
+    ) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogHashTag.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogHashTag.java
@@ -1,0 +1,35 @@
+package me.bombom.api.v1.blog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BlogHashTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String name;
+
+    @Builder
+    public BlogHashTag(
+            Long id,
+            @NonNull String name
+    ) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogHashtag.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogHashtag.java
@@ -15,7 +15,7 @@ import me.bombom.api.v1.common.BaseEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class BlogHashTag extends BaseEntity {
+public class BlogHashtag extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,7 +25,7 @@ public class BlogHashTag extends BaseEntity {
     private String name;
 
     @Builder
-    public BlogHashTag(
+    public BlogHashtag(
             Long id,
             @NonNull String name
     ) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogImageAsset.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogImageAsset.java
@@ -7,8 +7,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,14 +18,6 @@ import me.bombom.api.v1.common.BaseEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(
-        indexes = {
-                @Index(
-                        name = "idx_blog_image_asset_blog_post_status",
-                        columnList = "blog_post_id, status"
-                )
-        }
-)
 public class BlogImageAsset extends BaseEntity {
 
     @Id

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogImageAsset.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogImageAsset.java
@@ -1,0 +1,68 @@
+package me.bombom.api.v1.blog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        indexes = {
+                @Index(
+                        name = "idx_blog_image_asset_blog_post_status",
+                        columnList = "blog_post_id, status"
+                )
+        }
+)
+public class BlogImageAsset extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long blogPostId;
+
+    @Column(nullable = false, unique = true, length = 500)
+    private String objectKey;
+
+    @Column(nullable = false, length = 1000)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private BlogImageAssetStatus status;
+
+    private LocalDateTime deleteRequestedAt;
+
+    @Builder
+    public BlogImageAsset(
+            Long id,
+            @NonNull Long blogPostId,
+            @NonNull String objectKey,
+            @NonNull String imageUrl,
+            @NonNull BlogImageAssetStatus status,
+            LocalDateTime deleteRequestedAt
+    ) {
+        this.id = id;
+        this.blogPostId = blogPostId;
+        this.objectKey = objectKey;
+        this.imageUrl = imageUrl;
+        this.status = status;
+        this.deleteRequestedAt = deleteRequestedAt;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogImageAssetStatus.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogImageAssetStatus.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.blog.domain;
+
+public enum BlogImageAssetStatus {
+    UPLOADED,
+    ATTACHED,
+    DELETE_PENDING
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
@@ -7,8 +7,6 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
-import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -20,15 +18,6 @@ import me.bombom.api.v1.common.BaseEntity;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(
-        indexes = {
-                @Index(
-                        name = "idx_blog_post_status_visibility_published_at",
-                        columnList = "status, visibility, published_at"
-                ),
-                @Index(name = "idx_blog_post_category_id", columnList = "category_id")
-        }
-)
 public class BlogPost extends BaseEntity {
 
     @Id

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
@@ -41,7 +41,7 @@ public class BlogPost extends BaseEntity {
     @Column(length = 200)
     private String title;
 
-    @Column(columnDefinition = "longtext")
+    @Column(columnDefinition = "mediumtext")
     private String content;
 
     private Long thumbnailImageId;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
@@ -1,0 +1,87 @@
+package me.bombom.api.v1.blog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        indexes = {
+                @Index(
+                        name = "idx_blog_post_status_visibility_published_at",
+                        columnList = "status, visibility, published_at"
+                ),
+                @Index(name = "idx_blog_post_category_id", columnList = "category_id")
+        }
+)
+public class BlogPost extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(length = 200)
+    private String title;
+
+    @Column(columnDefinition = "longtext")
+    private String content;
+
+    private Long thumbnailImageId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private BlogPostStatus status;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private BlogPostVisibility visibility;
+
+    private Long categoryId;
+
+    private Integer expectedReadTime;
+
+    private LocalDateTime publishedAt;
+
+    @Builder
+    public BlogPost(
+            Long id,
+            @NonNull Long memberId,
+            String title,
+            String content,
+            Long thumbnailImageId,
+            @NonNull BlogPostStatus status,
+            @NonNull BlogPostVisibility visibility,
+            Long categoryId,
+            Integer expectedReadTime,
+            LocalDateTime publishedAt
+    ) {
+        this.id = id;
+        this.memberId = memberId;
+        this.title = title;
+        this.content = content;
+        this.thumbnailImageId = thumbnailImageId;
+        this.status = status;
+        this.visibility = visibility;
+        this.categoryId = categoryId;
+        this.expectedReadTime = expectedReadTime;
+        this.publishedAt = publishedAt;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostStatus.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostStatus.java
@@ -1,7 +1,9 @@
 package me.bombom.api.v1.blog.domain;
 
 public enum BlogPostStatus {
+
     DRAFT,
     PUBLISHED,
-    DELETED
+    DELETED,
+    ;
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostStatus.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostStatus.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.blog.domain;
+
+public enum BlogPostStatus {
+    DRAFT,
+    PUBLISHED,
+    DELETED
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostTag.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostTag.java
@@ -1,0 +1,50 @@
+package me.bombom.api.v1.blog.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_blog_post_tag_post_tag",
+                        columnNames = {"blog_post_id", "blog_hash_tag_id"}
+                )
+        }
+)
+public class BlogPostTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long blogPostId;
+
+    @Column(nullable = false)
+    private Long blogHashTagId;
+
+    @Builder
+    public BlogPostTag(
+            Long id,
+            @NonNull Long blogPostId,
+            @NonNull Long blogHashTagId
+    ) {
+        this.id = id;
+        this.blogPostId = blogPostId;
+        this.blogHashTagId = blogHashTagId;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostVisibility.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostVisibility.java
@@ -1,0 +1,6 @@
+package me.bombom.api.v1.blog.domain;
+
+public enum BlogPostVisibility {
+    PRIVATE,
+    PUBLIC
+}

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.0.0__create_blog_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.0.0__create_blog_tables.sql
@@ -3,7 +3,7 @@ CREATE TABLE blog_post (
                            id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                            member_id BIGINT NOT NULL,
                            title VARCHAR(200) NULL,
-                           content LONGTEXT NULL,
+                           content MEDIUMTEXT NULL,
                            thumbnail_image_id BIGINT NULL,
                            status ENUM('DRAFT', 'PUBLISHED', 'DELETED') NOT NULL,
                            visibility ENUM('PRIVATE', 'PUBLIC') NOT NULL,

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.0.0__create_blog_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.0.0__create_blog_tables.sql
@@ -1,0 +1,59 @@
+-- 블로그 글
+CREATE TABLE blog_post (
+                           id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                           member_id BIGINT NOT NULL,
+                           title VARCHAR(200) NULL,
+                           content LONGTEXT NULL,
+                           thumbnail_image_id BIGINT NULL,
+                           status ENUM('DRAFT', 'PUBLISHED', 'DELETED') NOT NULL,
+                           visibility ENUM('PRIVATE', 'PUBLIC') NOT NULL,
+                           category_id BIGINT NULL,
+                           expected_read_time INT NULL,
+                           published_at DATETIME(6) NULL,
+                           created_at DATETIME(6) NOT NULL,
+                           updated_at DATETIME(6) NOT NULL,
+                           KEY idx_blog_post_status_visibility_published_at (status, visibility, published_at),
+                           KEY idx_blog_post_category_id (category_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 블로그 카테고리
+CREATE TABLE blog_category (
+                               id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                               name VARCHAR(50) NOT NULL,
+                               created_at DATETIME(6) NOT NULL,
+                               updated_at DATETIME(6) NOT NULL,
+                               CONSTRAINT uk_blog_category_name UNIQUE (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 블로그 해시태그
+CREATE TABLE blog_hash_tag (
+                               id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                               name VARCHAR(50) NOT NULL,
+                               created_at DATETIME(6) NOT NULL,
+                               updated_at DATETIME(6) NOT NULL,
+                               CONSTRAINT uk_blog_hash_tag_name UNIQUE (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 블로그 해시태그 연관관계
+CREATE TABLE blog_post_tag (
+                               id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                               blog_post_id BIGINT NOT NULL,
+                               blog_hash_tag_id BIGINT NOT NULL,
+                               created_at DATETIME(6) NOT NULL,
+                               updated_at DATETIME(6) NOT NULL,
+                               CONSTRAINT uk_blog_post_tag_post_tag UNIQUE (blog_post_id, blog_hash_tag_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- 블로그 이미지
+CREATE TABLE blog_image_asset (
+                                  id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+                                  blog_post_id BIGINT NOT NULL,
+                                  object_key VARCHAR(500) NOT NULL,
+                                  image_url VARCHAR(1000) NOT NULL,
+                                  status ENUM('UPLOADED', 'ATTACHED', 'DELETE_PENDING') NOT NULL,
+                                  delete_requested_at DATETIME(6) NULL,
+                                  created_at DATETIME(6) NOT NULL,
+                                  updated_at DATETIME(6) NOT NULL,
+                                  CONSTRAINT uk_blog_image_asset_object_key UNIQUE (object_key),
+                                  KEY idx_blog_image_asset_blog_post_status (blog_post_id, status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.0.0__create_blog_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.0.0__create_blog_tables.sql
@@ -26,22 +26,22 @@ CREATE TABLE blog_category (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 블로그 해시태그
-CREATE TABLE blog_hash_tag (
+CREATE TABLE blog_hashtag (
                                id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                                name VARCHAR(50) NOT NULL,
                                created_at DATETIME(6) NOT NULL,
                                updated_at DATETIME(6) NOT NULL,
-                               CONSTRAINT uk_blog_hash_tag_name UNIQUE (name)
+                               CONSTRAINT uk_blog_hashtag_name UNIQUE (name)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 블로그 해시태그 연관관계
 CREATE TABLE blog_post_tag (
                                id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
                                blog_post_id BIGINT NOT NULL,
-                               blog_hash_tag_id BIGINT NOT NULL,
+                               blog_hashtag_id BIGINT NOT NULL,
                                created_at DATETIME(6) NOT NULL,
                                updated_at DATETIME(6) NOT NULL,
-                               CONSTRAINT uk_blog_post_tag_post_tag UNIQUE (blog_post_id, blog_hash_tag_id)
+                               CONSTRAINT uk_blog_post_tag_post_tag UNIQUE (blog_post_id, blog_hashtag_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 블로그 이미지

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.0.0__create_blog_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.0.0__create_blog_tables.sql
@@ -11,9 +11,7 @@ CREATE TABLE blog_post (
                            expected_read_time INT NULL,
                            published_at DATETIME(6) NULL,
                            created_at DATETIME(6) NOT NULL,
-                           updated_at DATETIME(6) NOT NULL,
-                           KEY idx_blog_post_status_visibility_published_at (status, visibility, published_at),
-                           KEY idx_blog_post_category_id (category_id)
+                           updated_at DATETIME(6) NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- 블로그 카테고리


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
블로그 관련 entity를 세팅합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
SEO 활성화를 위해 봄봄 블로그를 구현할 예정입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
#### 전반적인 설계가 궁금하신 분들은 [피그마](https://www.figma.com/board/J5thvKXNnO5dyuApXmQ3Oh/%EB%B4%84%EB%B4%84-%EB%B8%8C%EB%A0%88%EC%9D%B8-%EC%8A%A4%ED%86%A0%EB%B0%8D?node-id=0-1&p=f&t=uWBuOM9lOYXedkDL-0)에 가보시면 있습니다!
- 전체적인 테이블 구성은 다음과 같습니다. (편의상 BaseEntity 컬럼은 제외했습니다)
<img width="1133" height="698" alt="image" src="https://github.com/user-attachments/assets/8ca7545d-34f4-442c-915c-13178bbb52ba" />

#### `BlogPost`의 status
  - **`DRAFT`** : 임시저장 상태로 아직 발행되지 않은 글이고, 작성 중인 상태
  - **`PUBLISHED`** : 발행 완료
    - 목록/상세 조회 API에서 외부에 노출될 수 있는 상태
    - 단, visibility = `PRIVATE`면 admin 한정 노출
  - **`DELETED`** : 삭제 처리된 글
    - 바로 물리 삭제하지 않고 논리 삭제 상태로 두는 값
    - 나중에 복구 정책이나 운영 관리가 필요할 경우 사용

#### `BlogPost`의 visibility
- **`PRIVATE`**: 비공개처리, admin만 보기 가능
- **`PUBLIC`**: 공개처리, 모든 회원 보기 가능

#### `BlogImageAssets`의 status
- **`UPLOADED`**: 이미지는 업로드됐지만, 아직 본문이나 썸네일에서 사용 확정되지 않은 상태 (임시저장 또는 발행되지 않은 상태)
  - ex: 사용자가 이미지 업로드만 하고 저장 안 함, 에디터에 올렸지만 아직 임시저장 호출 전
- **`ATTACHED`**: 현재 글에서 실제 사용 중인 이미지 (이미지 삽입 후 임시저장 또는 발행 된 상태)
  - 본문에 참조되는 이미지 아이디 목록에 포함되거나, thumbnailImageId로 지정된 상태
  - ex: 본문 중간 이미지로 사용 중, 썸네일로 사용 중, 본문과 썸네일 둘 다에서 사용 중
- **`DELETE_PENDING`** : 삭제 예약 상태
  - 지금은 더 이상 사용하지 않지만, 아직 스케줄러가 실제 파일을 지우기 전인 상태
  - ex: 본문에서 제거된 이미지, 기존 썸네일이 교체되었고 더 이상 본문에서도 안 쓰는 경우, 글 자체가 삭제되면서 같이 정리 대상이 된 이미지
  - 이 상태의 이미지는 백엔드 스케줄러가 아래 순서로 확인 후 삭제:
    - 스토리지에서 실제 파일 삭제
    - DB row hard delete


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 참조관계가 적절한지 확인 부탁드립니다. 다른 부분은 자유롭게 리뷰 부탁드립니다!