### PR TITLE
hotifx: 회원가입 과정에서 pendingMember 세션 유실 문제 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/resolver/LoginMemberArgumentResolver.java
@@ -145,7 +145,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
     private void invalidateSessionIfPresent(HttpServletRequest request) {
         HttpSession session = request.getSession(false);
-        if (session != null) {
+        if (session != null && session.getAttribute("pendingMember") == null) {
             session.invalidate();
         }
     }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
회원가입 완료 요청 시 OAuth 가입용 pendingMember 세션이 유지되지 않아 가입이 실패하던 문제

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
회원가입 플로우에서 pendingMember 세션이 가입 완료 요청까지 유지되도록 세션 처리 로직을 수정

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
