### PR TITLE
[BOM-1103] chore: 로컬 환경에서의 logback 설정 추가

### DIFF
--- a/backend/bom-bom-server/src/main/resources/logback-spring.xml
+++ b/backend/bom-bom-server/src/main/resources/logback-spring.xml
@@ -12,4 +12,15 @@
         <include resource="logback-prod.xml"/>
     </springProfile>
 
+    <springProfile name="!dev &amp; !prod">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+
 </configuration>


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
로컬 환경에서의 logback 설정을 추가했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
<img width="1283" height="468" alt="image" src="https://github.com/user-attachments/assets/a01fb6b6-0117-4a7e-8dd2-ab42e61e69ea" />

이게 놀랍게도 실행 중인 서버 로그입니다,,

 logback-spring.xml이 dev, prod 프로파일에 대해서만 appender를 정의하고 있어, 로컬 환경(default 프로파일)에서는 appender가 없어 로그가 전혀 출력되지 않았습니다.  

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
`logback-spring.xml`에 `!dev & !prod` 조건의 springProfile 블록을 추가해 로컬 환경에서 단순 콘솔 appender가 활성화되도록 했습니다. 파일 로깅은 로컬에서 불필요하므로 콘솔 출력만 설정했습니다.
기존  `logback-dev.xml`, 나 `logback-prod.xml`를 활용하도록 `application.yml`에서 profile을 설정할 수 있지만, 그렇게 하면 파일 로깅도 추가되어 새롭게 설정을 추가했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
개발 환경의 경우엔 `logback-dev.xml`, 운영 환경의 경우엔 `logback-prod.xml`이 존재하는데, 
로컬 환경은 설정이 간단하고 자주 수정하지 않을거 같아 `logback-spring.xml`에 추가했습니다.
이 방식이 괜찮을까용?