### PR TITLE
[BOM-1037] feat: 스트릭 조회 API에 오늘 미완료 데이터 포함하도록 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeStreakResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeStreakResponse.java
@@ -3,6 +3,8 @@ package me.bombom.api.v1.challenge.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
 
@@ -21,6 +23,12 @@ public record ChallengeStreakResponse(
 
     public static ChallengeStreakResponse of(int streak, List<ChallengeDailyResult> results) {
         List<StreakDayResponse> days = StreakDayResponse.from(results.reversed());
+        return new ChallengeStreakResponse(streak, days);
+    }
+
+    public static ChallengeStreakResponse withTodayAbsent(int streak, List<ChallengeDailyResult> results, LocalDate today) {
+        List<StreakDayResponse> days = new ArrayList<>(StreakDayResponse.from(results.reversed()));
+        days.add(StreakDayResponse.notParticipated(today));
         return new ChallengeStreakResponse(streak, days);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/StreakDayResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/StreakDayResponse.java
@@ -17,6 +17,9 @@ public record StreakDayResponse(
         DayOfWeek dayOfWeek,
 
         @Schema(requiredMode = RequiredMode.REQUIRED)
+        boolean isCompleted,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         boolean isShieldApplied
 ) {
 
@@ -24,8 +27,13 @@ public record StreakDayResponse(
         return new StreakDayResponse(
                 result.getDate(),
                 result.getDate().getDayOfWeek(),
+                true,
                 result.getStatus() == ChallengeDailyStatus.SHIELD
         );
+    }
+
+    public static StreakDayResponse notParticipated(LocalDate date) {
+        return new StreakDayResponse(date, date.getDayOfWeek(), false, false);
     }
 
     public static List<StreakDayResponse> from(List<ChallengeDailyResult> results) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -77,16 +77,26 @@ public class ChallengeProgressService {
         ChallengeParticipant participant = getChallengeParticipant(challengeId, member.getId());
 
         int streak = participant.getStreak();
-        int fetchCount = Math.min(limit, streak);
-        if (fetchCount == 0) {
-            return ChallengeStreakResponse.empty();
+        LocalDate today = LocalDate.now(clock);
+        boolean completedToday = challengeDailyResultRepository.existsByParticipantIdAndDate(participant.getId(), today);
+
+        if (completedToday) {
+            int fetchCount = Math.min(limit, streak);
+            if (fetchCount == 0) {
+                return ChallengeStreakResponse.empty();
+            }
+            List<ChallengeDailyResult> recentDaysResult = challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(
+                    participant.getId(),
+                    PageRequest.of(0, fetchCount)
+            );
+            return ChallengeStreakResponse.of(streak, recentDaysResult);
         }
 
-        List<ChallengeDailyResult> recentDays = challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(
-                participant.getId(),
-                PageRequest.of(0, fetchCount)
-        );
-        return ChallengeStreakResponse.of(streak, recentDays);
+        int fetchCount = Math.min(limit - 1, streak);
+        List<ChallengeDailyResult> recentDays = fetchCount > 0
+                ? challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(participant.getId(), PageRequest.of(0, fetchCount))
+                : List.of();
+        return ChallengeStreakResponse.withTodayAbsent(streak, recentDays, today);
     }
 
     public TeamChallengeProgressResponse getTeamProgressByTeamId(Long challengeId, Long teamId, Member member) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -46,10 +46,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @AutoConfigureMockMvc
 @Import({
@@ -234,9 +234,9 @@ class ChallengeProgressControllerUnitTest {
         ChallengeStreakResponse response = new ChallengeStreakResponse(
                 3,
                 List.of(
-                        new StreakDayResponse(today.minusDays(2), today.minusDays(2).getDayOfWeek(), false),
-                        new StreakDayResponse(today.minusDays(1), today.minusDays(1).getDayOfWeek(), true),
-                        new StreakDayResponse(today, today.getDayOfWeek(), false)
+                        new StreakDayResponse(today.minusDays(2), today.minusDays(2).getDayOfWeek(), true, false),
+                        new StreakDayResponse(today.minusDays(1), today.minusDays(1).getDayOfWeek(), true, true),
+                        new StreakDayResponse(today, today.getDayOfWeek(), true, false)
                 )
         );
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -451,7 +451,9 @@ class ChallengeProgressServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(response.streak()).isEqualTo(0);
-            softly.assertThat(response.streakDays()).isEmpty();
+            softly.assertThat(response.streakDays()).hasSize(1);
+            softly.assertThat(response.streakDays().getFirst().date()).isEqualTo(LocalDate.now());
+            softly.assertThat(response.streakDays().getFirst().isCompleted()).isFalse();
         });
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -623,6 +623,98 @@ class ChallengeProgressServiceTest {
     }
 
     @Test
+    void 오늘_미완료시_이전_기록과_오늘_미완료_항목이_함께_반환된다() {
+        // given - streak=3, 오늘 미완료
+        Challenge streakChallenge = createStreakChallenge("오늘 미완료 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .streak(3)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        LocalDate today = LocalDate.now();
+        challengeDailyResultRepository.saveAll(List.of(
+                createChallengeDailyResult(participant.getId(), today.minusDays(3), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), today.minusDays(2), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), today.minusDays(1), ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when - limit=5, 오늘 미완료이므로 최근 4개 + 오늘 미완료 = 4개(streak=3이라 3개) + 오늘
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streak()).isEqualTo(3);
+            softly.assertThat(response.streakDays()).hasSize(4);
+            softly.assertThat(response.streakDays().getLast().date()).isEqualTo(today);
+            softly.assertThat(response.streakDays().getLast().isCompleted()).isFalse();
+        });
+    }
+
+    @Test
+    void 오늘_미완료시_limit_적용은_오늘_포함_기준이다() {
+        // given - streak=5, limit=3, 오늘 미완료 → limit-1=2개 + 오늘 = 3개
+        Challenge streakChallenge = createStreakChallenge("limit 확인 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(5)
+                .streak(5)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        LocalDate today = LocalDate.now();
+        for (int i = 5; i >= 1; i--) {
+            challengeDailyResultRepository.save(
+                    createChallengeDailyResult(participant.getId(), today.minusDays(i), ChallengeDailyStatus.COMPLETE));
+        }
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 3);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streakDays()).hasSize(3);
+            softly.assertThat(response.streakDays().getLast().date()).isEqualTo(today);
+            softly.assertThat(response.streakDays().getLast().isCompleted()).isFalse();
+        });
+    }
+
+    @Test
+    void 오늘_완료시_isCompleted가_true다() {
+        // given
+        Challenge streakChallenge = createStreakChallenge("오늘 완료 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(2)
+                .streak(2)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        LocalDate today = LocalDate.now();
+        challengeDailyResultRepository.saveAll(List.of(
+                createChallengeDailyResult(participant.getId(), today.minusDays(1), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), today, ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streakDays()).hasSize(2);
+            softly.assertThat(response.streakDays().getLast().date()).isEqualTo(today);
+            softly.assertThat(response.streakDays().getLast().isCompleted()).isTrue();
+        });
+    }
+
+    @Test
     void 연속_참여_스트릭이_응답에_포함된다() {
         // given
         NewsletterGroup group = newsletterGroupRepository.save(TestFixture.createNewsletterGroup("스트릭 그룹"));


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
스트릭 조회 API에 오늘 미완료 데이터 포함하도록 구현했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
오늘 완료 여부와 관계없이 오늘 날짜 데이터를 항상 응답에 포함해야 클라이언트에서 오늘 상태를 별도 처리 없이 렌더링할 수 있습니다. 

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- StreakDayResponse에 isCompleted 필드 추가 — 기존 레코드는 true, 오늘 미완료는 false                                                                                                                                         
- ChallengeStreakResponse.withTodayAbsent() 팩토리 메서드 추가
- getMemberStreak 서비스 로직 분기                                                                                                                                                                                            
  - 오늘 완료: 기존 로직 유지 (limit개 반환)
  - 오늘 미완료: limit - 1개 조회 + 오늘 미완료 항목 append   

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

<img width="562" height="319" alt="image" src="https://github.com/user-attachments/assets/e8eb6dda-ab69-4bb8-ace0-de8bf7a2b88f" />


이런식으로 오늘 채워야 할 빈칸을 보여주기 위함입니다!