### PR TITLE
[BOM-1041] feat: 챌린지 시작 이후 참여자 팀 자동 배정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/repository/ChallengeTeamRepository.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.challenge.repository;
 
 import java.util.List;
+import java.util.Optional;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -16,6 +17,17 @@ public interface ChallengeTeamRepository extends JpaRepository<ChallengeTeam, Lo
         ORDER BY ct.id
     """)
     List<ChallengeTeam> findAllByChallengeIdOrderById(@Param("challengeId") Long challengeId);
+
+    @Query("""
+        SELECT ct
+        FROM ChallengeTeam ct
+        LEFT JOIN ChallengeParticipant cp ON cp.challengeTeamId = ct.id
+        WHERE ct.challengeId = :challengeId
+        GROUP BY ct
+        ORDER BY COUNT(cp.id), ct.id
+        LIMIT 1
+    """)
+    Optional<ChallengeTeam> findTeamWithFewestMembers(@Param("challengeId") Long challengeId);
 
     @Modifying
     @Query("""

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeService.java
@@ -157,9 +157,12 @@ public class ChallengeService {
             throw createApplyException(challengeId, member, reason);
         }
 
+        Long teamId = challenge.hasStarted(LocalDate.now(clock)) ? getFewestTeamId(challengeId) : null;
+
         ChallengeParticipant participant = ChallengeParticipant.builder()
                 .challengeId(challengeId)
                 .memberId(member.getId())
+                .challengeTeamId(teamId)
                 .isSurvived(true)
                 .build();
 
@@ -364,5 +367,11 @@ public class ChallengeService {
                 .addContext(ErrorContextKeys.ENTITY_TYPE, "challenge")
                 .addContext(ErrorContextKeys.OPERATION, "applyChallenge")
                 .addContext("reason", "ELIGIBLE 상태에서는 예외를 생성할 수 없습니다.");
+    }
+
+    private Long getFewestTeamId(Long challengeId) {
+        return challengeTeamRepository.findTeamWithFewestMembers(challengeId)
+                .map(ChallengeTeam::getId)
+                .orElse(null);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -762,6 +762,60 @@ class ChallengeServiceTest {
     }
 
     @Test
+    void 챌린지_시작_후_참여_시_멤버_수_가장_적은_팀에_배정된다() {
+        // given
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        Challenge challenge = TestFixture.createChallenge("챌린지", today.minusDays(1), today.plusDays(20), 20, group.getId());
+        challengeRepository.save(challenge);
+
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(challenge.getNewsletterGroupId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+        subscribeRepository.save(TestFixture.createSubscribe(newsletters.get(0), member));
+
+        ChallengeTeam team1 = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 0));
+        ChallengeTeam team2 = challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 0));
+
+        Member otherMember1 = memberRepository.save(TestFixture.createUniqueMember("other1", "other1@test.com"));
+        Member otherMember2 = memberRepository.save(TestFixture.createUniqueMember("other2", "other2@test.com"));
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipantWithTeam(challenge.getId(), otherMember1.getId(), team1.getId(), 0, 0));
+        challengeParticipantRepository.save(TestFixture.createChallengeParticipantWithTeam(challenge.getId(), otherMember2.getId(), team1.getId(), 0, 0));
+
+        // when
+        challengeService.applyChallenge(challenge.getId(), member);
+
+        // then
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                challenge.getId(),
+                member.getId()
+        ).orElseThrow();
+        assertThat(participant.getChallengeTeamId()).isEqualTo(team2.getId());
+    }
+
+    @Test
+    void 챌린지_시작_전_참여_시_팀이_배정되지_않는다() {
+        // given
+        NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");
+        newsletterGroupRepository.save(group);
+        Challenge challenge = TestFixture.createChallenge("챌린지", today.plusDays(5), today.plusDays(25), 20, group.getId());
+        challengeRepository.save(challenge);
+
+        NewsletterGroupItem item = TestFixture.createNewsletterGroupItem(challenge.getNewsletterGroupId(), newsletters.get(0).getId());
+        newsletterGroupItemRepository.save(item);
+        subscribeRepository.save(TestFixture.createSubscribe(newsletters.get(0), member));
+
+        challengeTeamRepository.save(TestFixture.createChallengeTeam(challenge.getId(), 0));
+
+        // when
+        challengeService.applyChallenge(challenge.getId(), member);
+
+        // then
+        ChallengeParticipant participant = challengeParticipantRepository
+                .findByChallengeIdAndMemberId(challenge.getId(), member.getId()).orElseThrow();
+        assertThat(participant.getChallengeTeamId()).isNull();
+    }
+
+    @Test
     void 구독하지_않은_뉴스레터를_가진_챌린지_신청_시_예외가_발생한다() {
         // given
         NewsletterGroup group = TestFixture.createNewsletterGroup("그룹");

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeServiceTest.java
@@ -810,8 +810,10 @@ class ChallengeServiceTest {
         challengeService.applyChallenge(challenge.getId(), member);
 
         // then
-        ChallengeParticipant participant = challengeParticipantRepository
-                .findByChallengeIdAndMemberId(challenge.getId(), member.getId()).orElseThrow();
+        ChallengeParticipant participant = challengeParticipantRepository.findByChallengeIdAndMemberId(
+                challenge.getId(),
+                member.getId()
+        ).orElseThrow();
         assertThat(participant.getChallengeTeamId()).isNull();
     }
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
챌린지 시작 이후 참여자는 팀이 자동 배정되도록 구현했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
챌린지 시작 전 참여자는 어드민 스케줄러가 팀을 배정하지만, 시작 이후 지각 참여자에 대한 팀 배정 로직이 없어 challengeTeamId가 null인 채로 저장되고 있었습니다.  

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
`applyChallenge` 시점에 `challenge.hasStarted()`를 확인해 시작 이후 참여자인 경우, 현재 인원이 가장 적은 팀을 조회해 즉시 배정합니다.                                                                                               
- `ChallengeTeamRepository`에 `findTeamWithFewestMembers` 쿼리 추가                                                                                                                                                                 
  - LEFT JOIN + GROUP BY + ORDER BY COUNT + LIMIT 1로 단일 쿼리 처리
  - 챌린지 팀에 챌린지 참여자가 없는 경우가 없지만 **방어적으로 LEFT JOIN**으로 했습니다.                                                                                                                                                                      

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
