### PR TITLE
[BOM-1098] fix: 주말에는 스트릭이 초기화 되지 않도록 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -125,8 +125,8 @@ public class ReadingService {
 
     @Transactional
     public void resetContinueReadingCount() {
-        LocalDate targetDate = LocalDate.now(clock).minusDays(1);
-        if (isWeekend(targetDate)) {
+        LocalDate yesterday = LocalDate.now(clock).minusDays(1);
+        if (isWeekend(yesterday)) {
             return;
         }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.reading.service;
 
 import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -124,6 +125,11 @@ public class ReadingService {
 
     @Transactional
     public void resetContinueReadingCount() {
+        LocalDate targetDate = LocalDate.now(clock).minusDays(1);
+        if (isWeekend(targetDate)) {
+            return;
+        }
+
         todayReadingRepository.findTotalNonZeroAndCurrentZero()
                 .forEach(this::applyResetContinueReadingCount);
     }
@@ -474,5 +480,10 @@ public class ReadingService {
 
     private boolean canIncreaseContinueReadingCount(TodayReading todayReading) {
         return todayReading.getCurrentCount() == 0;
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
@@ -1,0 +1,125 @@
+package me.bombom.api.v1.reading.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import me.bombom.api.v1.badge.service.BadgeService;
+import me.bombom.api.v1.common.ContinueReadingRankingScheduleProperties;
+import me.bombom.api.v1.common.MonthlyRankingScheduleProperties;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
+import me.bombom.api.v1.reading.domain.TodayReading;
+import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
+import me.bombom.api.v1.reading.repository.ContinueReadingSnapshotRepository;
+import me.bombom.api.v1.reading.repository.MonthlyReadingRealtimeRepository;
+import me.bombom.api.v1.reading.repository.MonthlyReadingSnapshotRepository;
+import me.bombom.api.v1.reading.repository.TodayReadingRepository;
+import me.bombom.api.v1.reading.repository.WeeklyReadingRepository;
+import me.bombom.api.v1.reading.repository.YearlyReadingRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReadingServiceResetContinueReadingCountTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+
+    @InjectMocks
+    private ReadingService readingService;
+
+    @Mock
+    private ReadingSnapshotMetaService readingSnapshotMetaService;
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private ContinueReadingRealtimeRepository continueReadingRepository;
+
+    @Mock
+    private ContinueReadingSnapshotRepository continueReadingRankingSnapshotRepository;
+
+    @Mock
+    private TodayReadingRepository todayReadingRepository;
+
+    @Mock
+    private WeeklyReadingRepository weeklyReadingRepository;
+
+    @Mock
+    private MonthlyReadingSnapshotRepository monthlyReadingSnapshotRepository;
+
+    @Mock
+    private MonthlyReadingRealtimeRepository monthlyReadingRealtimeRepository;
+
+    @Mock
+    private YearlyReadingRepository yearlyReadingRepository;
+
+    @Mock
+    private MonthlyRankingScheduleProperties scheduleProps;
+
+    @Mock
+    private ContinueReadingRankingScheduleProperties continueReadingRankingScheduleProperties;
+
+    @Mock
+    private BadgeService badgeService;
+
+    @Mock
+    private ApplicationEventPublisher applicationEventPublisher;
+
+    @Mock
+    private Clock clock;
+
+    @Test
+    void 어제가_토요일이면_연속_읽기_횟수를_초기화하지_않는다() {
+        fixClockTo(LocalDate.of(2026, 4, 26)); // Sunday
+
+        readingService.resetContinueReadingCount();
+
+        verify(todayReadingRepository, never()).findTotalNonZeroAndCurrentZero();
+    }
+
+    @Test
+    void 어제가_일요일이면_연속_읽기_횟수를_초기화하지_않는다() {
+        fixClockTo(LocalDate.of(2026, 4, 27)); // Monday
+
+        readingService.resetContinueReadingCount();
+
+        verify(todayReadingRepository, never()).findTotalNonZeroAndCurrentZero();
+    }
+
+    @Test
+    void 어제가_평일이면_기존_조건대로_연속_읽기_횟수를_초기화한다() {
+        fixClockTo(LocalDate.of(2026, 4, 28)); // Tuesday
+        TodayReading todayReading = TodayReading.builder()
+                .memberId(1L)
+                .totalCount(3)
+                .currentCount(0)
+                .build();
+        ContinueReadingRealtime continueReading = ContinueReadingRealtime.builder()
+                .memberId(1L)
+                .dayCount(10)
+                .build();
+        given(todayReadingRepository.findTotalNonZeroAndCurrentZero()).willReturn(List.of(todayReading));
+        given(continueReadingRepository.findByMemberId(1L)).willReturn(Optional.of(continueReading));
+
+        readingService.resetContinueReadingCount();
+
+        assertThat(continueReading.getDayCount()).isZero();
+    }
+
+    private void fixClockTo(LocalDate date) {
+        given(clock.instant()).willReturn(date.atStartOfDay(SEOUL_ZONE).toInstant());
+        given(clock.getZone()).willReturn(SEOUL_ZONE);
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
주말에는 서비스 이용자가 적고 종종 불규칙적으로 뉴스레터가 수신되어 대부분의 유저가 스트릭이 깨지는 현상이 발생함

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

이전에도 주말에 깜짝 뉴스레터 때문에 스트릭이 끊기는 것을 문제라고 인식하고 있었고 이제는 랭킹에도 보이기 때문에 불필요한 의욕 상실이 발생하지 않도록 주말에는 스트릭이 초기화 되지 않도록 하는 것을 팀원들에게 공유하였고 모두 공감함


## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

스트릭 초기화 로직에서 초기화 대상 날짜를 `현재 날짜 - 1일`로 계산했습니다.
해당 날짜가 토요일 또는 일요일이면 스트릭 초기화 로직을 실행하지 않고 바로 반환하도록 처리했습니다.

<before>
- 매일 정해진 시각에 스트릭 초기화 수행

<after>
- 어제가 토요일이면 스트릭 초기화를 수행하지 않음
- 어제가 일요일이면 스트릭 초기화를 수행하지 않음
- 어제가 평일이면 기존 조건대로 스트릭 초기화를 수행함 

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 곧 주말이라 주말 스트릭 초기화 되기전에 머지를 해야해서 D-0으로 설정했습니다.
- 간단한 변경이니 오늘(금)내에 봐주시면 감사합니다.