### PR TITLE
[BOM-1033] feat: 블로그 글 목록 및 상세조회 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostController.java
@@ -1,6 +1,8 @@
 package me.bombom.api.v1.blog.controller;
 
+import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.blog.dto.response.BlogPostDetailResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
 import me.bombom.api.v1.blog.service.BlogService;
 import me.bombom.api.v1.common.resolver.LoginMember;
@@ -10,10 +12,13 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.data.web.SortDefault;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/blog/posts")
@@ -32,5 +37,14 @@ public class BlogPostController implements BlogPostControllerApi {
             }) Pageable pageable
     ) {
         return blogService.getPublishedPosts(member, pageable);
+    }
+
+    @Override
+    @GetMapping("/{postId}")
+    public BlogPostDetailResponse getPublishedPostDetail(
+            @LoginMember(anonymous = true, allowInvalidToken = true) Member member,
+            @PathVariable @Positive(message = "postId는 1 이상의 값이어야 합니다.") Long postId
+    ) {
+        return blogService.getPublishedPostDetail(postId, member);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostController.java
@@ -1,7 +1,9 @@
 package me.bombom.api.v1.blog.controller;
 
 import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.blog.dto.response.BlogCategoryResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostDetailResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
 import me.bombom.api.v1.blog.service.BlogService;
@@ -21,13 +23,13 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/blog/posts")
+@RequestMapping("/api/v1/blog")
 public class BlogPostController implements BlogPostControllerApi {
 
     private final BlogService blogService;
 
     @Override
-    @GetMapping
+    @GetMapping("/posts")
     public Page<BlogPostResponse> getPublishedPosts(
             @LoginMember(anonymous = true, allowInvalidToken = true) Member member,
             @PageableDefault(size = 20)
@@ -40,11 +42,17 @@ public class BlogPostController implements BlogPostControllerApi {
     }
 
     @Override
-    @GetMapping("/{postId}")
+    @GetMapping("/posts/{postId}")
     public BlogPostDetailResponse getPublishedPostDetail(
             @LoginMember(anonymous = true, allowInvalidToken = true) Member member,
             @PathVariable @Positive(message = "postId는 1 이상의 값이어야 합니다.") Long postId
     ) {
         return blogService.getPublishedPostDetail(postId, member);
+    }
+
+    @Override
+    @GetMapping("/categories")
+    public List<BlogCategoryResponse> getBlogCategories() {
+        return blogService.getBlogCategories();
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostController.java
@@ -1,0 +1,36 @@
+package me.bombom.api.v1.blog.controller;
+
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
+import me.bombom.api.v1.blog.service.BlogService;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/blog/posts")
+public class BlogPostController implements BlogPostControllerApi {
+
+    private final BlogService blogService;
+
+    @Override
+    @GetMapping
+    public Page<BlogPostResponse> getPublishedPosts(
+            @LoginMember(anonymous = true, allowInvalidToken = true) Member member,
+            @PageableDefault(size = 20)
+            @SortDefault.SortDefaults({
+                    @SortDefault(sort = "publishedAt", direction = Sort.Direction.DESC),
+                    @SortDefault(sort = "id", direction = Sort.Direction.DESC)
+            }) Pageable pageable
+    ) {
+        return blogService.getPublishedPosts(member, pageable);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostControllerApi.java
@@ -7,6 +7,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
+import java.util.List;
+import me.bombom.api.v1.blog.dto.response.BlogCategoryResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostDetailResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
@@ -44,4 +46,13 @@ public interface BlogPostControllerApi {
             @Parameter(description = "블로그 글 ID")
             @PathVariable @Positive(message = "postId는 1 이상의 값이어야 합니다.") Long postId
     );
+
+    @Operation(
+            summary = "블로그 카테고리 목록 조회",
+            description = "블로그 카테고리 목록을 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "블로그 카테고리 목록 조회 성공")
+    })
+    List<BlogCategoryResponse> getBlogCategories();
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostControllerApi.java
@@ -2,14 +2,18 @@ package me.bombom.api.v1.blog.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Positive;
+import me.bombom.api.v1.blog.dto.response.BlogPostDetailResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Tag(name = "Blog", description = "블로그 관련 API")
 public interface BlogPostControllerApi {
@@ -24,5 +28,20 @@ public interface BlogPostControllerApi {
     Page<BlogPostResponse> getPublishedPosts(
             @Parameter(hidden = true) @LoginMember(anonymous = true, allowInvalidToken = true) Member member,
             @Parameter(description = "페이징 관련 요청 (예: ?page=0&size=20&sort=publishedAt,desc)") Pageable pageable
+    );
+
+    @Operation(
+            summary = "블로그 글 상세 조회",
+            description = "특정 블로그 글의 상세 정보를 조회합니다. 비공개 글은 관리자만 조회할 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "블로그 글 상세 조회 성공"),
+            @ApiResponse(responseCode = "403", description = "블로그 글에 대한 접근 권한 없음", content = @Content),
+            @ApiResponse(responseCode = "404", description = "블로그 글을 찾을 수 없음", content = @Content)
+    })
+    BlogPostDetailResponse getPublishedPostDetail(
+            @Parameter(hidden = true) @LoginMember(anonymous = true, allowInvalidToken = true) Member member,
+            @Parameter(description = "블로그 글 ID")
+            @PathVariable @Positive(message = "postId는 1 이상의 값이어야 합니다.") Long postId
     );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/controller/BlogPostControllerApi.java
@@ -1,0 +1,28 @@
+package me.bombom.api.v1.blog.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
+import me.bombom.api.v1.common.resolver.LoginMember;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+@Tag(name = "Blog", description = "블로그 관련 API")
+public interface BlogPostControllerApi {
+
+    @Operation(
+            summary = "블로그 글 목록 조회",
+            description = "발행된 블로그 글 목록을 조회합니다. 공개 글은 누구나 볼 수 있고, 비공개 글은 관리자만 볼 수 있습니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "블로그 글 목록 조회 성공")
+    })
+    Page<BlogPostResponse> getPublishedPosts(
+            @Parameter(hidden = true) @LoginMember(anonymous = true, allowInvalidToken = true) Member member,
+            @Parameter(description = "페이징 관련 요청 (예: ?page=0&size=20&sort=publishedAt,desc)") Pageable pageable
+    );
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
@@ -33,6 +33,9 @@ public class BlogPost extends BaseEntity {
     @Column(columnDefinition = "mediumtext")
     private String content;
 
+    @Column(length = 500)
+    private String description;
+
     private Long thumbnailImageId;
 
     @Column(nullable = false)
@@ -53,6 +56,7 @@ public class BlogPost extends BaseEntity {
             @NonNull Long memberId,
             String title,
             String content,
+            String description,
             Long thumbnailImageId,
             @NonNull BlogPostStatus status,
             @NonNull BlogPostVisibility visibility,
@@ -63,6 +67,7 @@ public class BlogPost extends BaseEntity {
         this.memberId = memberId;
         this.title = title;
         this.content = content;
+        this.description = description;
         this.thumbnailImageId = thumbnailImageId;
         this.status = status;
         this.visibility = visibility;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPost.java
@@ -45,8 +45,6 @@ public class BlogPost extends BaseEntity {
 
     private Long categoryId;
 
-    private Integer expectedReadTime;
-
     private LocalDateTime publishedAt;
 
     @Builder
@@ -59,7 +57,6 @@ public class BlogPost extends BaseEntity {
             @NonNull BlogPostStatus status,
             @NonNull BlogPostVisibility visibility,
             Long categoryId,
-            Integer expectedReadTime,
             LocalDateTime publishedAt
     ) {
         this.id = id;
@@ -70,7 +67,6 @@ public class BlogPost extends BaseEntity {
         this.status = status;
         this.visibility = visibility;
         this.categoryId = categoryId;
-        this.expectedReadTime = expectedReadTime;
         this.publishedAt = publishedAt;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostTag.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/domain/BlogPostTag.java
@@ -21,7 +21,7 @@ import me.bombom.api.v1.common.BaseEntity;
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_blog_post_tag_post_tag",
-                        columnNames = {"blog_post_id", "blog_hash_tag_id"}
+                        columnNames = {"blog_post_id", "blog_hashtag_id"}
                 )
         }
 )
@@ -34,17 +34,17 @@ public class BlogPostTag extends BaseEntity {
     @Column(nullable = false)
     private Long blogPostId;
 
-    @Column(nullable = false)
-    private Long blogHashTagId;
+    @Column(name = "blog_hashtag_id", nullable = false)
+    private Long blogHashtagId;
 
     @Builder
     public BlogPostTag(
             Long id,
             @NonNull Long blogPostId,
-            @NonNull Long blogHashTagId
+            @NonNull Long blogHashtagId
     ) {
         this.id = id;
         this.blogPostId = blogPostId;
-        this.blogHashTagId = blogHashTagId;
+        this.blogHashtagId = blogHashtagId;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogCategoryResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogCategoryResponse.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.blog.dto.response;
 
 import jakarta.validation.constraints.NotNull;
+import java.util.List;
 import me.bombom.api.v1.blog.domain.BlogCategory;
 
 public record BlogCategoryResponse(
@@ -17,5 +18,11 @@ public record BlogCategoryResponse(
                 blogCategory.getId(),
                 blogCategory.getName()
         );
+    }
+
+    public static List<BlogCategoryResponse> from(List<BlogCategory> blogCategory) {
+        return blogCategory.stream()
+                .map(BlogCategoryResponse::from)
+                .toList();
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogCategoryResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogCategoryResponse.java
@@ -1,0 +1,21 @@
+package me.bombom.api.v1.blog.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+import me.bombom.api.v1.blog.domain.BlogCategory;
+
+public record BlogCategoryResponse(
+
+        @NotNull
+        Long id,
+
+        @NotNull
+        String categoryName
+) {
+
+    public static BlogCategoryResponse from(BlogCategory blogCategory) {
+        return new BlogCategoryResponse(
+                blogCategory.getId(),
+                blogCategory.getName()
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostDetailResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostDetailResponse.java
@@ -1,0 +1,47 @@
+package me.bombom.api.v1.blog.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import java.util.List;
+import me.bombom.api.v1.blog.domain.BlogCategory;
+import me.bombom.api.v1.blog.domain.BlogPost;
+
+public record BlogPostDetailResponse(
+
+        @NotNull
+        String title,
+
+        @NotNull
+        String content,
+
+        String thumbnailImageUrl,
+
+        @NotNull
+        String categoryName,
+
+        Integer expectedReadTime,
+
+        @NotNull
+        LocalDateTime publishedAt,
+
+        @NotNull
+        List<String> hashTags
+) {
+
+    public static BlogPostDetailResponse of(
+            BlogPost blogPost,
+            String thumbnailImageUrl,
+            BlogCategory category,
+            List<String> hashTags
+    ) {
+        return new BlogPostDetailResponse(
+                blogPost.getTitle(),
+                blogPost.getContent(),
+                thumbnailImageUrl,
+                category.getName(),
+                blogPost.getExpectedReadTime(),
+                blogPost.getPublishedAt(),
+                hashTags
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostDetailResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostDetailResponse.java
@@ -19,8 +19,6 @@ public record BlogPostDetailResponse(
         @NotNull
         String categoryName,
 
-        Integer expectedReadTime,
-
         @NotNull
         LocalDateTime publishedAt,
 
@@ -39,7 +37,6 @@ public record BlogPostDetailResponse(
                 blogPost.getContent(),
                 thumbnailImageUrl,
                 category.getName(),
-                blogPost.getExpectedReadTime(),
                 blogPost.getPublishedAt(),
                 hashTags
         );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
@@ -1,7 +1,5 @@
 package me.bombom.api.v1.blog.dto.response;
 
-import io.swagger.v3.oas.annotations.media.Schema;
-import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
@@ -17,9 +15,6 @@ public record BlogPostResponse(
 
         @NotNull
         String categoryName,
-
-        @Schema(requiredMode = RequiredMode.REQUIRED)
-        int expectedReadTime,
 
         @NotNull
         LocalDateTime publishedAt

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
@@ -1,0 +1,23 @@
+package me.bombom.api.v1.blog.dto.response;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record BlogPostResponse(
+
+        @NotNull
+        Long postId,
+
+        @NotNull
+        String title,
+
+        @NotNull
+        String thumbnailImageUrl,
+
+        @NotNull
+        String categoryName,
+
+        @NotNull
+        LocalDateTime publishedAt
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
@@ -11,6 +11,9 @@ public record BlogPostResponse(
         @NotNull
         String title,
 
+        @NotNull
+        String description,
+
         String thumbnailImageUrl,
 
         @NotNull

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
@@ -11,7 +11,6 @@ public record BlogPostResponse(
         @NotNull
         String title,
 
-        @NotNull
         String thumbnailImageUrl,
 
         @NotNull

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/dto/response/BlogPostResponse.java
@@ -1,5 +1,7 @@
 package me.bombom.api.v1.blog.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
@@ -15,6 +17,9 @@ public record BlogPostResponse(
 
         @NotNull
         String categoryName,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
+        int expectedReadTime,
 
         @NotNull
         LocalDateTime publishedAt

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogCategoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogCategoryRepository.java
@@ -1,7 +1,10 @@
 package me.bombom.api.v1.blog.repository;
 
+import java.util.List;
 import me.bombom.api.v1.blog.domain.BlogCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BlogCategoryRepository extends JpaRepository<BlogCategory, Long> {
+
+    List<BlogCategory> findAllByOrderByIdAsc();
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogCategoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogCategoryRepository.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.blog.repository;
+
+import me.bombom.api.v1.blog.domain.BlogCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogCategoryRepository extends JpaRepository<BlogCategory, Long> {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogHashtagRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogHashtagRepository.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.blog.repository;
+
+import me.bombom.api.v1.blog.domain.BlogHashtag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogHashtagRepository extends JpaRepository<BlogHashtag, Long> {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogImageAssetRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogImageAssetRepository.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.blog.repository;
+
+import me.bombom.api.v1.blog.domain.BlogImageAsset;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BlogImageAssetRepository extends JpaRepository<BlogImageAsset, Long> {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostRepository.java
@@ -1,0 +1,60 @@
+package me.bombom.api.v1.blog.repository;
+
+import me.bombom.api.v1.blog.domain.BlogPost;
+import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BlogPostRepository extends JpaRepository<BlogPost, Long> {
+
+    @Query(
+            value = """
+            SELECT new me.bombom.api.v1.blog.dto.response.BlogPostResponse(
+                bp.id,
+                bp.title,
+                bia.imageUrl,
+                bc.name,
+                bp.publishedAt
+            )
+            FROM BlogPost bp
+            LEFT JOIN BlogImageAsset bia ON bia.id = bp.thumbnailImageId
+            LEFT JOIN BlogCategory bc ON bc.id = bp.categoryId
+            WHERE bp.status = me.bombom.api.v1.blog.domain.BlogPostStatus.PUBLISHED
+                AND (
+                    bp.visibility = me.bombom.api.v1.blog.domain.BlogPostVisibility.PUBLIC
+                    OR (
+                        bp.visibility = me.bombom.api.v1.blog.domain.BlogPostVisibility.PRIVATE
+                        AND EXISTS (
+                            SELECT 1
+                            FROM Member m
+                            JOIN Role r ON r.id = m.roleId
+                            WHERE m.id = :memberId
+                              AND r.authority = 'ADMIN'
+                        )
+                    )
+                )
+            """,
+            countQuery = """
+            SELECT COUNT(bp)
+            FROM BlogPost bp
+            WHERE bp.status = me.bombom.api.v1.blog.domain.BlogPostStatus.PUBLISHED
+                AND (
+                    bp.visibility = me.bombom.api.v1.blog.domain.BlogPostVisibility.PUBLIC
+                    OR (
+                        bp.visibility = me.bombom.api.v1.blog.domain.BlogPostVisibility.PRIVATE
+                        AND EXISTS (
+                            SELECT 1
+                            FROM Member m
+                            JOIN Role r ON r.id = m.roleId
+                            WHERE m.id = :memberId
+                              AND r.authority = 'ADMIN'
+                        )
+                    )
+                )
+            """
+    )
+    Page<BlogPostResponse> findPublishedPosts(@Param("memberId") Long memberId, Pageable pageable);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostRepository.java
@@ -15,6 +15,7 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Long> {
             SELECT new me.bombom.api.v1.blog.dto.response.BlogPostResponse(
                 bp.id,
                 bp.title,
+                bp.description,
                 bia.imageUrl,
                 bc.name,
                 bp.publishedAt

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostRepository.java
@@ -17,6 +17,7 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Long> {
                 bp.title,
                 bia.imageUrl,
                 bc.name,
+                bp.expectedReadTime,
                 bp.publishedAt
             )
             FROM BlogPost bp

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostRepository.java
@@ -17,7 +17,6 @@ public interface BlogPostRepository extends JpaRepository<BlogPost, Long> {
                 bp.title,
                 bia.imageUrl,
                 bc.name,
-                bp.expectedReadTime,
                 bp.publishedAt
             )
             FROM BlogPost bp

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostTagRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/repository/BlogPostTagRepository.java
@@ -1,0 +1,18 @@
+package me.bombom.api.v1.blog.repository;
+
+import java.util.List;
+import me.bombom.api.v1.blog.domain.BlogPostTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface BlogPostTagRepository extends JpaRepository<BlogPostTag, Long> {
+
+    @Query("""
+        SELECT bh.name
+        FROM BlogPostTag bpt
+        JOIN BlogHashtag bh ON bh.id = bpt.blogHashtagId
+        WHERE bpt.blogPostId = :blogPostId
+    """)
+    List<String> findHashtagNamesByBlogPostId(@Param("blogPostId") Long blogPostId);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
@@ -1,9 +1,22 @@
 package me.bombom.api.v1.blog.service;
 
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.blog.domain.BlogCategory;
+import me.bombom.api.v1.blog.domain.BlogImageAsset;
+import me.bombom.api.v1.blog.domain.BlogPost;
+import me.bombom.api.v1.blog.domain.BlogPostStatus;
+import me.bombom.api.v1.blog.domain.BlogPostVisibility;
+import me.bombom.api.v1.blog.dto.response.BlogPostDetailResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
+import me.bombom.api.v1.blog.repository.BlogCategoryRepository;
+import me.bombom.api.v1.blog.repository.BlogImageAssetRepository;
 import me.bombom.api.v1.blog.repository.BlogPostRepository;
+import me.bombom.api.v1.blog.repository.BlogPostTagRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorContextKeys;
+import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -15,9 +28,67 @@ import org.springframework.transaction.annotation.Transactional;
 public class BlogService {
 
     private final BlogPostRepository blogPostRepository;
+    private final BlogCategoryRepository blogCategoryRepository;
+    private final BlogImageAssetRepository blogImageAssetRepository;
+    private final BlogPostTagRepository blogPostTagRepository;
+    private final MemberRepository memberRepository;
 
     public Page<BlogPostResponse> getPublishedPosts(Member member, Pageable pageable) {
         Long memberId = member == null ? null : member.getId();
         return blogPostRepository.findPublishedPosts(memberId, pageable);
+    }
+
+    public BlogPostDetailResponse getPublishedPostDetail(Long postId, Member member) {
+        Long memberId = member == null ? null : member.getId();
+        BlogPost blogPost = findPublishedPostById(postId, memberId);
+        validateAccessible(blogPost, memberId);
+
+        String blogImageUrl = blogPost.getThumbnailImageId() == null ? null
+                    : blogImageAssetRepository.findById(blogPost.getThumbnailImageId())
+                            .map(BlogImageAsset::getImageUrl)
+                            .orElse(null);
+
+        BlogCategory blogCategory = blogCategoryRepository.findById(blogPost.getCategoryId())
+                        .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                                .addContext(ErrorContextKeys.ENTITY_TYPE, "blogCategory")
+                                .addContext("postId", postId)
+                                .addContext("categoryId", blogPost.getCategoryId()));
+
+        return BlogPostDetailResponse.of(
+                blogPost,
+                blogImageUrl,
+                blogCategory,
+                blogPostTagRepository.findHashtagNamesByBlogPostId(postId)
+        );
+    }
+
+    private BlogPost findPublishedPostById(Long postId, Long memberId) {
+        BlogPost blogPost = blogPostRepository.findById(postId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "blogPost")
+                        .addContext("postId", postId)
+                        .addContext(ErrorContextKeys.MEMBER_ID, memberId));
+
+        if (blogPost.getStatus() != BlogPostStatus.PUBLISHED) {
+            throw new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                    .addContext(ErrorContextKeys.ENTITY_TYPE, "blogPost")
+                    .addContext("postId", postId)
+                    .addContext("status", blogPost.getStatus());
+        }
+        return blogPost;
+    }
+
+    private void validateAccessible(BlogPost blogPost, Long memberId) {
+        if (blogPost.getVisibility() == BlogPostVisibility.PUBLIC) {
+            return;
+        }
+
+        boolean isAdmin = memberId != null && memberRepository.existsByIdAndRoleAuthority(memberId, "ADMIN");
+        if (!isAdmin) {
+            throw new CIllegalArgumentException(ErrorDetail.FORBIDDEN_RESOURCE)
+                    .addContext("postId", blogPost.getId())
+                    .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                    .addContext(ErrorContextKeys.OPERATION, "getPublishedPostDetail");
+        }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
@@ -65,9 +65,7 @@ public class BlogService {
     }
 
     public List<BlogCategoryResponse> getBlogCategories() {
-        return blogCategoryRepository.findAllByOrderByIdAsc().stream()
-                .map(BlogCategoryResponse::from)
-                .toList();
+        return BlogCategoryResponse.from(blogCategoryRepository.findAllByOrderByIdAsc());
     }
 
     private BlogPost findPublishedPostById(Long postId, Long memberId) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
@@ -1,0 +1,23 @@
+package me.bombom.api.v1.blog.service;
+
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
+import me.bombom.api.v1.blog.repository.BlogPostRepository;
+import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BlogService {
+
+    private final BlogPostRepository blogPostRepository;
+
+    public Page<BlogPostResponse> getPublishedPosts(Member member, Pageable pageable) {
+        Long memberId = member == null ? null : member.getId();
+        return blogPostRepository.findPublishedPosts(memberId, pageable);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
@@ -1,11 +1,13 @@
 package me.bombom.api.v1.blog.service;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.blog.domain.BlogCategory;
 import me.bombom.api.v1.blog.domain.BlogImageAsset;
 import me.bombom.api.v1.blog.domain.BlogPost;
 import me.bombom.api.v1.blog.domain.BlogPostStatus;
 import me.bombom.api.v1.blog.domain.BlogPostVisibility;
+import me.bombom.api.v1.blog.dto.response.BlogCategoryResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostDetailResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
 import me.bombom.api.v1.blog.repository.BlogCategoryRepository;
@@ -60,6 +62,12 @@ public class BlogService {
                 blogCategory,
                 blogPostTagRepository.findHashtagNamesByBlogPostId(postId)
         );
+    }
+
+    public List<BlogCategoryResponse> getBlogCategories() {
+        return blogCategoryRepository.findAllByOrderByIdAsc().stream()
+                .map(BlogCategoryResponse::from)
+                .toList();
     }
 
     private BlogPost findPublishedPostById(Long postId, Long memberId) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/blog/service/BlogService.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.blog.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.blog.domain.BlogCategory;
 import me.bombom.api.v1.blog.domain.BlogImageAsset;
 import me.bombom.api.v1.blog.domain.BlogPost;
@@ -24,6 +25,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -48,7 +50,11 @@ public class BlogService {
         String blogImageUrl = blogPost.getThumbnailImageId() == null ? null
                     : blogImageAssetRepository.findById(blogPost.getThumbnailImageId())
                             .map(BlogImageAsset::getImageUrl)
-                            .orElse(null);
+                            .orElseGet(() -> {
+                                log.warn("블로그 게시글 썸네일 이미지 정합성 불일치 - postId: {}, thumbnailImageId: {}",
+                                        blogPost.getId(), blogPost.getThumbnailImageId());
+                                return null;
+                            });
 
         BlogCategory blogCategory = blogCategoryRepository.findById(blogPost.getCategoryId())
                         .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeStreakResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/ChallengeStreakResponse.java
@@ -3,6 +3,8 @@ package me.bombom.api.v1.challenge.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import me.bombom.api.v1.challenge.domain.ChallengeDailyResult;
 
@@ -21,6 +23,12 @@ public record ChallengeStreakResponse(
 
     public static ChallengeStreakResponse of(int streak, List<ChallengeDailyResult> results) {
         List<StreakDayResponse> days = StreakDayResponse.from(results.reversed());
+        return new ChallengeStreakResponse(streak, days);
+    }
+
+    public static ChallengeStreakResponse withTodayAbsent(int streak, List<ChallengeDailyResult> results, LocalDate today) {
+        List<StreakDayResponse> days = new ArrayList<>(StreakDayResponse.from(results.reversed()));
+        days.add(StreakDayResponse.notParticipated(today));
         return new ChallengeStreakResponse(streak, days);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/StreakDayResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/StreakDayResponse.java
@@ -17,6 +17,9 @@ public record StreakDayResponse(
         DayOfWeek dayOfWeek,
 
         @Schema(requiredMode = RequiredMode.REQUIRED)
+        boolean isCompleted,
+
+        @Schema(requiredMode = RequiredMode.REQUIRED)
         boolean isShieldApplied
 ) {
 
@@ -24,8 +27,13 @@ public record StreakDayResponse(
         return new StreakDayResponse(
                 result.getDate(),
                 result.getDate().getDayOfWeek(),
+                true,
                 result.getStatus() == ChallengeDailyStatus.SHIELD
         );
+    }
+
+    public static StreakDayResponse notParticipated(LocalDate date) {
+        return new StreakDayResponse(date, date.getDayOfWeek(), false, false);
     }
 
     public static List<StreakDayResponse> from(List<ChallengeDailyResult> results) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -77,16 +77,26 @@ public class ChallengeProgressService {
         ChallengeParticipant participant = getChallengeParticipant(challengeId, member.getId());
 
         int streak = participant.getStreak();
-        int fetchCount = Math.min(limit, streak);
-        if (fetchCount == 0) {
-            return ChallengeStreakResponse.empty();
+        LocalDate today = LocalDate.now(clock);
+        boolean completedToday = challengeDailyResultRepository.existsByParticipantIdAndDate(participant.getId(), today);
+
+        if (completedToday) {
+            int fetchCount = Math.min(limit, streak);
+            if (fetchCount == 0) {
+                return ChallengeStreakResponse.empty();
+            }
+            List<ChallengeDailyResult> recentDaysResult = challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(
+                    participant.getId(),
+                    PageRequest.of(0, fetchCount)
+            );
+            return ChallengeStreakResponse.of(streak, recentDaysResult);
         }
 
-        List<ChallengeDailyResult> recentDays = challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(
-                participant.getId(),
-                PageRequest.of(0, fetchCount)
-        );
-        return ChallengeStreakResponse.of(streak, recentDays);
+        int fetchCount = Math.min(limit - 1, streak);
+        List<ChallengeDailyResult> recentDays = fetchCount > 0
+                ? challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(participant.getId(), PageRequest.of(0, fetchCount))
+                : List.of();
+        return ChallengeStreakResponse.withTodayAbsent(streak, recentDays, today);
     }
 
     public TeamChallengeProgressResponse getTeamProgressByTeamId(Long challengeId, Long teamId, Member member) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/service/ChallengeProgressService.java
@@ -81,18 +81,17 @@ public class ChallengeProgressService {
         boolean completedToday = challengeDailyResultRepository.existsByParticipantIdAndDate(participant.getId(), today);
 
         if (completedToday) {
-            int fetchCount = Math.min(limit, streak);
-            if (fetchCount == 0) {
+            if (streak == 0) {
                 return ChallengeStreakResponse.empty();
             }
             List<ChallengeDailyResult> recentDaysResult = challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(
                     participant.getId(),
-                    PageRequest.of(0, fetchCount)
+                    PageRequest.of(0, limit)
             );
             return ChallengeStreakResponse.of(streak, recentDaysResult);
         }
 
-        int fetchCount = Math.min(limit - 1, streak);
+        int fetchCount = streak > 0 ? limit - 1 : 0;
         List<ChallengeDailyResult> recentDays = fetchCount > 0
                 ? challengeDailyResultRepository.findByParticipantIdOrderByDateDesc(participant.getId(), PageRequest.of(0, fetchCount))
                 : List.of();

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
@@ -29,4 +29,13 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     """)
     Optional<Long> findArchiveAdminId();
 
+    @Query("""
+        SELECT COUNT(m) > 0
+        FROM Member m
+        JOIN Role r ON m.roleId = r.id
+        WHERE m.id = :memberId
+          AND r.authority = :authority
+    """)
+    boolean existsByIdAndRoleAuthority(@Param("memberId") Long memberId, @Param("authority") String authority);
+
 }

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.1.0__remove_expected_read_time_from_blog_post.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.1.0__remove_expected_read_time_from_blog_post.sql
@@ -1,0 +1,2 @@
+ALTER TABLE blog_post
+    DROP COLUMN expected_read_time;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.2.0__add_description_to_blog_post.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.2.0__add_description_to_blog_post.sql
@@ -1,0 +1,2 @@
+ALTER TABLE blog_post
+    ADD COLUMN description VARCHAR(500) NULL;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -6,10 +6,12 @@ import java.util.List;
 import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.domain.RecentArticle;
 import me.bombom.api.v1.blog.domain.BlogCategory;
+import me.bombom.api.v1.blog.domain.BlogHashtag;
 import me.bombom.api.v1.blog.domain.BlogImageAsset;
 import me.bombom.api.v1.blog.domain.BlogImageAssetStatus;
 import me.bombom.api.v1.blog.domain.BlogPost;
 import me.bombom.api.v1.blog.domain.BlogPostStatus;
+import me.bombom.api.v1.blog.domain.BlogPostTag;
 import me.bombom.api.v1.blog.domain.BlogPostVisibility;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeComment;
@@ -836,6 +838,7 @@ public final class TestFixture {
     public static BlogPost createBlogPost(
             Long memberId,
             String title,
+            String content,
             Long thumbnailImageId,
             Long categoryId,
             BlogPostStatus status,
@@ -845,7 +848,7 @@ public final class TestFixture {
         return BlogPost.builder()
                 .memberId(memberId)
                 .title(title)
-                .content("본문")
+                .content(content)
                 .thumbnailImageId(thumbnailImageId)
                 .status(status)
                 .visibility(visibility)
@@ -864,6 +867,25 @@ public final class TestFixture {
                 .objectKey(objectKey)
                 .imageUrl(imageUrl)
                 .status(BlogImageAssetStatus.ATTACHED)
+                .build();
+    }
+
+    /**
+     * BlogHashtag
+     */
+    public static BlogHashtag createBlogHashtag(String name) {
+        return BlogHashtag.builder()
+                .name(name)
+                .build();
+    }
+
+    /**
+     * BlogPostTag
+     */
+    public static BlogPostTag createBlogPostTag(Long blogPostId, Long blogHashtagId) {
+        return BlogPostTag.builder()
+                .blogPostId(blogPostId)
+                .blogHashtagId(blogHashtagId)
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -849,6 +849,7 @@ public final class TestFixture {
                 .memberId(memberId)
                 .title(title)
                 .content(content)
+                .description(title + " 설명")
                 .thumbnailImageId(thumbnailImageId)
                 .status(status)
                 .visibility(visibility)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -5,6 +5,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import me.bombom.api.v1.article.domain.Article;
 import me.bombom.api.v1.article.domain.RecentArticle;
+import me.bombom.api.v1.blog.domain.BlogCategory;
+import me.bombom.api.v1.blog.domain.BlogImageAsset;
+import me.bombom.api.v1.blog.domain.BlogImageAssetStatus;
+import me.bombom.api.v1.blog.domain.BlogPost;
+import me.bombom.api.v1.blog.domain.BlogPostStatus;
+import me.bombom.api.v1.blog.domain.BlogPostVisibility;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeComment;
 import me.bombom.api.v1.challenge.domain.ChallengeCommentReply;
@@ -86,6 +92,17 @@ public final class TestFixture {
                 .nickname(nickname)
                 .gender(Gender.FEMALE)
                 .roleId(1L)
+                .build();
+    }
+
+    public static Member createMemberWithRole(String nickname, String providerId, Long roleId) {
+        return Member.builder()
+                .provider("provider")
+                .providerId(providerId)
+                .email(providerId + "@bombom.news")
+                .nickname(nickname)
+                .gender(Gender.FEMALE)
+                .roleId(roleId)
                 .build();
     }
 
@@ -801,6 +818,52 @@ public final class TestFixture {
                 .participantId(participantId)
                 .reply(reply)
                 .isPrivate(isPrivate)
+                .build();
+    }
+
+    /**
+     * BlogCategory
+     */
+    public static BlogCategory createBlogCategory(String name) {
+        return BlogCategory.builder()
+                .name(name)
+                .build();
+    }
+
+    /**
+     * BlogPost
+     */
+    public static BlogPost createBlogPost(
+            Long memberId,
+            String title,
+            Long thumbnailImageId,
+            Long categoryId,
+            BlogPostStatus status,
+            BlogPostVisibility visibility,
+            LocalDateTime publishedAt
+    ) {
+        return BlogPost.builder()
+                .memberId(memberId)
+                .title(title)
+                .content("본문")
+                .thumbnailImageId(thumbnailImageId)
+                .status(status)
+                .visibility(visibility)
+                .categoryId(categoryId)
+                .expectedReadTime(3)
+                .publishedAt(publishedAt)
+                .build();
+    }
+
+    /**
+     * BlogImageAsset
+     */
+    public static BlogImageAsset createBlogImageAsset(Long blogPostId, String objectKey, String imageUrl) {
+        return BlogImageAsset.builder()
+                .blogPostId(blogPostId)
+                .objectKey(objectKey)
+                .imageUrl(imageUrl)
+                .status(BlogImageAssetStatus.ATTACHED)
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/TestFixture.java
@@ -853,7 +853,6 @@ public final class TestFixture {
                 .status(status)
                 .visibility(visibility)
                 .categoryId(categoryId)
-                .expectedReadTime(3)
                 .publishedAt(publishedAt)
                 .build();
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
@@ -149,6 +149,7 @@ class BlogServiceTest {
             softly.assertThat(result.getTotalElements()).isEqualTo(1);
             softly.assertThat(result.getContent()).hasSize(1);
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
+            softly.assertThat(result.getContent().getFirst().description()).isEqualTo("공개 글 설명");
             softly.assertThat(result.getContent().getFirst().thumbnailImageUrl()).isEqualTo("https://cdn.bombom.me/public.png");
             softly.assertThat(result.getContent().getFirst().categoryName()).isEqualTo("테크");
         });
@@ -167,6 +168,7 @@ class BlogServiceTest {
             softly.assertThat(result.getTotalElements()).isEqualTo(1);
             softly.assertThat(result.getContent()).hasSize(1);
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
+            softly.assertThat(result.getContent().getFirst().description()).isEqualTo("공개 글 설명");
         });
     }
 
@@ -183,7 +185,9 @@ class BlogServiceTest {
             softly.assertThat(result.getTotalElements()).isEqualTo(2);
             softly.assertThat(result.getContent()).hasSize(2);
             softly.assertThat(result.getContent().get(0).title()).isEqualTo("공개 글");
+            softly.assertThat(result.getContent().get(0).description()).isEqualTo("공개 글 설명");
             softly.assertThat(result.getContent().get(1).title()).isEqualTo("비공개 글");
+            softly.assertThat(result.getContent().get(1).description()).isEqualTo("비공개 글 설명");
         });
     }
 
@@ -213,6 +217,7 @@ class BlogServiceTest {
             softly.assertThat(result.getTotalPages()).isEqualTo(2);
             softly.assertThat(result.getContent()).hasSize(1);
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
+            softly.assertThat(result.getContent().getFirst().description()).isEqualTo("공개 글 설명");
             softly.assertThat(result.hasNext()).isTrue();
         });
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
@@ -151,6 +151,7 @@ class BlogServiceTest {
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
             softly.assertThat(result.getContent().getFirst().thumbnailImageUrl()).isEqualTo("https://cdn.bombom.me/public.png");
             softly.assertThat(result.getContent().getFirst().categoryName()).isEqualTo("테크");
+            softly.assertThat(result.getContent().getFirst().expectedReadTime()).isEqualTo(3);
         });
     }
 
@@ -167,6 +168,7 @@ class BlogServiceTest {
             softly.assertThat(result.getTotalElements()).isEqualTo(1);
             softly.assertThat(result.getContent()).hasSize(1);
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
+            softly.assertThat(result.getContent().getFirst().expectedReadTime()).isEqualTo(3);
         });
     }
 
@@ -184,6 +186,8 @@ class BlogServiceTest {
             softly.assertThat(result.getContent()).hasSize(2);
             softly.assertThat(result.getContent().get(0).title()).isEqualTo("공개 글");
             softly.assertThat(result.getContent().get(1).title()).isEqualTo("비공개 글");
+            softly.assertThat(result.getContent().get(0).expectedReadTime()).isEqualTo(3);
+            softly.assertThat(result.getContent().get(1).expectedReadTime()).isEqualTo(3);
         });
     }
 
@@ -213,6 +217,7 @@ class BlogServiceTest {
             softly.assertThat(result.getTotalPages()).isEqualTo(2);
             softly.assertThat(result.getContent()).hasSize(1);
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
+            softly.assertThat(result.getContent().getFirst().expectedReadTime()).isEqualTo(3);
             softly.assertThat(result.hasNext()).isTrue();
         });
     }
@@ -228,6 +233,7 @@ class BlogServiceTest {
             softly.assertThat(result.content()).isEqualTo("공개 글 본문");
             softly.assertThat(result.thumbnailImageUrl()).isEqualTo("https://cdn.bombom.me/public.png");
             softly.assertThat(result.categoryName()).isEqualTo("테크");
+            softly.assertThat(result.expectedReadTime()).isEqualTo(3);
             softly.assertThat(result.publishedAt()).isEqualTo(LocalDateTime.of(2026, 3, 25, 9, 0));
             softly.assertThat(result.hashTags()).containsExactlyInAnyOrder("스프링", "백엔드");
         });
@@ -252,6 +258,7 @@ class BlogServiceTest {
             softly.assertThat(result.content()).isEqualTo("비공개 글 본문");
             softly.assertThat(result.thumbnailImageUrl()).isNull();
             softly.assertThat(result.categoryName()).isEqualTo("테크");
+            softly.assertThat(result.expectedReadTime()).isEqualTo(3);
             softly.assertThat(result.hashTags()).isEmpty();
         });
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
@@ -151,7 +151,6 @@ class BlogServiceTest {
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
             softly.assertThat(result.getContent().getFirst().thumbnailImageUrl()).isEqualTo("https://cdn.bombom.me/public.png");
             softly.assertThat(result.getContent().getFirst().categoryName()).isEqualTo("테크");
-            softly.assertThat(result.getContent().getFirst().expectedReadTime()).isEqualTo(3);
         });
     }
 
@@ -168,7 +167,6 @@ class BlogServiceTest {
             softly.assertThat(result.getTotalElements()).isEqualTo(1);
             softly.assertThat(result.getContent()).hasSize(1);
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
-            softly.assertThat(result.getContent().getFirst().expectedReadTime()).isEqualTo(3);
         });
     }
 
@@ -186,8 +184,6 @@ class BlogServiceTest {
             softly.assertThat(result.getContent()).hasSize(2);
             softly.assertThat(result.getContent().get(0).title()).isEqualTo("공개 글");
             softly.assertThat(result.getContent().get(1).title()).isEqualTo("비공개 글");
-            softly.assertThat(result.getContent().get(0).expectedReadTime()).isEqualTo(3);
-            softly.assertThat(result.getContent().get(1).expectedReadTime()).isEqualTo(3);
         });
     }
 
@@ -217,7 +213,6 @@ class BlogServiceTest {
             softly.assertThat(result.getTotalPages()).isEqualTo(2);
             softly.assertThat(result.getContent()).hasSize(1);
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
-            softly.assertThat(result.getContent().getFirst().expectedReadTime()).isEqualTo(3);
             softly.assertThat(result.hasNext()).isTrue();
         });
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
@@ -1,0 +1,209 @@
+package me.bombom.api.v1.blog.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.blog.domain.BlogCategory;
+import me.bombom.api.v1.blog.domain.BlogImageAsset;
+import me.bombom.api.v1.blog.domain.BlogPost;
+import me.bombom.api.v1.blog.domain.BlogPostStatus;
+import me.bombom.api.v1.blog.domain.BlogPostVisibility;
+import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
+import me.bombom.api.v1.blog.repository.BlogCategoryRepository;
+import me.bombom.api.v1.blog.repository.BlogImageAssetRepository;
+import me.bombom.api.v1.blog.repository.BlogPostRepository;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.domain.Role;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@IntegrationTest
+class BlogServiceTest {
+
+    @Autowired
+    private BlogService blogService;
+
+    @Autowired
+    private BlogPostRepository blogPostRepository;
+
+    @Autowired
+    private BlogCategoryRepository blogCategoryRepository;
+
+    @Autowired
+    private BlogImageAssetRepository blogImageAssetRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Autowired
+    private PlatformTransactionManager transactionManager;
+
+    private Member userMember;
+    private Member adminMember;
+
+    @BeforeEach
+    void setUp() {
+        initializeRoles();
+        blogImageAssetRepository.deleteAllInBatch();
+        blogPostRepository.deleteAllInBatch();
+        blogCategoryRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+
+        Role userRole = findRoleByAuthority("USER");
+        Role adminRole = findRoleByAuthority("ADMIN");
+
+        userMember = memberRepository.save(TestFixture.createMemberWithRole("blog-user", "blog-user", userRole.getId()));
+        adminMember = memberRepository.save(TestFixture.createMemberWithRole("blog-admin", "blog-admin", adminRole.getId()));
+
+        BlogCategory category = blogCategoryRepository.save(TestFixture.createBlogCategory("테크"));
+
+        BlogPost publicPost = blogPostRepository.save(TestFixture.createBlogPost(
+                userMember.getId(),
+                "공개 글",
+                null,
+                category.getId(),
+                BlogPostStatus.PUBLISHED,
+                BlogPostVisibility.PUBLIC,
+                LocalDateTime.of(2026, 3, 25, 9, 0)
+        ));
+
+        BlogImageAsset thumbnail = blogImageAssetRepository.save(
+                TestFixture.createBlogImageAsset(publicPost.getId(), "blog/public-thumb", "https://cdn.bombom.me/public.png")
+        );
+        ReflectionTestUtils.setField(publicPost, "thumbnailImageId", thumbnail.getId());
+        blogPostRepository.save(publicPost);
+
+        blogPostRepository.save(TestFixture.createBlogPost(
+                adminMember.getId(),
+                "비공개 글",
+                null,
+                category.getId(),
+                BlogPostStatus.PUBLISHED,
+                BlogPostVisibility.PRIVATE,
+                LocalDateTime.of(2026, 3, 24, 9, 0)
+        ));
+
+        blogPostRepository.save(TestFixture.createBlogPost(
+                userMember.getId(),
+                "임시 글",
+                null,
+                category.getId(),
+                BlogPostStatus.DRAFT,
+                BlogPostVisibility.PUBLIC,
+                LocalDateTime.of(2026, 3, 23, 9, 0)
+        ));
+    }
+
+    @Test
+    void 익명_사용자가_블로그_목록을_조회한다() {
+        // when
+        Page<BlogPostResponse> result = blogService.getPublishedPosts(
+                null,
+                PageRequest.of(0, 20, Sort.by(Sort.Order.desc("publishedAt"), Sort.Order.desc("id")))
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotalElements()).isEqualTo(1);
+            softly.assertThat(result.getContent()).hasSize(1);
+            softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
+            softly.assertThat(result.getContent().getFirst().thumbnailImageUrl()).isEqualTo("https://cdn.bombom.me/public.png");
+            softly.assertThat(result.getContent().getFirst().categoryName()).isEqualTo("테크");
+        });
+    }
+
+    @Test
+    void 일반_사용자가_블로그_목록을_조회한다() {
+        // when
+        Page<BlogPostResponse> result = blogService.getPublishedPosts(
+                userMember,
+                PageRequest.of(0, 20, Sort.by(Sort.Order.desc("publishedAt"), Sort.Order.desc("id")))
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotalElements()).isEqualTo(1);
+            softly.assertThat(result.getContent()).hasSize(1);
+            softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
+        });
+    }
+
+    @Test
+    void 관리자가_블로그_목록을_조회한다() {
+        // when
+        Page<BlogPostResponse> result = blogService.getPublishedPosts(
+                adminMember,
+                PageRequest.of(0, 20, Sort.by(Sort.Order.desc("publishedAt"), Sort.Order.desc("id")))
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotalElements()).isEqualTo(2);
+            softly.assertThat(result.getContent()).hasSize(2);
+            softly.assertThat(result.getContent().get(0).title()).isEqualTo("공개 글");
+            softly.assertThat(result.getContent().get(1).title()).isEqualTo("비공개 글");
+        });
+    }
+
+    @Test
+    void 블로그_글_목록을_페이지네이션한다() {
+        // given
+        blogPostRepository.save(TestFixture.createBlogPost(
+                userMember.getId(),
+                "두번째 공개 글",
+                null,
+                null,
+                BlogPostStatus.PUBLISHED,
+                BlogPostVisibility.PUBLIC,
+                LocalDateTime.of(2026, 3, 22, 9, 0)
+        ));
+
+        // when
+        Page<BlogPostResponse> result = blogService.getPublishedPosts(
+                null,
+                PageRequest.of(0, 1, Sort.by(Sort.Order.desc("publishedAt"), Sort.Order.desc("id")))
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotalElements()).isEqualTo(2);
+            softly.assertThat(result.getTotalPages()).isEqualTo(2);
+            softly.assertThat(result.getContent()).hasSize(1);
+            softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
+            softly.assertThat(result.hasNext()).isTrue();
+        });
+    }
+
+    private void initializeRoles() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        tx.executeWithoutResult(status -> {
+            entityManager.createNativeQuery("TRUNCATE TABLE role").executeUpdate();
+            entityManager.persist(Role.builder().authority("USER").build());
+            entityManager.persist(Role.builder().authority("ADMIN").build());
+            entityManager.flush();
+        });
+    }
+
+    private Role findRoleByAuthority(String authority) {
+        return entityManager.createQuery(
+                        "SELECT r FROM Role r WHERE r.authority = :authority",
+                        Role.class
+                )
+                .setParameter("authority", authority)
+                .getSingleResult();
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
@@ -228,7 +228,6 @@ class BlogServiceTest {
             softly.assertThat(result.content()).isEqualTo("공개 글 본문");
             softly.assertThat(result.thumbnailImageUrl()).isEqualTo("https://cdn.bombom.me/public.png");
             softly.assertThat(result.categoryName()).isEqualTo("테크");
-            softly.assertThat(result.expectedReadTime()).isEqualTo(3);
             softly.assertThat(result.publishedAt()).isEqualTo(LocalDateTime.of(2026, 3, 25, 9, 0));
             softly.assertThat(result.hashTags()).containsExactlyInAnyOrder("스프링", "백엔드");
         });
@@ -253,7 +252,6 @@ class BlogServiceTest {
             softly.assertThat(result.content()).isEqualTo("비공개 글 본문");
             softly.assertThat(result.thumbnailImageUrl()).isNull();
             softly.assertThat(result.categoryName()).isEqualTo("테크");
-            softly.assertThat(result.expectedReadTime()).isEqualTo(3);
             softly.assertThat(result.hashTags()).isEmpty();
         });
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
+import java.util.List;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.blog.domain.BlogCategory;
 import me.bombom.api.v1.blog.domain.BlogHashtag;
@@ -12,6 +13,7 @@ import me.bombom.api.v1.blog.domain.BlogImageAsset;
 import me.bombom.api.v1.blog.domain.BlogPost;
 import me.bombom.api.v1.blog.domain.BlogPostStatus;
 import me.bombom.api.v1.blog.domain.BlogPostVisibility;
+import me.bombom.api.v1.blog.dto.response.BlogCategoryResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostDetailResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
 import me.bombom.api.v1.blog.repository.BlogCategoryRepository;
@@ -260,6 +262,24 @@ class BlogServiceTest {
                 .isInstanceOf(CIllegalArgumentException.class)
                 .extracting("errorDetail")
                 .isEqualTo(ErrorDetail.ENTITY_NOT_FOUND);
+    }
+
+    @Test
+    void 블로그_카테고리_목록을_조회한다() {
+        // given
+        BlogCategory secondCategory = blogCategoryRepository.save(TestFixture.createBlogCategory("라이프"));
+
+        // when
+        List<BlogCategoryResponse> result = blogService.getBlogCategories();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(2);
+            softly.assertThat(result.get(0).id()).isNotNull();
+            softly.assertThat(result.get(0).categoryName()).isEqualTo("테크");
+            softly.assertThat(result.get(1).id()).isEqualTo(secondCategory.getId());
+            softly.assertThat(result.get(1).categoryName()).isEqualTo("라이프");
+        });
     }
 
     private void initializeRoles() {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/blog/service/BlogServiceTest.java
@@ -1,19 +1,26 @@
 package me.bombom.api.v1.blog.service;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import jakarta.persistence.EntityManager;
 import java.time.LocalDateTime;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.blog.domain.BlogCategory;
+import me.bombom.api.v1.blog.domain.BlogHashtag;
 import me.bombom.api.v1.blog.domain.BlogImageAsset;
 import me.bombom.api.v1.blog.domain.BlogPost;
 import me.bombom.api.v1.blog.domain.BlogPostStatus;
 import me.bombom.api.v1.blog.domain.BlogPostVisibility;
+import me.bombom.api.v1.blog.dto.response.BlogPostDetailResponse;
 import me.bombom.api.v1.blog.dto.response.BlogPostResponse;
 import me.bombom.api.v1.blog.repository.BlogCategoryRepository;
+import me.bombom.api.v1.blog.repository.BlogHashtagRepository;
 import me.bombom.api.v1.blog.repository.BlogImageAssetRepository;
 import me.bombom.api.v1.blog.repository.BlogPostRepository;
+import me.bombom.api.v1.blog.repository.BlogPostTagRepository;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.domain.Role;
 import me.bombom.api.v1.member.repository.MemberRepository;
@@ -44,6 +51,12 @@ class BlogServiceTest {
     private BlogImageAssetRepository blogImageAssetRepository;
 
     @Autowired
+    private BlogHashtagRepository blogHashtagRepository;
+
+    @Autowired
+    private BlogPostTagRepository blogPostTagRepository;
+
+    @Autowired
     private MemberRepository memberRepository;
 
     @Autowired
@@ -54,10 +67,15 @@ class BlogServiceTest {
 
     private Member userMember;
     private Member adminMember;
+    private BlogPost publicPost;
+    private BlogPost privatePost;
+    private BlogPost draftPost;
 
     @BeforeEach
     void setUp() {
         initializeRoles();
+        blogPostTagRepository.deleteAllInBatch();
+        blogHashtagRepository.deleteAllInBatch();
         blogImageAssetRepository.deleteAllInBatch();
         blogPostRepository.deleteAllInBatch();
         blogCategoryRepository.deleteAllInBatch();
@@ -71,9 +89,10 @@ class BlogServiceTest {
 
         BlogCategory category = blogCategoryRepository.save(TestFixture.createBlogCategory("테크"));
 
-        BlogPost publicPost = blogPostRepository.save(TestFixture.createBlogPost(
+        publicPost = blogPostRepository.save(TestFixture.createBlogPost(
                 userMember.getId(),
                 "공개 글",
+                "공개 글 본문",
                 null,
                 category.getId(),
                 BlogPostStatus.PUBLISHED,
@@ -87,9 +106,15 @@ class BlogServiceTest {
         ReflectionTestUtils.setField(publicPost, "thumbnailImageId", thumbnail.getId());
         blogPostRepository.save(publicPost);
 
-        blogPostRepository.save(TestFixture.createBlogPost(
+        BlogHashtag firstHashtag = blogHashtagRepository.save(TestFixture.createBlogHashtag("스프링"));
+        BlogHashtag secondHashtag = blogHashtagRepository.save(TestFixture.createBlogHashtag("백엔드"));
+        blogPostTagRepository.save(TestFixture.createBlogPostTag(publicPost.getId(), firstHashtag.getId()));
+        blogPostTagRepository.save(TestFixture.createBlogPostTag(publicPost.getId(), secondHashtag.getId()));
+
+        privatePost = blogPostRepository.save(TestFixture.createBlogPost(
                 adminMember.getId(),
                 "비공개 글",
+                "비공개 글 본문",
                 null,
                 category.getId(),
                 BlogPostStatus.PUBLISHED,
@@ -97,9 +122,10 @@ class BlogServiceTest {
                 LocalDateTime.of(2026, 3, 24, 9, 0)
         ));
 
-        blogPostRepository.save(TestFixture.createBlogPost(
+        draftPost = blogPostRepository.save(TestFixture.createBlogPost(
                 userMember.getId(),
                 "임시 글",
+                "임시 글 본문",
                 null,
                 category.getId(),
                 BlogPostStatus.DRAFT,
@@ -165,6 +191,7 @@ class BlogServiceTest {
         blogPostRepository.save(TestFixture.createBlogPost(
                 userMember.getId(),
                 "두번째 공개 글",
+                "두번째 공개 글 본문",
                 null,
                 null,
                 BlogPostStatus.PUBLISHED,
@@ -186,6 +213,53 @@ class BlogServiceTest {
             softly.assertThat(result.getContent().getFirst().title()).isEqualTo("공개 글");
             softly.assertThat(result.hasNext()).isTrue();
         });
+    }
+
+    @Test
+    void 익명_사용자가_공개_블로그_상세를_조회한다() {
+        // when
+        BlogPostDetailResponse result = blogService.getPublishedPostDetail(publicPost.getId(), null);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.title()).isEqualTo("공개 글");
+            softly.assertThat(result.content()).isEqualTo("공개 글 본문");
+            softly.assertThat(result.thumbnailImageUrl()).isEqualTo("https://cdn.bombom.me/public.png");
+            softly.assertThat(result.categoryName()).isEqualTo("테크");
+            softly.assertThat(result.publishedAt()).isEqualTo(LocalDateTime.of(2026, 3, 25, 9, 0));
+            softly.assertThat(result.hashTags()).containsExactlyInAnyOrder("스프링", "백엔드");
+        });
+    }
+
+    @Test
+    void 일반_사용자가_비공개_블로그_상세를_조회하면_예외가_발생한다() {
+        assertThatThrownBy(() -> blogService.getPublishedPostDetail(privatePost.getId(), userMember))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .extracting("errorDetail")
+                .isEqualTo(ErrorDetail.FORBIDDEN_RESOURCE);
+    }
+
+    @Test
+    void 관리자가_비공개_블로그_상세를_조회한다() {
+        // when
+        BlogPostDetailResponse result = blogService.getPublishedPostDetail(privatePost.getId(), adminMember);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.title()).isEqualTo("비공개 글");
+            softly.assertThat(result.content()).isEqualTo("비공개 글 본문");
+            softly.assertThat(result.thumbnailImageUrl()).isNull();
+            softly.assertThat(result.categoryName()).isEqualTo("테크");
+            softly.assertThat(result.hashTags()).isEmpty();
+        });
+    }
+
+    @Test
+    void 발행되지_않은_블로그_글은_상세_조회할_수_없다() {
+        assertThatThrownBy(() -> blogService.getPublishedPostDetail(draftPost.getId(), adminMember))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .extracting("errorDetail")
+                .isEqualTo(ErrorDetail.ENTITY_NOT_FOUND);
     }
 
     private void initializeRoles() {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/controller/ChallengeProgressControllerUnitTest.java
@@ -46,10 +46,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @AutoConfigureMockMvc
 @Import({
@@ -234,9 +234,9 @@ class ChallengeProgressControllerUnitTest {
         ChallengeStreakResponse response = new ChallengeStreakResponse(
                 3,
                 List.of(
-                        new StreakDayResponse(today.minusDays(2), today.minusDays(2).getDayOfWeek(), false),
-                        new StreakDayResponse(today.minusDays(1), today.minusDays(1).getDayOfWeek(), true),
-                        new StreakDayResponse(today, today.getDayOfWeek(), false)
+                        new StreakDayResponse(today.minusDays(2), today.minusDays(2).getDayOfWeek(), true, false),
+                        new StreakDayResponse(today.minusDays(1), today.minusDays(1).getDayOfWeek(), true, true),
+                        new StreakDayResponse(today, today.getDayOfWeek(), true, false)
                 )
         );
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -578,6 +578,9 @@ class ChallengeProgressServiceTest {
         // 금→(토일)→월 구간이 포함된 스트릭 (gap 3일 이하 = 연속)
         LocalDate monday = LocalDate.now().with(java.time.DayOfWeek.MONDAY);
         LocalDate friday = monday.minusDays(3); // 직전 금요일
+        // 오늘을 월요일로 고정: monday에 완료 기록이 있으므로 completedToday=true → 오늘 미완료 데이터 미추가
+        given(clock.instant()).willReturn(monday.atStartOfDay(ZoneId.systemDefault()).toInstant());
+        given(clock.getZone()).willReturn(java.time.ZoneId.systemDefault());
 
         Challenge streakChallenge = createStreakChallenge("주말 낀 스트릭 챌린지");
         ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/service/ChallengeProgressServiceTest.java
@@ -451,7 +451,9 @@ class ChallengeProgressServiceTest {
         // then
         assertSoftly(softly -> {
             softly.assertThat(response.streak()).isEqualTo(0);
-            softly.assertThat(response.streakDays()).isEmpty();
+            softly.assertThat(response.streakDays()).hasSize(1);
+            softly.assertThat(response.streakDays().getFirst().date()).isEqualTo(LocalDate.now());
+            softly.assertThat(response.streakDays().getFirst().isCompleted()).isFalse();
         });
     }
 
@@ -618,6 +620,98 @@ class ChallengeProgressServiceTest {
                     UnauthorizedException exception = (UnauthorizedException) e;
                     assertThat(exception.getErrorDetail()).isEqualTo(ErrorDetail.FORBIDDEN_RESOURCE);
                 });
+    }
+
+    @Test
+    void 오늘_미완료시_이전_기록과_오늘_미완료_항목이_함께_반환된다() {
+        // given - streak=3, 오늘 미완료
+        Challenge streakChallenge = createStreakChallenge("오늘 미완료 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(3)
+                .streak(3)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        LocalDate today = LocalDate.now();
+        challengeDailyResultRepository.saveAll(List.of(
+                createChallengeDailyResult(participant.getId(), today.minusDays(3), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), today.minusDays(2), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), today.minusDays(1), ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when - limit=5, 오늘 미완료이므로 최근 4개 + 오늘 미완료 = 4개(streak=3이라 3개) + 오늘
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streak()).isEqualTo(3);
+            softly.assertThat(response.streakDays()).hasSize(4);
+            softly.assertThat(response.streakDays().getLast().date()).isEqualTo(today);
+            softly.assertThat(response.streakDays().getLast().isCompleted()).isFalse();
+        });
+    }
+
+    @Test
+    void 오늘_미완료시_limit_적용은_오늘_포함_기준이다() {
+        // given - streak=5, limit=3, 오늘 미완료 → limit-1=2개 + 오늘 = 3개
+        Challenge streakChallenge = createStreakChallenge("limit 확인 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(5)
+                .streak(5)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        LocalDate today = LocalDate.now();
+        for (int i = 5; i >= 1; i--) {
+            challengeDailyResultRepository.save(
+                    createChallengeDailyResult(participant.getId(), today.minusDays(i), ChallengeDailyStatus.COMPLETE));
+        }
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 3);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streakDays()).hasSize(3);
+            softly.assertThat(response.streakDays().getLast().date()).isEqualTo(today);
+            softly.assertThat(response.streakDays().getLast().isCompleted()).isFalse();
+        });
+    }
+
+    @Test
+    void 오늘_완료시_isCompleted가_true다() {
+        // given
+        Challenge streakChallenge = createStreakChallenge("오늘 완료 챌린지");
+        ChallengeParticipant participant = challengeParticipantRepository.save(ChallengeParticipant.builder()
+                .challengeId(streakChallenge.getId())
+                .memberId(member.getId())
+                .completedDays(2)
+                .streak(2)
+                .shield(0)
+                .isSurvived(true)
+                .build());
+
+        LocalDate today = LocalDate.now();
+        challengeDailyResultRepository.saveAll(List.of(
+                createChallengeDailyResult(participant.getId(), today.minusDays(1), ChallengeDailyStatus.COMPLETE),
+                createChallengeDailyResult(participant.getId(), today, ChallengeDailyStatus.COMPLETE)
+        ));
+
+        // when
+        ChallengeStreakResponse response = challengeProgressService.getMemberStreak(streakChallenge.getId(), member, 5);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.streakDays()).hasSize(2);
+            softly.assertThat(response.streakDays().getLast().date()).isEqualTo(today);
+            softly.assertThat(response.streakDays().getLast().isCompleted()).isTrue();
+        });
     }
 
     @Test


### PR DESCRIPTION
### 📍블로그 글의 컬럼 변경에 대해 PR 분리가 애매해서 이번 PR에 모두 진행하게 되었습니다. 
양해 부탁드립니다..!

## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
사용자에게 블로그가 보여질 때 UI에 필요한 API들을 구현했습니다.
- 블로그 글 목록 조회
- 블로그 글 상세 조회
- 블로그 카테고리 목록 조회

블로그 글 테이블의 컬럼들을 변경했습니다.
- expectedReadTime (읽기 예상 시간) 제거
- description (부제) 추가

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
사용자들에게 먼저 보여지기 위한 UI를 구현하기 위함입니다.
dev에서는 더미 데이터를 넣어둘 예정입니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
블로그 UI는 다음과 같습니다.

<img width="683" height="806" alt="image" src="https://github.com/user-attachments/assets/016ef55e-00cd-48f7-962e-c95dfa89c147" />
<img width="458" height="685" alt="image" src="https://github.com/user-attachments/assets/3339c8b1-a1fa-455e-bb37-c9b62a76a80f" />

### 블로그 글 관련 API

#### 1. 블로그 글 목록 조회 (`/api/v1/blog/posts`)
- 블로그 글 목록을 조회해오는 기준은 다음과 같습니다.
  - `status = PUBLISHED`로 발행한 글들만 조회합니다.
  - `visibility=PUBLIC`인 글은 `@LoginMember(anonymous=true)`로, 비회원이거나 일반 회원(admin 포함) 모두가 조회할 수 있습니다.
  - `visibility=PRIVATE`인 글은 admin에게만 조회 목록에 포함됩니다.

#### 2. 블로그 글 상세 조회 (`/api/v1/blog/posts/{postId}`)
- postId로 블로그 글을 상세조회합니다.
- 글 상세조회 시 글의 visibility에 따라 해당 사용자에 대한 권한을 검증합니다.
  - `visibility=PRIVATE`일 경우엔 현재 회원이 admin인지 검증합니다.

#### 3. 블로그 카테고리 목록 조회 (`/api/v1/blog/categories`)
- 블로그 글들에 대해 등록된 카테고리 목록들을 조회합니다.

### 블로그 글 컬럼 변경
#### 1. expectedReadTime (읽기 예상 시간) 컬럼 제거
- content에 저장되는 글의 형태가 text -> json으로 변경됨에 따라 읽기 예상시간 계산을 프론트에서 하는 것이 더 적절하다고 판단하게 되었습니다.
- 따라서 `BlogPost`에 있던 `expectedReadTime` 컬럼을 제거했습니다.

#### 2. description (부제) 컬럼 추가
- 글을 작성할 때 부제를 직접 추가하는 것이 사용자에게 더 유효한 정보를 제공할 수 있을 것이라고 생각해서 부제를 추가하게 되었습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
### 1. 블로그 글 목록 조회 (`/api/v1/blog/posts`)
- 지금 `Repository`의 메서드를 보면 publish 조건, 사용자에 따른 visibility 조건에 따라 쿼리가 조금 복잡합니다. 
- 그럼에도 Query Dsl을 사용하지 않은 이유는 조건이 동적으로 많이 늘어나지 않을 것이라고 예상했기 때문인데, 이 판단이 적절할지 리뷰 부탁드립니다.

### 2. 블로그 글 상세 조회 (`/api/v1/blog/posts/{postId}`)
- 블로그 글을 조회할 때 `BlogPost`에서 갖고있는 `thumbnailImageId`가 null이 아님에도 `BlogImageAssets`에서 조회가 불가능하면, 예외를 발생시키지 않고 일단 null을 반환하도록 만들었습니다.
```java
String blogImageUrl = blogPost.getThumbnailImageId() == null ? null
                    : blogImageAssetRepository.findById(blogPost.getThumbnailImageId())
                            .map(BlogImageAsset::getImageUrl)
                            .orElse(null);
```
- 이미지 조회를 실패한 것이 블로그 글 상세 조회의 실패로 이어지면 안될 것이라고 판단해서 skip으로 처리했는데 적절할지 피드백 부탁드립니다.

- admin 권한을 확인할 때 다음과 같이 판단했는데, 더 좋은 방법 있다면 추천 부탁드립니다!
```sql
SELECT COUNT(m) > 0
FROM Member m
JOIN Role r ON m.roleId = r.id
WHERE m.id = :memberId
AND r.authority = :authority ("ADMIN")
```