### PR TITLE
[BOM-1059] feat: 스트릭 뱃지 발급 기능 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/BadgeCategory.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/BadgeCategory.java
@@ -2,5 +2,6 @@ package me.bombom.api.v1.badge.domain;
 
 public enum BadgeCategory {
     RANKING,
-    CHALLENGE
+    CHALLENGE,
+    STREAK
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadge.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadge.java
@@ -3,6 +3,8 @@ package me.bombom.api.v1.badge.domain;
 import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,16 +17,17 @@ import lombok.NonNull;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StreakBadge extends Badge {
 
-    @Column(name = "streak_day_count", columnDefinition = "SMALLINT")
-    private int streakDayCount;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "streak_badge_tier", length = 20)
+    private StreakBadgeTier streakBadgeTier;
 
     @Builder
     public StreakBadge(
             Long id,
             @NonNull Long memberId,
-            int streakDayCount
+            @NonNull StreakBadgeTier streakBadgeTier
     ) {
         super(id, memberId, BadgeCategory.STREAK);
-        this.streakDayCount = streakDayCount;
+        this.streakBadgeTier = streakBadgeTier;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadge.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadge.java
@@ -1,0 +1,30 @@
+package me.bombom.api.v1.badge.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@Getter
+@DiscriminatorValue("STREAK")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StreakBadge extends Badge {
+
+    @Column(name = "streak_day_count", columnDefinition = "SMALLINT")
+    private int streakDayCount;
+
+    @Builder
+    public StreakBadge(
+            Long id,
+            @NonNull Long memberId,
+            int streakDayCount
+    ) {
+        super(id, memberId, BadgeCategory.STREAK);
+        this.streakDayCount = streakDayCount;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadgeTier.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadgeTier.java
@@ -21,7 +21,7 @@ public enum StreakBadgeTier {
 
     private final int dayCount;
 
-    public static Optional<StreakBadgeTier> fromStreakDayCount(int streakDayCount) {
+    public static Optional<StreakBadgeTier> from(int streakDayCount) {
         return Arrays.stream(values())
                 .filter(tier -> tier.dayCount == streakDayCount)
                 .findFirst();

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadgeTier.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadgeTier.java
@@ -13,6 +13,10 @@ public enum StreakBadgeTier {
     THIRTY(30),
     FIFTY(50),
     HUNDRED(100),
+    TWO_HUNDRED(200),
+    THREE_HUNDRED(300),
+    FOUR_HUNDRED(400),
+    FIVE_HUNDRED(500),
     ;
 
     private final int dayCount;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadgeTier.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadgeTier.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum StreakBadgeTier {
+
     SEVEN(7),
     FIFTEEN(15),
     THIRTY(30),

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadgeTier.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/domain/StreakBadgeTier.java
@@ -1,0 +1,25 @@
+package me.bombom.api.v1.badge.domain;
+
+import java.util.Arrays;
+import java.util.Optional;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum StreakBadgeTier {
+    SEVEN(7),
+    FIFTEEN(15),
+    THIRTY(30),
+    FIFTY(50),
+    HUNDRED(100),
+    ;
+
+    private final int dayCount;
+
+    public static Optional<StreakBadgeTier> fromStreakDayCount(int streakDayCount) {
+        return Arrays.stream(values())
+                .filter(tier -> tier.dayCount == streakDayCount)
+                .findFirst();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/event/ContinueReadingIncreasedEventListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/event/ContinueReadingIncreasedEventListener.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.badge.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.badge.service.BadgeService;
+import me.bombom.api.v1.reading.event.ContinueReadingIncreasedEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ContinueReadingIncreasedEventListener {
+
+    private final BadgeService badgeService;
+
+    @TransactionalEventListener
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void on(ContinueReadingIncreasedEvent event) {
+        log.info("ContinueReadingIncreasedEvent received - memberId={}, streakDayCount={}",
+                event.memberId(), event.streakDayCount());
+        badgeService.issueStreakBadge(event.memberId(), event.streakDayCount());
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/service/BadgeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/service/BadgeService.java
@@ -62,7 +62,7 @@ public class BadgeService {
 
     @Transactional
     public void issueStreakBadge(Long memberId, int streakDayCount) {
-        StreakBadgeTier.fromStreakDayCount(streakDayCount)
+        StreakBadgeTier.from(streakDayCount)
                 .ifPresent(tier -> {
                     StreakBadge badge = StreakBadge.builder()
                             .memberId(memberId)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/service/BadgeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/service/BadgeService.java
@@ -66,7 +66,7 @@ public class BadgeService {
                 .ifPresent(tier -> {
                     StreakBadge badge = StreakBadge.builder()
                             .memberId(memberId)
-                            .streakDayCount(tier.getDayCount())
+                            .streakBadgeTier(tier)
                             .build();
                     badgeRepository.save(badge);
                     log.info("스트릭 뱃지 발급 완료 - memberId: {}, streakDayCount: {}", memberId, tier.getDayCount());

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/service/BadgeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/badge/service/BadgeService.java
@@ -8,6 +8,8 @@ import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.badge.domain.BadgeGrade;
 import me.bombom.api.v1.badge.domain.ChallengeBadge;
 import me.bombom.api.v1.badge.domain.RankingBadge;
+import me.bombom.api.v1.badge.domain.StreakBadge;
+import me.bombom.api.v1.badge.domain.StreakBadgeTier;
 import me.bombom.api.v1.badge.repository.BadgeRepository;
 import me.bombom.api.v1.badge.repository.ChallengeBadgeRepository;
 import me.bombom.api.v1.badge.repository.RankingBadgeRepository;
@@ -56,6 +58,19 @@ public class BadgeService {
             Optional<BadgeGrade> badgeGrade = challengeGrade.toBadge();
             badgeGrade.ifPresent(grade -> issueChallengeBadge(participant.getMemberId(), grade, challenge));
         }
+    }
+
+    @Transactional
+    public void issueStreakBadge(Long memberId, int streakDayCount) {
+        StreakBadgeTier.fromStreakDayCount(streakDayCount)
+                .ifPresent(tier -> {
+                    StreakBadge badge = StreakBadge.builder()
+                            .memberId(memberId)
+                            .streakDayCount(tier.getDayCount())
+                            .build();
+                    badgeRepository.save(badge);
+                    log.info("스트릭 뱃지 발급 완료 - memberId: {}, streakDayCount: {}", memberId, tier.getDayCount());
+                });
     }
 
     private void issueRankingBadge(Long memberId, BadgeGrade grade, LocalDate period) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/event/ContinueReadingIncreasedEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/event/ContinueReadingIncreasedEvent.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.reading.event;
+
+public record ContinueReadingIncreasedEvent(
+        Long memberId,
+        int streakDayCount
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -39,6 +39,7 @@ import me.bombom.api.v1.reading.dto.response.ReadingInformationResponse;
 import me.bombom.api.v1.reading.dto.response.WeeklyGoalCountResponse;
 import me.bombom.api.v1.badge.domain.BadgeGrade;
 import me.bombom.api.v1.badge.service.BadgeService;
+import me.bombom.api.v1.reading.event.ContinueReadingIncreasedEvent;
 import me.bombom.api.v1.reading.repository.ContinueReadingSnapshotRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
 import me.bombom.api.v1.reading.repository.MonthlyReadingRealtimeRepository;
@@ -46,6 +47,7 @@ import me.bombom.api.v1.reading.repository.MonthlyReadingSnapshotRepository;
 import me.bombom.api.v1.reading.repository.TodayReadingRepository;
 import me.bombom.api.v1.reading.repository.WeeklyReadingRepository;
 import me.bombom.api.v1.reading.repository.YearlyReadingRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.support.CronExpression;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -73,6 +75,7 @@ public class ReadingService {
     private final MonthlyRankingScheduleProperties scheduleProps;
     private final ContinueReadingRankingScheduleProperties continueReadingRankingScheduleProperties;
     private final BadgeService badgeService;
+    private final ApplicationEventPublisher applicationEventPublisher;
     private final Clock clock;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -432,7 +435,9 @@ public class ReadingService {
                     .addContext(ErrorContextKeys.OPERATION, "updateContinueReadingCount"));
         if (canIncreaseContinueReadingCount(todayReading)) {
             continueReading.increaseDayCount();
-            badgeService.issueStreakBadge(memberId, continueReading.getDayCount());
+            applicationEventPublisher.publishEvent(
+                    new ContinueReadingIncreasedEvent(memberId, continueReading.getDayCount())
+            );
         }
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -432,6 +432,7 @@ public class ReadingService {
                     .addContext(ErrorContextKeys.OPERATION, "updateContinueReadingCount"));
         if (canIncreaseContinueReadingCount(todayReading)) {
             continueReading.increaseDayCount();
+            badgeService.issueStreakBadge(memberId, continueReading.getDayCount());
         }
     }
 

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.6.0__add_streak_day_count_to_badge.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.6.0__add_streak_day_count_to_badge.sql
@@ -1,2 +1,2 @@
 ALTER TABLE badge
-    ADD COLUMN streak_day_count SMALLINT NULL;
+    ADD COLUMN streak_badge_tier VARCHAR(20) NULL;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.6.0__add_streak_day_count_to_badge.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.6.0__add_streak_day_count_to_badge.sql
@@ -1,0 +1,2 @@
+ALTER TABLE badge
+    ADD COLUMN streak_day_count SMALLINT NULL;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.6.1__backfill_streak_badges_from_continue_reading.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.6.1__backfill_streak_badges_from_continue_reading.sql
@@ -10,7 +10,7 @@ INSERT INTO badge (
     challenge_id,
     challenge_name,
     challenge_generation,
-    streak_day_count,
+    streak_badge_tier,
     created_at,
     updated_at
 )
@@ -23,21 +23,21 @@ SELECT
     NULL,
     NULL,
     NULL,
-    m.milestone,
+    m.tier,
     CURRENT_TIMESTAMP(6),
     CURRENT_TIMESTAMP(6)
 FROM continue_reading_realtime cr
 JOIN (
-    SELECT 7 AS milestone UNION ALL
-    SELECT 15 UNION ALL
-    SELECT 30 UNION ALL
-    SELECT 50 UNION ALL
-    SELECT 100
+    SELECT 7 AS milestone, 'SEVEN' AS tier UNION ALL
+    SELECT 15, 'FIFTEEN' UNION ALL
+    SELECT 30, 'THIRTY' UNION ALL
+    SELECT 50, 'FIFTY' UNION ALL
+    SELECT 100, 'HUNDRED'
 ) m ON cr.day_count >= m.milestone
 WHERE NOT EXISTS (
     SELECT 1
     FROM badge b
     WHERE b.member_id = cr.member_id
       AND b.badge_category = 'STREAK'
-      AND b.streak_day_count = m.milestone
+      AND b.streak_badge_tier = m.tier
 );

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.6.1__backfill_streak_badges_from_continue_reading.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.6.1__backfill_streak_badges_from_continue_reading.sql
@@ -1,0 +1,43 @@
+-- 현재 연속 읽기 일수(day_count) 기준으로 달성한 마일스톤(7, 15, 30, 50, 100)마다 스트릭 뱃지를 소급 발급한다.
+-- 동일 회원·동일 마일스톤의 뱃지가 이미 존재하면 중복 삽입하지 않는다
+
+INSERT INTO badge (
+    member_id,
+    badge_category,
+    badge_grade,
+    period_year,
+    period_month,
+    challenge_id,
+    challenge_name,
+    challenge_generation,
+    streak_day_count,
+    created_at,
+    updated_at
+)
+SELECT 
+    cr.member_id,
+    'STREAK',
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    m.milestone,
+    CURRENT_TIMESTAMP(6),
+    CURRENT_TIMESTAMP(6)
+FROM continue_reading_realtime cr
+JOIN (
+    SELECT 7 AS milestone UNION ALL
+    SELECT 15 UNION ALL
+    SELECT 30 UNION ALL
+    SELECT 50 UNION ALL
+    SELECT 100
+) m ON cr.day_count >= m.milestone
+WHERE NOT EXISTS (
+    SELECT 1
+    FROM badge b
+    WHERE b.member_id = cr.member_id
+      AND b.badge_category = 'STREAK'
+      AND b.streak_day_count = m.milestone
+);

--- a/backend/bom-bom-server/src/main/resources/db/migration/V31.6.1__backfill_streak_badges_from_continue_reading.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V31.6.1__backfill_streak_badges_from_continue_reading.sql
@@ -1,4 +1,4 @@
--- 현재 연속 읽기 일수(day_count) 기준으로 달성한 마일스톤(7, 15, 30, 50, 100)마다 스트릭 뱃지를 소급 발급한다.
+-- 현재 연속 읽기 일수(day_count) 기준으로 달성한 마일스톤(7, 15, 30, 50, 100, 200, 300, 400, 500)마다 스트릭 뱃지를 소급 발급한다.
 -- 동일 회원·동일 마일스톤의 뱃지가 이미 존재하면 중복 삽입하지 않는다
 
 INSERT INTO badge (
@@ -32,7 +32,11 @@ JOIN (
     SELECT 15, 'FIFTEEN' UNION ALL
     SELECT 30, 'THIRTY' UNION ALL
     SELECT 50, 'FIFTY' UNION ALL
-    SELECT 100, 'HUNDRED'
+    SELECT 100, 'HUNDRED' UNION ALL
+    SELECT 200, 'TWO_HUNDRED' UNION ALL
+    SELECT 300, 'THREE_HUNDRED' UNION ALL
+    SELECT 400, 'FOUR_HUNDRED' UNION ALL
+    SELECT 500, 'FIVE_HUNDRED'
 ) m ON cr.day_count >= m.milestone
 WHERE NOT EXISTS (
     SELECT 1

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/badge/event/ContinueReadingIncreasedEventListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/badge/event/ContinueReadingIncreasedEventListenerTest.java
@@ -1,0 +1,34 @@
+package me.bombom.api.v1.badge.event;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import me.bombom.api.v1.badge.service.BadgeService;
+import me.bombom.api.v1.reading.event.ContinueReadingIncreasedEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContinueReadingIncreasedEventListenerTest {
+
+    @Mock
+    private BadgeService badgeService;
+
+    @InjectMocks
+    private ContinueReadingIncreasedEventListener continueReadingIncreasedEventListener;
+
+    @Test
+    void 연속_읽기_일수_증가_이벤트를_받으면_스트릭_뱃지를_발급한다() {
+        // given
+        ContinueReadingIncreasedEvent event = new ContinueReadingIncreasedEvent(1L, 7);
+
+        // when
+        continueReadingIncreasedEventListener.on(event);
+
+        // then
+        verify(badgeService, times(1)).issueStreakBadge(1L, 7);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/badge/service/BadgeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/badge/service/BadgeServiceTest.java
@@ -12,6 +12,7 @@ import me.bombom.api.v1.badge.domain.Badge;
 import me.bombom.api.v1.badge.domain.BadgeGrade;
 import me.bombom.api.v1.badge.domain.ChallengeBadge;
 import me.bombom.api.v1.badge.domain.RankingBadge;
+import me.bombom.api.v1.badge.domain.StreakBadge;
 import me.bombom.api.v1.badge.repository.BadgeRepository;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
@@ -490,5 +491,33 @@ class BadgeServiceTest {
             .map(b -> (ChallengeBadge) b)
             .filter(b -> b.getMemberId().equals(memberId) && b.getGrade() == grade)
             .findFirst();
+    }
+
+    @Test
+    void 연속_읽기_일수가_마일스톤에_도달하면_스트릭_뱃지를_발급한다() {
+        badgeService.issueStreakBadge(member1.getId(), 7);
+
+        List<Badge> badges = badgeRepository.findAll();
+        assertThat(badges).hasSize(1);
+        assertThat(badges.get(0)).isInstanceOf(StreakBadge.class);
+        StreakBadge streakBadge = (StreakBadge) badges.get(0);
+        assertThat(streakBadge.getStreakDayCount()).isEqualTo(7);
+    }
+
+    @Test
+    void 마일스톤이_아니면_스트릭_뱃지를_발급하지_않는다() {
+        badgeService.issueStreakBadge(member1.getId(), 6);
+
+        assertThat(badgeRepository.count()).isZero();
+    }
+
+    @Test
+    void 동일_마일스톤도_여러_번_발급할_수_있다() {
+        badgeService.issueStreakBadge(member1.getId(), 100);
+        badgeService.issueStreakBadge(member1.getId(), 100);
+
+        List<Badge> badges = badgeRepository.findAll();
+        assertThat(badges).hasSize(2);
+        assertThat(badges.stream().filter(b -> b instanceof StreakBadge).count()).isEqualTo(2);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/badge/service/BadgeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/badge/service/BadgeServiceTest.java
@@ -521,4 +521,15 @@ class BadgeServiceTest {
         assertThat(badges).hasSize(2);
         assertThat(badges.stream().filter(b -> b instanceof StreakBadge).count()).isEqualTo(2);
     }
+
+    @Test
+    void 신규_마일스톤에_도달하면_스트릭_뱃지를_발급한다() {
+        badgeService.issueStreakBadge(member1.getId(), 500);
+
+        List<Badge> badges = badgeRepository.findAll();
+        assertThat(badges).hasSize(1);
+        assertThat(badges.get(0)).isInstanceOf(StreakBadge.class);
+        StreakBadge streakBadge = (StreakBadge) badges.get(0);
+        assertThat(streakBadge.getStreakBadgeTier()).isEqualTo(StreakBadgeTier.FIVE_HUNDRED);
+    }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/badge/service/BadgeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/badge/service/BadgeServiceTest.java
@@ -13,6 +13,7 @@ import me.bombom.api.v1.badge.domain.BadgeGrade;
 import me.bombom.api.v1.badge.domain.ChallengeBadge;
 import me.bombom.api.v1.badge.domain.RankingBadge;
 import me.bombom.api.v1.badge.domain.StreakBadge;
+import me.bombom.api.v1.badge.domain.StreakBadgeTier;
 import me.bombom.api.v1.badge.repository.BadgeRepository;
 import me.bombom.api.v1.challenge.domain.Challenge;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
@@ -501,7 +502,7 @@ class BadgeServiceTest {
         assertThat(badges).hasSize(1);
         assertThat(badges.get(0)).isInstanceOf(StreakBadge.class);
         StreakBadge streakBadge = (StreakBadge) badges.get(0);
-        assertThat(streakBadge.getStreakDayCount()).isEqualTo(7);
+        assertThat(streakBadge.getStreakBadgeTier()).isEqualTo(StreakBadgeTier.SEVEN);
     }
 
     @Test


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
사용자의 연속 읽기(스트릭) 일수에 따른 뱃지 발급 기능을 구현했습니다.
- 연속 읽기 마일스톤(7, 15, 30, 50, 100, + 200, 300, 400, 500일) 달성 시 뱃지 자동 발급 로직 추가
- 기존 유저들을 위한 스트릭 뱃지 백필 마이그레이션 스크립트 작성
- badge 테이블 내 스트릭 정보를 담기 위한 `streak_day_count` 컬럼 추가

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
꾸준히 글을 읽는 습관을 기를 수 있도록 성취감을 제공하고, 리텐션을 높이기 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 도메인 모델: 기존 Badge 엔티티를 상속받은 StreakBadge를 추가했습니다.
- 발급 시점: ReadingService에서 사용자의 오늘 첫 읽기가 기록되어 스트릭이 증가하는 시점에 BadgeService.issueStreakBadge()를 호출하여 실시간으로 발급

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 마일스톤이 100일까지만 구현이 되어 있는데, 더 늘리는게 적절할지 의견 부탁드립니다. 현재 사용자중 가장 긴 스트릭은 20일 정도로 알 고 있습니다.
- 추후에 마일스톤에 몇번 도달했는지에 대한 정보도 필요할수도 있지 않을까 하는 의견이 있어서, 같은 마일스톤에 대해서 뱃지가 중복 발급되게 구현되어 있습니다.
