### PR TITLE
[BOM-1069] feat: 구독 취소 url 파싱 개선

### DIFF
--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -4,6 +4,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.springframework.util.StringUtils;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class UnsubscribeUrlExtractor {
@@ -30,7 +31,7 @@ public final class UnsubscribeUrlExtractor {
     );
 
     public static String extract(String articleContents) {
-        if (articleContents == null) {
+        if (StringUtils.hasText(articleContents)) {
             return null;
         }
 
@@ -43,7 +44,7 @@ public final class UnsubscribeUrlExtractor {
         while (anchorMatcher.find()) {
             String href = anchorMatcher.group(1);
             String anchorBody = anchorMatcher.group(2);
-            String text = INNER_TAG_PATTERN.matcher(anchorBody).replaceAll("").trim();
+            String text = INNER_TAG_PATTERN.matcher(anchorBody).replaceAll("").strip();
             if (UNSUBSCRIBE_TEXT_PATTERN.matcher(text).find()) {
                 return href;
             }

--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -31,7 +31,7 @@ public final class UnsubscribeUrlExtractor {
     );
 
     public static String extract(String articleContents) {
-        if (StringUtils.hasText(articleContents)) {
+        if (!StringUtils.hasText(articleContents)) {
             return null;
         }
 

--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -44,6 +44,9 @@ public final class UnsubscribeUrlExtractor {
         while (anchorMatcher.find()) {
             String href = anchorMatcher.group(1);
             String anchorBody = anchorMatcher.group(2);
+            if (href == null || anchorBody == null) {
+                continue;
+            }
             String text = INNER_TAG_PATTERN.matcher(anchorBody).replaceAll("").strip();
             if (UNSUBSCRIBE_TEXT_PATTERN.matcher(text).find()) {
                 return href;

--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -8,16 +8,47 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class UnsubscribeUrlExtractor {
 
-    private static final Pattern UNSUBSCRIBE_URL_PATTERN = Pattern.compile("href=\"([^\"]*unsubscribe[^\"]*)\"", Pattern.CASE_INSENSITIVE);
+    // 1단계: href URL 자체에 "unsubscribe"가 포함된 경우
+    private static final Pattern UNSUBSCRIBE_URL_PATTERN = Pattern.compile(
+            "href=\"([^\"]*unsubscribe[^\"]*)\"",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    // 2단계: <a href="...">...</a> 블록 전체를 추출 (href와 내부 HTML을 함께 캡처)
+    private static final Pattern ANCHOR_PATTERN = Pattern.compile(
+            "<a\\s[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>",
+            Pattern.CASE_INSENSITIVE | Pattern.DOTALL
+    );
+
+    // 앵커 내부의 <span> 등 중첩 태그를 제거해 순수 텍스트만 남기기 위한 패턴
+    private static final Pattern INNER_TAG_PATTERN = Pattern.compile("<[^>]+>");
+
+    // 앵커 텍스트가 수신거부 키워드로 시작하는지 확인. 앞에 '[', '(' 등 브라켓이 있어도 허용 (예: "[수신거부]")
+    private static final Pattern UNSUBSCRIBE_TEXT_PATTERN = Pattern.compile(
+            "^[\\[(\\s]*(unsubscribe|unsubscription|수신\\s*거부|구독\\s*취소|구독\\s*해지)",
+            Pattern.CASE_INSENSITIVE
+    );
 
     public static String extract(String articleContents) {
         if (articleContents == null) {
             return null;
         }
-        Matcher matcher = UNSUBSCRIBE_URL_PATTERN.matcher(articleContents);
-        if (matcher.find()) {
-            return matcher.group(1);
+
+        Matcher urlMatcher = UNSUBSCRIBE_URL_PATTERN.matcher(articleContents);
+        if (urlMatcher.find()) {
+            return urlMatcher.group(1);
         }
+
+        Matcher anchorMatcher = ANCHOR_PATTERN.matcher(articleContents);
+        while (anchorMatcher.find()) {
+            String href = anchorMatcher.group(1);
+            String anchorBody = anchorMatcher.group(2);
+            String text = INNER_TAG_PATTERN.matcher(anchorBody).replaceAll("").trim();
+            if (UNSUBSCRIBE_TEXT_PATTERN.matcher(text).find()) {
+                return href;
+            }
+        }
+
         return null;
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/Subscribe.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/Subscribe.java
@@ -33,6 +33,9 @@ public class Subscribe extends BaseEntity {
     private String unsubscribeUrl;
 
     public void updateUnsubscribeUrl(String unsubscribeUrl) {
+        if (unsubscribeUrl == null) {
+            return;
+        }
         this.unsubscribeUrl = unsubscribeUrl;
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
@@ -2,33 +2,85 @@ package news.bombomemail.article.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 class UnsubscribeUrlExtractorTest {
 
     @Test
-    void 구독_취소_URL을_성공적으로_추출한다() {
-        // given
-        String htmlContent = "<html><body><a href=\"https://example.com/unsubscribe?id=123\">Unsubscribe</a></body></html>";
-
-        // when
-        String unsubscribeUrl = UnsubscribeUrlExtractor.extract(htmlContent);
-
-        // then
-        assertThat(unsubscribeUrl).isEqualTo("https://example.com/unsubscribe?id=123");
+    void URL에_unsubscribe가_있으면_추출한다() {
+        String html = "<a href=\"https://example.com/unsubscribe?id=123\">Unsubscribe</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html))
+                .isEqualTo("https://example.com/unsubscribe?id=123");
     }
 
     @Test
-    void 구독_취소_URL이_없으면_null을_반환한다() {
-        // given
-        String htmlContent = "<html><body><a href=\"https://example.com/subscribe\">Subscribe</a></body></html>";
+    void 앵커_텍스트가_Unsubscribe이면_추출한다() {
+        // theSkimm, Korean FE Article
+        String html = "<a href=\"https://link.example.com/oc/abc123\">Unsubscribe or Update Your Preferences</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html))
+                .isEqualTo("https://link.example.com/oc/abc123");
+    }
 
-        // when
-        String unsubscribeUrl = UnsubscribeUrlExtractor.extract(htmlContent);
+    @Test
+    void span_내부에_Unsubscribe가_있으면_추출한다() {
+        // Substack
+        String html = "<a href=\"https://substack.com/redirect/2/eyJl...\"><span>Unsubscribe</span></a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html))
+                .isEqualTo("https://substack.com/redirect/2/eyJl...");
+    }
 
-        // then
-        assertThat(unsubscribeUrl).isNull();
+    @Test
+    void 앵커_텍스트가_수신거부이면_추출한다() {
+        // NHN Cloud, Careet
+        String html = "<a href=\"http://mkt.nhncloud.com/u/NDg4...\">수신거부</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html))
+                .isEqualTo("http://mkt.nhncloud.com/u/NDg4...");
+    }
+
+    @Test
+    void 대괄호로_감싼_수신거부도_추출한다() {
+        // Careet
+        String html = "<a href=\"https://event.stibee.com/v2/click/abc\">[수신거부]</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html))
+                .isEqualTo("https://event.stibee.com/v2/click/abc");
+    }
+
+    @Test
+    void 앵커_텍스트가_Unsubscription이면_추출한다() {
+        // NHN Cloud
+        String html = "<a href=\"http://mkt.nhncloud.com/u/NDg4...\">Unsubscription)</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html))
+                .isEqualTo("http://mkt.nhncloud.com/u/NDg4...");
+    }
+
+    @Test
+    void 앵커_텍스트가_구독취소이면_추출한다() {
+        String html = "<a href=\"https://example.com/cancel\">구독 취소</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html))
+                .isEqualTo("https://example.com/cancel");
+    }
+
+    @Test
+    void 앵커_텍스트가_구독해지이면_추출한다() {
+        String html = "<a href=\"https://example.com/cancel\">구독 해지</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html))
+                .isEqualTo("https://example.com/cancel");
+    }
+
+    @Test
+    void 본문_링크에_unsubscribe가_포함되어도_오탐하지_않는다() {
+        String html = "<a href=\"https://blog.example.com/email-tips\">Why unsubscribe rates matter for marketers</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html)).isNull();
+    }
+
+    @Test
+    void 수신거부_URL이_없으면_null을_반환한다() {
+        String html = "<a href=\"https://example.com/subscribe\">Subscribe</a>";
+        assertThat(UnsubscribeUrlExtractor.extract(html)).isNull();
+    }
+
+    @Test
+    void null_입력이면_null을_반환한다() {
+        assertThat(UnsubscribeUrlExtractor.extract(null)).isNull();
     }
 }


### PR DESCRIPTION
## 📌 What
구독 취소 URL 파싱 로직을 개선했습니다.

## ❓ Why
기존 파서는 href URL 자체에 "unsubscribe"가 포함된 경우만 처리할 수 있었습니다.
실제 뉴스레터들은 추적 리다이렉트, JWT 인코딩 등 다양한 URL 형태를 사용하기 때문에
아래 케이스들에서 파싱에 실패했습니다.

| 뉴스레터 | URL 패턴 | 앵커 텍스트 |
|--------|---------|-----------|
| theSkimm | 추적 리다이렉트 (`/oc/...`) | `Unsubscribe or Update Your Preferences` |
| Substack(FE News) | JWT 리다이렉트 (`/redirect/2/eyJ...`) | `Unsubscribe` (내부 `<span>`) |
| NHN Cloud ReadyLetter | 단축 경로 (`/u/...`) | `수신거부`, `Unsubscription` |
| Careet (stibee) | base64 리다이렉트 (`/v2/click/...`) | `[수신거부]` |

- 굿모닝 마이 브랜드, SPORTSNACK은 아티클 내에 구독 취소 URL이 없습니다,,

## 🔧 How
파싱을 2단계로 처리합니다.

**1단계 (기존 방식):** href URL에 `unsubscribe`가 포함된 경우 즉시 반환

**2단계 (신규):** href에 없으면 `<a>` 태그 내부 텍스트 기반으로 탐지
- 내부 `<span>` 등 중첩 태그를 제거 후 순수 텍스트 추출
- 텍스트가 아래 키워드로 시작하면 해당 href 반환
  - 영문: `unsubscribe`, `unsubscription`
  - 한글: `수신 거부`, `구독 취소`, `구독 해지`
- `[수신거부]` 처럼 브라켓으로 감싼 경우도 허용
- `"Why unsubscribe rates matter"` 처럼 키워드가 문장 중간에 있는 경우는 제외 (오탐 방지)
  - 앵커 텍스트가 수신거부 키워드로 시작하는 경우만 매칭 (중간에 포함된 경우 제외)
    - `"Unsubscribe or Update Your Preferences"` → 키워드로 시작 ✅
    - `"Why unsubscribe rates matter"` → `"Why"`로 시작 ❌

- 파싱 실패 시, 디스코드 알림을 추가할까 했는데, 환영 메일은 대부분 구독 취소 URL이 포함되어 있지 않고, 굿모닝 마이 브랜드/SPORTSNACK는 아예 담겨있지 않기 때문에 의미 없는 실패 알림이 계속해서 올거 같아 추가하지 않았습니다.

## 👀 Review Point (Optional)
- 구독 취소 URL을 파싱(탐지)하기 위한 패턴을 기존 구독 취소 자동화 구현 시에 추가한 패턴 관리 테이블로 관리할까 고민했지만, 상수로 관리하도록 했습니다. 아래 이유 때문입니다!
  - 우선, 현재 엣지 케이스를 모두 체크하고 커버하도록 했고, 테스트를 통과했기 때문에 패턴 수정이 자주 일어날 것 같지 않습니다.
  - 패턴 조회는 아티클 도착 시마다 수행됩니다. 하루 800~1,200개의 아티클이 30분~2시간 내에 집중적으로 도착하는데, 이 시간대에 아티클 삽입 쿼리와 패턴 조회가 겹쳐 커넥션을 불필요하게 소모하는 리스크를 만들고 싶지 않았습니다.