### PR TITLE
[BOM-1097] feat: 매일메일 구독자 수 집계 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/AsyncConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/AsyncConfig.java
@@ -1,14 +1,19 @@
 package me.bombom.api.v1.common.config;
 
+import java.util.Arrays;
 import java.util.concurrent.Executor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
+@Slf4j
 @EnableAsync
 @Configuration
-public class AsyncConfig {
+public class AsyncConfig implements AsyncConfigurer {
 
     @Bean(name = "taskExecutor")
     public Executor taskExecutor(AsyncExecutorProperties props) {
@@ -21,5 +26,16 @@ public class AsyncConfig {
         executor.setAwaitTerminationSeconds(60);
         executor.initialize();
         return executor;
+    }
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return (ex, method, params) -> log.error(
+                "[Async 예외] {}.{}() | params: {}",
+                method.getDeclaringClass().getSimpleName(),
+                method.getName(),
+                Arrays.toString(params),
+                ex
+        );
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/controller/MaeilMailSubscribeController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/controller/MaeilMailSubscribeController.java
@@ -34,6 +34,6 @@ public class MaeilMailSubscribeController implements MaeilMailSubscribeControlle
             @LoginMember Member member,
             @RequestBody @Valid MaeilMailSubscribeRequest request
     ) {
-        maeilMailSubscribeService.subscribe(member.getId(), request);
+        maeilMailSubscribeService.subscribe(member, request);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/event/MaeilMailSubscribedEvent.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/event/MaeilMailSubscribedEvent.java
@@ -1,0 +1,14 @@
+package me.bombom.api.v1.nativenewsletter.maeilmail.event;
+
+import java.time.LocalDate;
+
+public record MaeilMailSubscribedEvent(
+
+        Long newsletterId,
+        LocalDate birthDate
+) {
+
+    public static MaeilMailSubscribedEvent of(Long newsletterId, LocalDate birthDate) {
+        return new MaeilMailSubscribedEvent(newsletterId, birthDate);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/event/MaeilMailSubscribedEventListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/event/MaeilMailSubscribedEventListener.java
@@ -1,0 +1,22 @@
+package me.bombom.api.v1.nativenewsletter.maeilmail.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.subscribe.service.NewsletterSubscriptionCountService;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MaeilMailSubscribedEventListener {
+
+    private final NewsletterSubscriptionCountService newsletterSubscriptionCountService;
+
+    @Async
+    @TransactionalEventListener
+    public void handle(MaeilMailSubscribedEvent event) {
+        newsletterSubscriptionCountService.updateNewsletterSubscriptionCount(event.newsletterId(), event.birthDate());
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/service/MaeilMailSubscribeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/service/MaeilMailSubscribeService.java
@@ -5,16 +5,19 @@ import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
 import me.bombom.api.v1.nativenewsletter.maeilmail.domain.MaeilMailTrack;
 import me.bombom.api.v1.nativenewsletter.maeilmail.dto.MaeilMailSubscribeRequest;
 import me.bombom.api.v1.nativenewsletter.maeilmail.dto.MaeilMailSubscriptionResponse;
+import me.bombom.api.v1.nativenewsletter.maeilmail.event.MaeilMailSubscribedEvent;
 import me.bombom.api.v1.nativenewsletter.maeilmail.repository.MaeilMailSubscriptionTrackRepository;
 import me.bombom.api.v1.newsletter.domain.Newsletter;
 import me.bombom.api.v1.newsletter.domain.NewsletterSource;
 import me.bombom.api.v1.newsletter.repository.NewsletterRepository;
 import me.bombom.api.v1.subscribe.domain.Subscribe;
 import me.bombom.api.v1.subscribe.repository.SubscribeRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +29,7 @@ public class MaeilMailSubscribeService {
     private final SubscribeRepository subscribeRepository;
     private final NewsletterRepository newsletterRepository;
     private final MaeilMailSubscriptionTrackRepository maeilMailSubscriptionTrackRepository;
+    private final ApplicationEventPublisher applicationEventPublisher;
 
     public MaeilMailSubscriptionResponse getSubscription(Long memberId) {
         List<MaeilMailSubscriptionTrack> tracks = maeilMailSubscriptionTrackRepository.findByMemberId(memberId);
@@ -33,17 +37,18 @@ public class MaeilMailSubscribeService {
     }
 
     @Transactional
-    public void subscribe(Long memberId, MaeilMailSubscribeRequest request) {
+    public void subscribe(Member member, MaeilMailSubscribeRequest request) {
         Newsletter newsletter = getMaeilMailNewsletter();
-        validateNotSubscribed(memberId, newsletter.getId());
+        validateNotSubscribed(member.getId(), newsletter.getId());
         validateTracks(request);
 
         Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
-                .memberId(memberId)
+                .memberId(member.getId())
                 .newsletterId(newsletter.getId())
                 .build());
 
-        maeilMailSubscriptionTrackRepository.saveAll(buildSubscriptionTracks(subscribe.getId(), memberId, request.tracks()));
+        maeilMailSubscriptionTrackRepository.saveAll(buildSubscriptionTracks(subscribe.getId(), member.getId(), request.tracks()));
+        applicationEventPublisher.publishEvent(MaeilMailSubscribedEvent.of(newsletter.getId(), member.getBirthDate()));
     }
 
     private Newsletter getMaeilMailNewsletter() {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.reading.service;
 
 import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -124,6 +125,11 @@ public class ReadingService {
 
     @Transactional
     public void resetContinueReadingCount() {
+        LocalDate yesterday = LocalDate.now(clock).minusDays(1);
+        if (isWeekend(yesterday)) {
+            return;
+        }
+
         todayReadingRepository.findTotalNonZeroAndCurrentZero()
                 .forEach(this::applyResetContinueReadingCount);
     }
@@ -474,5 +480,10 @@ public class ReadingService {
 
     private boolean canIncreaseContinueReadingCount(TodayReading todayReading) {
         return todayReading.getCurrentCount() == 0;
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/AgeGroup.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/domain/AgeGroup.java
@@ -1,0 +1,36 @@
+package me.bombom.api.v1.subscribe.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum AgeGroup {
+
+    AGE0S("age0s"),
+    AGE10S("age10s"),
+    AGE20S("age20s"),
+    AGE30S("age30s"),
+    AGE40S("age40s"),
+    AGE50S("age50s"),
+    AGE60PLUS("age60plus"),
+    ;
+
+    private final String dbKey;
+
+    AgeGroup(String dbKey) {
+        this.dbKey = dbKey;
+    }
+
+    public static AgeGroup fromBirthYear(int currentYear, int birthYear) {
+        int age = currentYear - birthYear;
+        int decade = Math.max(0, Math.min(6, age / 10)); // 0~60+ clamp
+        return switch (decade) {
+            case 0 -> AGE0S;
+            case 1 -> AGE10S;
+            case 2 -> AGE20S;
+            case 3 -> AGE30S;
+            case 4 -> AGE40S;
+            case 5 -> AGE50S;
+            default -> AGE60PLUS;
+        };
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/repository/NewsletterSubscriptionCountRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/repository/NewsletterSubscriptionCountRepository.java
@@ -2,6 +2,39 @@ package me.bombom.api.v1.subscribe.repository;
 
 import me.bombom.api.v1.subscribe.domain.NewsletterSubscriptionCount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NewsletterSubscriptionCountRepository extends JpaRepository<NewsletterSubscriptionCount, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query(value = """
+            INSERT INTO newsletter_subscription_count
+                (newsletter_id, total, age0s, age10s, age20s, age30s, age40s, age50s, age60plus)
+            VALUES (
+                :newsletterId,
+                1,
+                IF(:ageGroup = 'age0s', 1, 0),
+                IF(:ageGroup = 'age10s', 1, 0),
+                IF(:ageGroup = 'age20s', 1, 0),
+                IF(:ageGroup = 'age30s', 1, 0),
+                IF(:ageGroup = 'age40s', 1, 0),
+                IF(:ageGroup = 'age50s', 1, 0),
+                IF(:ageGroup = 'age60plus', 1, 0)
+            )
+            ON DUPLICATE KEY UPDATE
+                total     = total     + 1,
+                age0s     = age0s     + IF(:ageGroup = 'age0s', 1, 0),
+                age10s    = age10s    + IF(:ageGroup = 'age10s', 1, 0),
+                age20s    = age20s    + IF(:ageGroup = 'age20s', 1, 0),
+                age30s    = age30s    + IF(:ageGroup = 'age30s', 1, 0),
+                age40s    = age40s    + IF(:ageGroup = 'age40s', 1, 0),
+                age50s    = age50s    + IF(:ageGroup = 'age50s', 1, 0),
+                age60plus = age60plus + IF(:ageGroup = 'age60plus', 1, 0)
+            """, nativeQuery = true)
+    void increaseSubscriptionCountByNewsletterIdAndAgeGroup(
+            @Param("newsletterId") Long newsletterId,
+            @Param("ageGroup") String ageGroup
+    );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/service/NewsletterSubscriptionCountService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/subscribe/service/NewsletterSubscriptionCountService.java
@@ -1,0 +1,33 @@
+package me.bombom.api.v1.subscribe.service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.subscribe.domain.AgeGroup;
+import me.bombom.api.v1.subscribe.repository.NewsletterSubscriptionCountRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NewsletterSubscriptionCountService {
+
+    private final Clock clock;
+    private final NewsletterSubscriptionCountRepository newsletterSubscriptionCountRepository;
+
+    @Transactional
+    public void updateNewsletterSubscriptionCount(Long newsletterId, LocalDate birthDate) {
+        if (birthDate == null) {
+            log.debug("멤버의 생년월일이 없어 구독자 수가 업데이트 되지 않습니다.");
+            return;
+        }
+
+        AgeGroup group = AgeGroup.fromBirthYear(LocalDate.now(clock).getYear(), birthDate.getYear());
+        newsletterSubscriptionCountRepository.increaseSubscriptionCountByNewsletterIdAndAgeGroup(
+                newsletterId,
+                group.getDbKey()
+        );
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/nativenewsletter/maeilmail/service/MaeilMailSubscribeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/nativenewsletter/maeilmail/service/MaeilMailSubscribeServiceTest.java
@@ -68,7 +68,7 @@ class MaeilMailSubscribeServiceTest {
         Member member = memberRepository.save(TestFixture.normalMemberFixture());
         Newsletter newsletter = newsletterRepository.save(createMaeilMailNewsletter());
 
-        maeilMailSubscribeService.subscribe(member.getId(), new MaeilMailSubscribeRequest(
+        maeilMailSubscribeService.subscribe(member, new MaeilMailSubscribeRequest(
                 List.of(MaeilMailTrack.BE, MaeilMailTrack.FE)
         ));
 
@@ -91,7 +91,7 @@ class MaeilMailSubscribeServiceTest {
         Member member = memberRepository.save(TestFixture.normalMemberFixture());
         Newsletter newsletter = newsletterRepository.save(createMaeilMailNewsletter());
 
-        maeilMailSubscribeService.subscribe(member.getId(), new MaeilMailSubscribeRequest(
+        maeilMailSubscribeService.subscribe(member, new MaeilMailSubscribeRequest(
                 List.of(MaeilMailTrack.BE, MaeilMailTrack.FE)
         ));
 
@@ -127,7 +127,7 @@ class MaeilMailSubscribeServiceTest {
                 .newsletterId(newsletter.getId())
                 .build());
 
-        assertThatThrownBy(() -> maeilMailSubscribeService.subscribe(member.getId(), new MaeilMailSubscribeRequest(
+        assertThatThrownBy(() -> maeilMailSubscribeService.subscribe(member, new MaeilMailSubscribeRequest(
                 List.of(MaeilMailTrack.BE)
         )))
                 .isInstanceOf(CIllegalArgumentException.class)
@@ -141,7 +141,7 @@ class MaeilMailSubscribeServiceTest {
         Member member = memberRepository.save(TestFixture.normalMemberFixture());
         newsletterRepository.save(createMaeilMailNewsletter());
 
-        assertThatThrownBy(() -> maeilMailSubscribeService.subscribe(member.getId(), new MaeilMailSubscribeRequest(
+        assertThatThrownBy(() -> maeilMailSubscribeService.subscribe(member, new MaeilMailSubscribeRequest(
                 List.of(MaeilMailTrack.BE, MaeilMailTrack.BE)
         )))
                 .isInstanceOf(CIllegalArgumentException.class)

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
@@ -1,0 +1,125 @@
+package me.bombom.api.v1.reading.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import me.bombom.api.v1.badge.service.BadgeService;
+import me.bombom.api.v1.common.ContinueReadingRankingScheduleProperties;
+import me.bombom.api.v1.common.MonthlyRankingScheduleProperties;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
+import me.bombom.api.v1.reading.domain.TodayReading;
+import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
+import me.bombom.api.v1.reading.repository.ContinueReadingSnapshotRepository;
+import me.bombom.api.v1.reading.repository.MonthlyReadingRealtimeRepository;
+import me.bombom.api.v1.reading.repository.MonthlyReadingSnapshotRepository;
+import me.bombom.api.v1.reading.repository.TodayReadingRepository;
+import me.bombom.api.v1.reading.repository.WeeklyReadingRepository;
+import me.bombom.api.v1.reading.repository.YearlyReadingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReadingServiceResetContinueReadingCountTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    @InjectMocks
+    private ReadingService readingService;
+
+    @Mock
+    private ReadingSnapshotMetaService readingSnapshotMetaService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ContinueReadingRealtimeRepository continueReadingRepository;
+
+    @Mock
+    private ContinueReadingSnapshotRepository continueReadingRankingSnapshotRepository;
+
+    @Mock
+    private TodayReadingRepository todayReadingRepository;
+
+    @Mock
+    private WeeklyReadingRepository weeklyReadingRepository;
+
+    @Mock
+    private MonthlyReadingSnapshotRepository monthlyReadingSnapshotRepository;
+
+    @Mock
+    private MonthlyReadingRealtimeRepository monthlyReadingRealtimeRepository;
+
+    @Mock
+    private YearlyReadingRepository yearlyReadingRepository;
+
+    @Mock
+    private MonthlyRankingScheduleProperties scheduleProps;
+
+    @Mock
+    private ContinueReadingRankingScheduleProperties continueReadingRankingScheduleProperties;
+
+    @Mock
+    private BadgeService badgeService;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private Clock clock;
+
+    @Test
+    void 어제가_토요일이면_연속_읽기_횟수를_초기화하지_않는다() {
+        fixClockTo(LocalDate.of(2026, 4, 26)); // Sunday
+
+        readingService.resetContinueReadingCount();
+
+        verify(todayReadingRepository, never()).findTotalNonZeroAndCurrentZero();
+    }
+
+    @Test
+    void 어제가_일요일이면_연속_읽기_횟수를_초기화하지_않는다() {
+        fixClockTo(LocalDate.of(2026, 4, 27)); // Monday
+
+        readingService.resetContinueReadingCount();
+
+        verify(todayReadingRepository, never()).findTotalNonZeroAndCurrentZero();
+    }
+
+    @Test
+    void 어제가_평일이면_기존_조건대로_연속_읽기_횟수를_초기화한다() {
+        fixClockTo(LocalDate.of(2026, 4, 28)); // Tuesday
+        TodayReading todayReading = TodayReading.builder()
+                .memberId(1L)
+                .totalCount(3)
+                .currentCount(0)
+                .build();
+        ContinueReadingRealtime continueReading = ContinueReadingRealtime.builder()
+                .memberId(1L)
+                .dayCount(10)
+                .build();
+        given(todayReadingRepository.findTotalNonZeroAndCurrentZero()).willReturn(List.of(todayReading));
+        given(continueReadingRepository.findByMemberId(1L)).willReturn(Optional.of(continueReading));
+
+        readingService.resetContinueReadingCount();
+
+        assertThat(continueReading.getDayCount()).isZero();
+    }
+
+    private void fixClockTo(LocalDate date) {
+        given(clock.instant()).willReturn(date.atStartOfDay(SEOUL_ZONE).toInstant());
+        given(clock.getZone()).willReturn(SEOUL_ZONE);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -26,10 +26,10 @@ import me.bombom.api.v1.reading.domain.ReadingSnapshotType;
 import me.bombom.api.v1.reading.domain.TodayReading;
 import me.bombom.api.v1.reading.domain.WeeklyReading;
 import me.bombom.api.v1.reading.domain.YearlyReading;
-import me.bombom.api.v1.reading.dto.response.MemberMonthlyReadingRankResponse;
-import me.bombom.api.v1.reading.dto.response.MonthlyReadingRankingResponse;
 import me.bombom.api.v1.reading.dto.response.ContinueReadingRankingResponse;
 import me.bombom.api.v1.reading.dto.response.MemberContinueReadingRankResponse;
+import me.bombom.api.v1.reading.dto.response.MemberMonthlyReadingRankResponse;
+import me.bombom.api.v1.reading.dto.response.MonthlyReadingRankingResponse;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingSnapshotRepository;
 import me.bombom.api.v1.reading.repository.MonthlyReadingRealtimeRepository;
@@ -329,13 +329,14 @@ class ReadingServiceTest {
     void 연속_읽기_초기화_후에도_최대_스트릭_일수는_유지된다() {
         ContinueReadingRealtime cr = continueReadingRepository.findByMemberId(member.getId()).get();
         int initialMaxDayCount = cr.getMaxDayCount();
+        int initialDayCount = cr.getDayCount();
 
         readingService.resetContinueReadingCount();
 
         ContinueReadingRealtime updatedContinueReadingRealtime = continueReadingRepository.findByMemberId(member.getId()).get();
 
         assertSoftly(softly -> {
-            softly.assertThat(updatedContinueReadingRealtime.getDayCount()).isZero();
+            softly.assertThat(updatedContinueReadingRealtime.getDayCount()).isEqualTo(initialDayCount);
             softly.assertThat(updatedContinueReadingRealtime.getMaxDayCount()).isEqualTo(initialMaxDayCount);
         });
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/service/NewsletterSubscriptionCountServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/subscribe/service/NewsletterSubscriptionCountServiceTest.java
@@ -1,0 +1,89 @@
+package me.bombom.api.v1.subscribe.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import me.bombom.api.v1.subscribe.domain.NewsletterSubscriptionCount;
+import me.bombom.api.v1.subscribe.repository.NewsletterSubscriptionCountRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@IntegrationTest
+class NewsletterSubscriptionCountServiceTest {
+
+    private static final Instant FIXED_INSTANT = Instant.parse("2026-01-01T00:00:00Z");
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    // 기준 연도 2026 기준 고정 birth dates
+    private static final LocalDate AGE_20S_BIRTH_DATE = LocalDate.of(2001, 1, 1); // age 25
+    private static final LocalDate AGE_30S_BIRTH_DATE = LocalDate.of(1991, 1, 1); // age 35
+
+    @Autowired
+    private NewsletterSubscriptionCountService newsletterSubscriptionCountService;
+
+    @Autowired
+    private NewsletterSubscriptionCountRepository newsletterSubscriptionCountRepository;
+
+    @MockitoBean
+    private Clock clock;
+
+    @BeforeEach
+    void setup() {
+        newsletterSubscriptionCountRepository.deleteAllInBatch();
+        given(clock.instant()).willReturn(FIXED_INSTANT);
+        given(clock.getZone()).willReturn(SEOUL_ZONE);
+    }
+
+    @Test
+    void 생년월일이_없으면_구독자_수를_업데이트하지_않는다() {
+        newsletterSubscriptionCountService.updateNewsletterSubscriptionCount(1L, null);
+
+        assertThat(newsletterSubscriptionCountRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    void 최초_구독시_새_행을_생성하고_해당_연령대와_total을_1로_설정한다() {
+        newsletterSubscriptionCountService.updateNewsletterSubscriptionCount(1L, AGE_20S_BIRTH_DATE);
+
+        List<NewsletterSubscriptionCount> result = newsletterSubscriptionCountRepository.findAll();
+        assertSoftly(softly -> {
+            softly.assertThat(result).hasSize(1);
+            softly.assertThat(result.getFirst().getTotal()).isEqualTo(1);
+            softly.assertThat(result.getFirst().getAge20s()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void 동일_뉴스레터에_재호출_시_total과_연령대_수가_누적된다() {
+        newsletterSubscriptionCountService.updateNewsletterSubscriptionCount(1L, AGE_20S_BIRTH_DATE);
+        newsletterSubscriptionCountService.updateNewsletterSubscriptionCount(1L, AGE_20S_BIRTH_DATE);
+
+        NewsletterSubscriptionCount result = newsletterSubscriptionCountRepository.findAll().getFirst();
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotal()).isEqualTo(2);
+            softly.assertThat(result.getAge20s()).isEqualTo(2);
+        });
+    }
+
+    @Test
+    void 연령대가_다른_두_구독자가_구독하면_각_연령대_컬럼과_total이_증가한다() {
+        newsletterSubscriptionCountService.updateNewsletterSubscriptionCount(1L, AGE_20S_BIRTH_DATE);
+        newsletterSubscriptionCountService.updateNewsletterSubscriptionCount(1L, AGE_30S_BIRTH_DATE);
+
+        NewsletterSubscriptionCount result = newsletterSubscriptionCountRepository.findAll().getFirst();
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotal()).isEqualTo(2);
+            softly.assertThat(result.getAge20s()).isEqualTo(1);
+            softly.assertThat(result.getAge30s()).isEqualTo(1);
+        });
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
매일메일 구독 시 NewsletterSubscriptionCount에 연령대별 구독자 수를 집계합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존 외부 뉴스레터는 이메일 서버에서 구독 이벤트를 받아 집계했지만, 매일메일은 자체 발행 뉴스레터라 내부에서 직접 집계가 필요했습니다.  

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- **AgeGroup enum 추가**: 생년월일 기반으로 연령대를 계산하고 DB 컬럼 키(age0s ~ age60plus)를 반환                                                                              
- **NewsletterSubscriptionCountRepository에 MySQL INSERT ... ON DUPLICATE KEY UPDATE 쿼리 추가**: IF(:ageGroup = ...) 조건으로 단일 쿼리에서 원자적 UPSERT 처리
- **NewsletterSubscriptionCountService 추가**: 생년월일이 없는 멤버는 집계에서 제외                                                                                             
- **매일메일 구독 트랜잭션 커밋 후 `@Async` `@TransactionalEventListener`로 집계 처리**: 집계 실패가 구독 응답에 영향을 주지 않도록, 집계 시간이 응답 시간에 영향을 주지 않도록 분리                                            
- **MaeilMailSubscribeService.subscribe() 파라미터를 `Long memberId` → `Member member`로 변경**: 컨트롤러에서 이미 보유한 Member 객체의 birthDate를 이벤트에 직접 전달해 불필요한 DB 조회 제거 

대부분 이메일 서버의 로직을 그대로 가져왔습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
