### PR TITLE
[BOM-1090] feat: 매일메일 발행 로직 구현

### DIFF
--- a/backend/mail-server/.gitignore
+++ b/backend/mail-server/.gitignore
@@ -1,6 +1,7 @@
 HELP.md
 .gradle
 build/
+src/main/generated/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/backend/mail-server/build.gradle.kts
+++ b/backend/mail-server/build.gradle.kts
@@ -44,6 +44,10 @@ dependencies {
     // spring mail
     implementation("org.springframework.boot:spring-boot-starter-mail")
 
+    // shedlock
+    implementation("net.javacrumbs.shedlock:shedlock-spring:6.9.2")
+    implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.9.2")
+
     // html parser
     implementation("org.jsoup:jsoup:1.21.2")
     implementation("ch.digitalfondue.jfiveparse:jfiveparse:1.1.4")

--- a/backend/mail-server/build.gradle.kts
+++ b/backend/mail-server/build.gradle.kts
@@ -30,6 +30,10 @@ dependencies {
 
     // jpa
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+    annotationProcessor("com.querydsl:querydsl-apt:5.1.0:jakarta")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 
     // lombok
     compileOnly("org.projectlombok:lombok")

--- a/backend/mail-server/src/main/java/news/bombomemail/article/event/ArticleArrivedEvent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/event/ArticleArrivedEvent.java
@@ -1,7 +1,5 @@
 package news.bombomemail.article.event;
 
-import jakarta.mail.internet.MimeMessage;
-
 public record ArticleArrivedEvent(
         Long newsletterId,
         String newsletterName,
@@ -9,8 +7,8 @@ public record ArticleArrivedEvent(
         String articleTitle,
         Long memberId,
         String unsubscribeUrl,
-        MimeMessage message,
-        String contents
+        String contents,
+        ArticleSource source
 ) {
     public static ArticleArrivedEvent of(
             Long newsletterId,
@@ -19,8 +17,8 @@ public record ArticleArrivedEvent(
             String articleTitle,
             Long memberId,
             String unsubscribeUrl,
-            MimeMessage message,
-            String contents
+            String contents,
+            ArticleSource source
     ) {
         return new ArticleArrivedEvent(
                 newsletterId,
@@ -29,8 +27,8 @@ public record ArticleArrivedEvent(
                 articleTitle,
                 memberId,
                 unsubscribeUrl,
-                message,
-                contents
+                contents,
+                source
         );
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/article/event/ArticleSource.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/event/ArticleSource.java
@@ -1,0 +1,7 @@
+package news.bombomemail.article.event;
+
+public enum ArticleSource {
+
+    EMAIL_RECEIVED,
+    MAEIL_MAIL_ISSUED
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/article/event/RecentArticleEventListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/event/RecentArticleEventListener.java
@@ -18,7 +18,7 @@ public class RecentArticleEventListener {
         try {
             recentArticleService.save(
                     event.articleId(),
-                    event.message(),
+                    event.articleTitle(),
                     event.contents(),
                     event.memberId(),
                     event.newsletterId()

--- a/backend/mail-server/src/main/java/news/bombomemail/article/service/ArticleService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/service/ArticleService.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import news.bombomemail.article.event.ArticleSource;
 import news.bombomemail.article.domain.Article;
 import news.bombomemail.article.event.ArticleArrivedEvent;
 import news.bombomemail.article.repository.ArticleRepository;
@@ -64,8 +65,8 @@ public class ArticleService {
                         article.getTitle(),
                         member.getId(),
                         unsubscribeUrl,
-                        message,
-                        contents
+                        contents,
+                        ArticleSource.EMAIL_RECEIVED
                 )
         );
         return true;

--- a/backend/mail-server/src/main/java/news/bombomemail/article/service/RecentArticleService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/service/RecentArticleService.java
@@ -1,7 +1,7 @@
 package news.bombomemail.article.service;
 
+import java.time.Clock;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombomemail.article.domain.RecentArticle;
@@ -21,6 +21,7 @@ public class RecentArticleService {
 
     private final HtmlTagCleaner htmlTagCleaner;
     private final RecentArticleRepository recentArticleRepository;
+    private final Clock clock;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void save(
@@ -49,7 +50,7 @@ public class RecentArticleService {
                 .contentsSummary(SummaryGenerator.summarize(contents))
                 .memberId(memberId)
                 .newsletterId(newsletterId)
-                .arrivedDateTime(LocalDateTime.now(ZoneId.of("Asia/Seoul")))
+                .arrivedDateTime(LocalDateTime.now(clock))
                 .build();
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/article/service/RecentArticleService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/service/RecentArticleService.java
@@ -1,7 +1,5 @@
 package news.bombomemail.article.service;
 
-import jakarta.mail.MessagingException;
-import jakarta.mail.internet.MimeMessage;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
@@ -27,25 +25,24 @@ public class RecentArticleService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void save(
             Long articleId,
-            MimeMessage message,
+            String articleTitle,
             String contents,
             Long memberId,
             Long newsletterId
-    )
-            throws MessagingException {
-        recentArticleRepository.save(buildRecentArticle(articleId, message, contents, memberId, newsletterId));
+    ) {
+        recentArticleRepository.save(buildRecentArticle(articleId, articleTitle, contents, memberId, newsletterId));
     }
 
     private RecentArticle buildRecentArticle(
             Long articleId,
-            MimeMessage message,
+            String articleTitle,
             String contents,
             Long memberId,
             Long newsletterId
-    ) throws MessagingException {
+    ) {
         return RecentArticle.builder()
                 .articleId(articleId)
-                .title(message.getSubject())
+                .title(articleTitle)
                 .contents(contents)
                 .contentsText(htmlTagCleaner.clean(contents))
                 .expectedReadTime(ReadingTimeCalculator.calculate(contents))

--- a/backend/mail-server/src/main/java/news/bombomemail/common/RandomConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/RandomConfig.java
@@ -1,0 +1,14 @@
+package news.bombomemail.common;
+
+import java.util.Random;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RandomConfig {
+
+    @Bean
+    public Random random() {
+        return new Random();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/common/SchedulingConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/SchedulingConfig.java
@@ -1,9 +1,25 @@
 package news.bombomemail.common;
 
+import javax.sql.DataSource;
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "PT30M")
 public class SchedulingConfig {
+
+    @Bean
+    public LockProvider lockProvider(DataSource dataSource) {
+        return new JdbcTemplateLockProvider(
+                JdbcTemplateLockProvider.Configuration.builder()
+                        .withJdbcTemplate(new JdbcTemplate(dataSource))
+                        .usingDbTime()
+                        .build());
+    }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/common/TimeConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/TimeConfig.java
@@ -1,0 +1,15 @@
+package news.bombomemail.common;
+
+import java.time.Clock;
+import java.time.ZoneId;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailContent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailContent.java
@@ -1,0 +1,58 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombomemail.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MaeilMailContent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long topicId;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "MEDIUMTEXT")
+    private String content;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String contentsText;
+
+    @Column(nullable = false)
+    private String contentsSummary;
+
+    @Column(columnDefinition = "TINYINT", nullable = false)
+    private int expectedReadTime;
+
+    @Builder
+    public MaeilMailContent(
+            @NonNull Long topicId,
+            @NonNull String title,
+            @NonNull String content,
+            @NonNull String contentsText,
+            @NonNull String contentsSummary,
+            int expectedReadTime
+    ) {
+        this.topicId = topicId;
+        this.title = title;
+        this.content = content;
+        this.contentsText = contentsText;
+        this.contentsSummary = contentsSummary;
+        this.expectedReadTime = expectedReadTime;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailContent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailContent.java
@@ -24,7 +24,7 @@ public class MaeilMailContent extends BaseEntity {
     @Column(nullable = false)
     private Long topicId;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 50)
     private String title;
 
     @Column(nullable = false, columnDefinition = "MEDIUMTEXT")
@@ -33,7 +33,7 @@ public class MaeilMailContent extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String contentsText;
 
-    @Column(nullable = false)
+    @Column(nullable = false, length = 100)
     private String contentsSummary;
 
     @Column(columnDefinition = "TINYINT", nullable = false)

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueHistory.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueHistory.java
@@ -7,7 +7,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,8 +17,8 @@ import lombok.NonNull;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = @UniqueConstraint(
-        name = "uk_maeil_mail_issue_history_date_member_topic",
-        columnNames = {"issue_date", "member_id", "topic_id"}
+        name = "uk_maeil_mail_issue_history_article_id",
+        columnNames = "article_id"
 ))
 public class MaeilMailIssueHistory {
 
@@ -28,22 +27,17 @@ public class MaeilMailIssueHistory {
     private Long id;
 
     @Column(nullable = false)
-    private LocalDate issueDate;
+    private Long articleId;
 
     @Column(nullable = false)
-    private Long memberId;
-
-    @Column(nullable = false)
-    private Long topicId;
+    private Long contentId;
 
     @Builder
     public MaeilMailIssueHistory(
-            @NonNull LocalDate issueDate,
-            @NonNull Long memberId,
-            @NonNull Long topicId
+            @NonNull Long articleId,
+            @NonNull Long contentId
     ) {
-        this.issueDate = issueDate;
-        this.memberId = memberId;
-        this.topicId = topicId;
+        this.articleId = articleId;
+        this.contentId = contentId;
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueHistory.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueHistory.java
@@ -1,0 +1,49 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_maeil_mail_issue_history_date_member_topic",
+        columnNames = {"issue_date", "member_id", "topic_id"}
+))
+public class MaeilMailIssueHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate issueDate;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Long topicId;
+
+    @Builder
+    public MaeilMailIssueHistory(
+            @NonNull LocalDate issueDate,
+            @NonNull Long memberId,
+            @NonNull Long topicId
+    ) {
+        this.issueDate = issueDate;
+        this.memberId = memberId;
+        this.topicId = topicId;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJob.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJob.java
@@ -1,0 +1,134 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombomemail.common.BaseEntity;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_maeil_mail_issue_job_issue_date",
+        columnNames = "issue_date"
+))
+public class MaeilMailIssueJob extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private LocalDate issueDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private MaeilMailIssueJobStatus status;
+
+    @Column(nullable = false)
+    private Long lastProcessedTrackId;
+
+    @Column(nullable = false)
+    private long chunkCount;
+
+    @Column(nullable = false)
+    private long processedTrackCount;
+
+    @Column(nullable = false)
+    private long issuedArticleCount;
+
+    @Column(nullable = false)
+    private long previouslyIssuedTrackCount;
+
+    @Column(length = 1000)
+    private String failedMessage;
+
+    @Column(nullable = false)
+    private LocalDateTime startedAt;
+
+    private LocalDateTime completedAt;
+
+    private LocalDateTime failedAt;
+
+    private MaeilMailIssueJob(
+            @NonNull LocalDate issueDate,
+            @NonNull Long startTrackId,
+            @NonNull LocalDateTime startedAt
+    ) {
+        this.issueDate = issueDate;
+        this.status = MaeilMailIssueJobStatus.RUNNING;
+        this.lastProcessedTrackId = startTrackId;
+        this.startedAt = startedAt;
+    }
+
+    public static MaeilMailIssueJob start(
+            LocalDate issueDate,
+            Long startTrackId,
+            LocalDateTime startedAt
+    ) {
+        return new MaeilMailIssueJob(issueDate, startTrackId, startedAt);
+    }
+
+    public boolean isCompleted() {
+        return status == MaeilMailIssueJobStatus.COMPLETED;
+    }
+
+    public void resume(LocalDateTime startedAt) {
+        if (isCompleted()) {
+            return;
+        }
+
+        this.status = MaeilMailIssueJobStatus.RUNNING;
+        this.failedMessage = null;
+        this.failedAt = null;
+        if (this.startedAt == null) {
+            this.startedAt = startedAt;
+        }
+    }
+
+    public void recordChunk(IssueChunkResult result) {
+        if (!result.hasTracks()) {
+            return;
+        }
+
+        if (status != MaeilMailIssueJobStatus.RUNNING) {
+            throw new IllegalStateException("실행 중인 매일메일 발행 job만 chunk 결과를 기록할 수 있습니다. jobId=" + id);
+        }
+
+        this.lastProcessedTrackId = result.lastTrackId();
+        this.chunkCount++;
+        this.processedTrackCount += result.trackCount();
+        this.issuedArticleCount += result.issuedArticleCount();
+        this.previouslyIssuedTrackCount += result.previouslyIssuedTrackCount();
+    }
+
+    public void complete(LocalDateTime completedAt) {
+        this.status = MaeilMailIssueJobStatus.COMPLETED;
+        this.completedAt = completedAt;
+        this.failedMessage = null;
+        this.failedAt = null;
+    }
+
+    public void fail(String failedMessage, LocalDateTime failedAt) {
+        if (isCompleted()) {
+            return;
+        }
+
+        this.status = MaeilMailIssueJobStatus.FAILED;
+        this.failedMessage = failedMessage;
+        this.failedAt = failedAt;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJob.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJob.java
@@ -101,13 +101,13 @@ public class MaeilMailIssueJob extends BaseEntity {
         }
     }
 
-    public void recordChunk(IssueChunkResult result) {
+    public void recordPublishedChunk(IssueChunkResult result) {
         if (!result.hasTracks()) {
             return;
         }
 
         if (status != MaeilMailIssueJobStatus.RUNNING) {
-            throw new IllegalStateException("실행 중인 매일메일 발행 job만 chunk 결과를 기록할 수 있습니다. jobId=" + id);
+            throw new IllegalStateException("실행 중인 매일메일 발행 job만 발행 chunk 결과를 기록할 수 있습니다. jobId=" + id);
         }
 
         this.lastProcessedTrackId = result.lastTrackId();

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJob.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJob.java
@@ -118,6 +118,14 @@ public class MaeilMailIssueJob extends BaseEntity {
     }
 
     public void complete(LocalDateTime completedAt) {
+        if (isCompleted()) {
+            return;
+        }
+
+        if (status != MaeilMailIssueJobStatus.RUNNING) {
+            throw new IllegalStateException("실행 중인 매일메일 발행 job만 완료할 수 있습니다. jobId=" + id);
+        }
+
         this.status = MaeilMailIssueJobStatus.COMPLETED;
         this.completedAt = completedAt;
         this.failedMessage = null;

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJob.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJob.java
@@ -27,6 +27,8 @@ import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
 ))
 public class MaeilMailIssueJob extends BaseEntity {
 
+    private static final int MAX_FAILED_MESSAGE_LENGTH = 1000;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -128,7 +130,14 @@ public class MaeilMailIssueJob extends BaseEntity {
         }
 
         this.status = MaeilMailIssueJobStatus.FAILED;
-        this.failedMessage = failedMessage;
+        this.failedMessage = truncateFailedMessage(failedMessage);
         this.failedAt = failedAt;
+    }
+
+    private String truncateFailedMessage(String failedMessage) {
+        if (failedMessage == null || failedMessage.length() <= MAX_FAILED_MESSAGE_LENGTH) {
+            return failedMessage;
+        }
+        return failedMessage.substring(0, MAX_FAILED_MESSAGE_LENGTH);
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobStatus.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobStatus.java
@@ -1,0 +1,8 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+public enum MaeilMailIssueJobStatus {
+
+    RUNNING,
+    COMPLETED,
+    FAILED
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailSentContent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailSentContent.java
@@ -1,0 +1,49 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombomemail.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_maeil_mail_sent_content",
+        columnNames = {"member_id", "topic_id", "content_id"}
+))
+public class MaeilMailSentContent extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Long topicId;
+
+    @Column(nullable = false)
+    private Long contentId;
+
+    @Builder
+    public MaeilMailSentContent(
+            @NonNull Long memberId,
+            @NonNull Long topicId,
+            @NonNull Long contentId
+    ) {
+        this.memberId = memberId;
+        this.topicId = topicId;
+        this.contentId = contentId;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailSubscriptionTrack.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailSubscriptionTrack.java
@@ -1,0 +1,53 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "uk_maeil_mail_subscription_track_subscribe_id_field",
+        columnNames = {"subscribe_id", "field"}
+))
+public class MaeilMailSubscriptionTrack {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long subscribeId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 3)
+    private MaeilMailTrack field;
+
+    @Column(nullable = false)
+    private int curriculumIndex = 0;
+
+    private LocalDate lastIssuedDate;
+
+    @Builder
+    public MaeilMailSubscriptionTrack(Long subscribeId, Long memberId, MaeilMailTrack field) {
+        this.subscribeId = subscribeId;
+        this.memberId = memberId;
+        this.field = field;
+        this.curriculumIndex = 0;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailTopic.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailTopic.java
@@ -1,0 +1,52 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import news.bombomemail.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "uk_maeil_mail_topic_track_name", columnNames = {"track", "name"}),
+        @UniqueConstraint(name = "uk_maeil_mail_topic_track_order", columnNames = {"track", "display_order"})
+})
+public class MaeilMailTopic extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 3)
+    private MaeilMailTrack track;
+
+    @Column(nullable = false, length = 50)
+    private String name;
+
+    @Column(nullable = false)
+    private int displayOrder;
+
+    @Builder
+    public MaeilMailTopic(
+            @NonNull MaeilMailTrack track,
+            @NonNull String name,
+            int displayOrder
+    ) {
+        this.track = track;
+        this.name = name;
+        this.displayOrder = displayOrder;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailTrack.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailTrack.java
@@ -1,0 +1,7 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+public enum MaeilMailTrack {
+
+    BE,
+    FE
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueChunkResult.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueChunkResult.java
@@ -1,0 +1,23 @@
+package news.bombomemail.nativenewsletter.maeilmail.dto;
+
+public record IssueChunkResult(
+        boolean hasTracks,
+        Long lastTrackId,
+        int trackCount,
+        int issuedArticleCount,
+        int previouslyIssuedTrackCount
+) {
+
+    public static IssueChunkResult empty() {
+        return new IssueChunkResult(false, null, 0, 0, 0);
+    }
+
+    public static IssueChunkResult of(
+            Long lastTrackId,
+            int trackCount,
+            int issuedArticleCount,
+            int previouslyIssuedTrackCount
+    ) {
+        return new IssueChunkResult(true, lastTrackId, trackCount, issuedArticleCount, previouslyIssuedTrackCount);
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueData.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueData.java
@@ -1,0 +1,15 @@
+package news.bombomemail.nativenewsletter.maeilmail.dto;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
+
+public record IssueData(
+        Map<Long, MaeilMailTopic> issueTopicsByTrackId,
+        Map<Long, List<Long>> contentIdsByTopicId,
+        Map<MemberTopicKey, List<Long>> sentContentIdsByMemberTopic,
+        Set<MemberTopicKey> issuedMemberTopicKeys,
+        Long newsletterId
+) {
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueEntry.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueEntry.java
@@ -1,17 +1,23 @@
 package news.bombomemail.nativenewsletter.maeilmail.dto;
 
 import java.util.List;
+import java.util.Objects;
 import news.bombomemail.article.domain.Article;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
 
 public record IssueEntry(
         Article article,
         List<Long> trackIds,
-        MaeilMailSentContent sentContent,
-        Long contentId
+        MaeilMailSentContent sentContent
 ) {
 
     public IssueEntry {
-        trackIds = List.copyOf(trackIds);
+        article = Objects.requireNonNull(article);
+        trackIds = List.copyOf(Objects.requireNonNull(trackIds));
+        sentContent = Objects.requireNonNull(sentContent);
+    }
+
+    public Long contentId() {
+        return sentContent.getContentId();
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueEntry.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueEntry.java
@@ -1,0 +1,16 @@
+package news.bombomemail.nativenewsletter.maeilmail.dto;
+
+import java.util.List;
+import news.bombomemail.article.domain.Article;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+
+public record IssueEntry(
+        Article article,
+        List<Long> trackIds,
+        MaeilMailSentContent sentContent
+) {
+
+    public IssueEntry {
+        trackIds = List.copyOf(trackIds);
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueEntry.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueEntry.java
@@ -7,7 +7,8 @@ import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
 public record IssueEntry(
         Article article,
         List<Long> trackIds,
-        MaeilMailSentContent sentContent
+        MaeilMailSentContent sentContent,
+        Long contentId
 ) {
 
     public IssueEntry {

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/MemberTopicKey.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/MemberTopicKey.java
@@ -1,0 +1,4 @@
+package news.bombomemail.nativenewsletter.maeilmail.dto;
+
+public record MemberTopicKey(Long memberId, Long topicId) {
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/PreparedIssueEntries.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/PreparedIssueEntries.java
@@ -1,0 +1,13 @@
+package news.bombomemail.nativenewsletter.maeilmail.dto;
+
+import java.util.List;
+
+public record PreparedIssueEntries(
+        List<IssueEntry> entries,
+        List<Long> previouslyIssuedTrackIds
+) {
+
+    public boolean isEmpty() {
+        return entries.isEmpty() && previouslyIssuedTrackIds.isEmpty();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/TopicContentId.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/TopicContentId.java
@@ -1,0 +1,7 @@
+package news.bombomemail.nativenewsletter.maeilmail.dto;
+
+public record TopicContentId(
+        Long topicId,
+        Long contentId
+) {
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/CustomMaeilMailIssueHistoryRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/CustomMaeilMailIssueHistoryRepository.java
@@ -1,0 +1,14 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.Set;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+
+public interface CustomMaeilMailIssueHistoryRepository {
+
+    Set<MemberTopicKey> findIssuedMemberTopicKeys(
+            LocalDate issueDate,
+            Collection<MemberTopicKey> keys
+    );
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/CustomMaeilMailSentContentRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/CustomMaeilMailSentContentRepository.java
@@ -1,0 +1,11 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import java.util.Collection;
+import java.util.List;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+
+public interface CustomMaeilMailSentContentRepository {
+
+    List<MaeilMailSentContent> findAllByMemberTopicKeys(Collection<MemberTopicKey> keys);
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailContentRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailContentRepository.java
@@ -1,0 +1,19 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import java.util.Collection;
+import java.util.List;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailContent;
+import news.bombomemail.nativenewsletter.maeilmail.dto.TopicContentId;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface MaeilMailContentRepository extends JpaRepository<MaeilMailContent, Long> {
+
+    @Query("""
+            SELECT new news.bombomemail.nativenewsletter.maeilmail.dto.TopicContentId(c.topicId, c.id)
+            FROM MaeilMailContent c
+            WHERE c.topicId IN :topicIds
+            """)
+    List<TopicContentId> findContentIdsByTopicIdIn(@Param("topicIds") Collection<Long> topicIds);
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepository.java
@@ -1,0 +1,8 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MaeilMailIssueHistoryRepository
+        extends JpaRepository<MaeilMailIssueHistory, Long>, CustomMaeilMailIssueHistoryRepository {
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepositoryImpl.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepositoryImpl.java
@@ -1,0 +1,56 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+
+@RequiredArgsConstructor
+public class MaeilMailIssueHistoryRepositoryImpl implements CustomMaeilMailIssueHistoryRepository {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public Set<MemberTopicKey> findIssuedMemberTopicKeys(
+            LocalDate issueDate,
+            Collection<MemberTopicKey> keys
+    ) {
+        if (keys.isEmpty()) {
+            return Set.of();
+        }
+
+        Set<MemberTopicKey> targetKeys = Set.copyOf(keys);
+        Set<Long> memberIds = extractMemberIds(targetKeys);
+        Set<Long> topicIds = extractTopicIds(targetKeys);
+        return entityManager.createQuery("""
+                        SELECT h FROM MaeilMailIssueHistory h
+                        WHERE h.issueDate = :issueDate
+                        AND h.memberId IN :memberIds
+                        AND h.topicId IN :topicIds
+                        """, MaeilMailIssueHistory.class)
+                .setParameter("issueDate", issueDate)
+                .setParameter("memberIds", memberIds)
+                .setParameter("topicIds", topicIds)
+                .getResultList()
+                .stream()
+                .map(history -> new MemberTopicKey(history.getMemberId(), history.getTopicId()))
+                .filter(targetKeys::contains)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Set<Long> extractMemberIds(Collection<MemberTopicKey> keys) {
+        return keys.stream()
+                .map(MemberTopicKey::memberId)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Set<Long> extractTopicIds(Collection<MemberTopicKey> keys) {
+        return keys.stream()
+                .map(MemberTopicKey::topicId)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepositoryImpl.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepositoryImpl.java
@@ -2,11 +2,11 @@ package news.bombomemail.nativenewsletter.maeilmail.repository;
 
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
 import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
 
 @RequiredArgsConstructor
@@ -26,18 +26,27 @@ public class MaeilMailIssueHistoryRepositoryImpl implements CustomMaeilMailIssue
         Set<MemberTopicKey> targetKeys = Set.copyOf(keys);
         Set<Long> memberIds = extractMemberIds(targetKeys);
         Set<Long> topicIds = extractTopicIds(targetKeys);
+        LocalDateTime startOfDay = issueDate.atStartOfDay();
+        LocalDateTime nextDay = issueDate.plusDays(1).atStartOfDay();
         return entityManager.createQuery("""
-                        SELECT h FROM MaeilMailIssueHistory h
-                        WHERE h.issueDate = :issueDate
-                        AND h.memberId IN :memberIds
-                        AND h.topicId IN :topicIds
-                        """, MaeilMailIssueHistory.class)
-                .setParameter("issueDate", issueDate)
+                        SELECT new news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey(
+                            a.memberId,
+                            c.topicId
+                        )
+                        FROM MaeilMailIssueHistory h
+                        JOIN Article a ON a.id = h.articleId
+                        JOIN MaeilMailContent c ON c.id = h.contentId
+                        WHERE a.arrivedDateTime >= :startOfDay
+                        AND a.arrivedDateTime < :nextDay
+                        AND a.memberId IN :memberIds
+                        AND c.topicId IN :topicIds
+                        """, MemberTopicKey.class)
+                .setParameter("startOfDay", startOfDay)
+                .setParameter("nextDay", nextDay)
                 .setParameter("memberIds", memberIds)
                 .setParameter("topicIds", topicIds)
                 .getResultList()
                 .stream()
-                .map(history -> new MemberTopicKey(history.getMemberId(), history.getTopicId()))
                 .filter(targetKeys::contains)
                 .collect(Collectors.toUnmodifiableSet());
     }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepositoryImpl.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepositoryImpl.java
@@ -1,5 +1,8 @@
 package news.bombomemail.nativenewsletter.maeilmail.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -7,6 +10,9 @@ import java.util.Collection;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import news.bombomemail.article.domain.QArticle;
+import news.bombomemail.nativenewsletter.maeilmail.domain.QMaeilMailContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.QMaeilMailIssueHistory;
 import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
 
 @RequiredArgsConstructor
@@ -23,43 +29,42 @@ public class MaeilMailIssueHistoryRepositoryImpl implements CustomMaeilMailIssue
             return Set.of();
         }
 
-        Set<MemberTopicKey> targetKeys = Set.copyOf(keys);
-        Set<Long> memberIds = extractMemberIds(targetKeys);
-        Set<Long> topicIds = extractTopicIds(targetKeys);
+        QMaeilMailIssueHistory issueHistory = QMaeilMailIssueHistory.maeilMailIssueHistory;
+        QArticle article = QArticle.article;
+        QMaeilMailContent content = QMaeilMailContent.maeilMailContent;
         LocalDateTime startOfDay = issueDate.atStartOfDay();
         LocalDateTime nextDay = issueDate.plusDays(1).atStartOfDay();
-        return entityManager.createQuery("""
-                        SELECT new news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey(
-                            a.memberId,
-                            c.topicId
-                        )
-                        FROM MaeilMailIssueHistory h
-                        JOIN Article a ON a.id = h.articleId
-                        JOIN MaeilMailContent c ON c.id = h.contentId
-                        WHERE a.arrivedDateTime >= :startOfDay
-                        AND a.arrivedDateTime < :nextDay
-                        AND a.memberId IN :memberIds
-                        AND c.topicId IN :topicIds
-                        """, MemberTopicKey.class)
-                .setParameter("startOfDay", startOfDay)
-                .setParameter("nextDay", nextDay)
-                .setParameter("memberIds", memberIds)
-                .setParameter("topicIds", topicIds)
-                .getResultList()
+        return new JPAQueryFactory(entityManager)
+                .select(Projections.constructor(
+                        MemberTopicKey.class,
+                        article.memberId,
+                        content.topicId
+                ))
+                .from(issueHistory)
+                .join(article).on(article.id.eq(issueHistory.articleId))
+                .join(content).on(content.id.eq(issueHistory.contentId))
+                .where(
+                        article.arrivedDateTime.goe(startOfDay),
+                        article.arrivedDateTime.lt(nextDay),
+                        memberTopicCondition(article, content, keys)
+                )
+                .fetch()
                 .stream()
-                .filter(targetKeys::contains)
                 .collect(Collectors.toUnmodifiableSet());
     }
 
-    private Set<Long> extractMemberIds(Collection<MemberTopicKey> keys) {
-        return keys.stream()
-                .map(MemberTopicKey::memberId)
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
-    private Set<Long> extractTopicIds(Collection<MemberTopicKey> keys) {
-        return keys.stream()
-                .map(MemberTopicKey::topicId)
-                .collect(Collectors.toUnmodifiableSet());
+    private BooleanBuilder memberTopicCondition(
+            QArticle article,
+            QMaeilMailContent content,
+            Collection<MemberTopicKey> keys
+    ) {
+        BooleanBuilder condition = new BooleanBuilder();
+        keys.stream()
+                .distinct()
+                .forEach(key -> condition.or(
+                        article.memberId.eq(key.memberId())
+                                .and(content.topicId.eq(key.topicId()))
+                ));
+        return condition;
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueJobRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueJobRepository.java
@@ -1,0 +1,11 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MaeilMailIssueJobRepository extends JpaRepository<MaeilMailIssueJob, Long> {
+
+    Optional<MaeilMailIssueJob> findByIssueDate(LocalDate issueDate);
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueJobRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueJobRepository.java
@@ -1,11 +1,18 @@
 package news.bombomemail.nativenewsletter.maeilmail.repository;
 
 import java.time.LocalDate;
+import java.util.Collection;
 import java.util.Optional;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJobStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MaeilMailIssueJobRepository extends JpaRepository<MaeilMailIssueJob, Long> {
 
     Optional<MaeilMailIssueJob> findByIssueDate(LocalDate issueDate);
+
+    Optional<MaeilMailIssueJob> findByIssueDateAndStatusIn(
+            LocalDate issueDate,
+            Collection<MaeilMailIssueJobStatus> statuses
+    );
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSentContentRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSentContentRepository.java
@@ -1,0 +1,12 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+
+public interface MaeilMailSentContentRepository
+        extends JpaRepository<MaeilMailSentContent, Long>, CustomMaeilMailSentContentRepository {
+
+    @Modifying
+    void deleteByMemberIdAndTopicId(Long memberId, Long topicId);
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSentContentRepositoryImpl.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSentContentRepositoryImpl.java
@@ -1,0 +1,52 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import jakarta.persistence.EntityManager;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+
+@RequiredArgsConstructor
+public class MaeilMailSentContentRepositoryImpl implements CustomMaeilMailSentContentRepository {
+
+    private final EntityManager entityManager;
+
+    @Override
+    public List<MaeilMailSentContent> findAllByMemberTopicKeys(Collection<MemberTopicKey> keys) {
+        if (keys.isEmpty()) {
+            return List.of();
+        }
+
+        Set<MemberTopicKey> targetKeys = Set.copyOf(keys);
+        Set<Long> memberIds = extractMemberIds(targetKeys);
+        Set<Long> topicIds = extractTopicIds(targetKeys);
+        return entityManager.createQuery("""
+                        SELECT s FROM MaeilMailSentContent s
+                        WHERE s.memberId IN :memberIds
+                        AND s.topicId IN :topicIds
+                        """, MaeilMailSentContent.class)
+                .setParameter("memberIds", memberIds)
+                .setParameter("topicIds", topicIds)
+                .getResultList()
+                .stream()
+                .filter(sentContent -> targetKeys.contains(
+                        new MemberTopicKey(sentContent.getMemberId(), sentContent.getTopicId())
+                ))
+                .toList();
+    }
+
+    private Set<Long> extractMemberIds(Collection<MemberTopicKey> keys) {
+        return keys.stream()
+                .map(MemberTopicKey::memberId)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private Set<Long> extractTopicIds(Collection<MemberTopicKey> keys) {
+        return keys.stream()
+                .map(MemberTopicKey::topicId)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSentContentRepositoryImpl.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSentContentRepositoryImpl.java
@@ -1,12 +1,13 @@
 package news.bombomemail.nativenewsletter.maeilmail.repository;
 
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.QMaeilMailSentContent;
 import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
 
 @RequiredArgsConstructor
@@ -20,33 +21,24 @@ public class MaeilMailSentContentRepositoryImpl implements CustomMaeilMailSentCo
             return List.of();
         }
 
-        Set<MemberTopicKey> targetKeys = Set.copyOf(keys);
-        Set<Long> memberIds = extractMemberIds(targetKeys);
-        Set<Long> topicIds = extractTopicIds(targetKeys);
-        return entityManager.createQuery("""
-                        SELECT s FROM MaeilMailSentContent s
-                        WHERE s.memberId IN :memberIds
-                        AND s.topicId IN :topicIds
-                        """, MaeilMailSentContent.class)
-                .setParameter("memberIds", memberIds)
-                .setParameter("topicIds", topicIds)
-                .getResultList()
-                .stream()
-                .filter(sentContent -> targetKeys.contains(
-                        new MemberTopicKey(sentContent.getMemberId(), sentContent.getTopicId())
-                ))
-                .toList();
+        QMaeilMailSentContent sentContent = QMaeilMailSentContent.maeilMailSentContent;
+        return new JPAQueryFactory(entityManager)
+                .selectFrom(sentContent)
+                .where(memberTopicCondition(sentContent, keys))
+                .fetch();
     }
 
-    private Set<Long> extractMemberIds(Collection<MemberTopicKey> keys) {
-        return keys.stream()
-                .map(MemberTopicKey::memberId)
-                .collect(Collectors.toUnmodifiableSet());
-    }
-
-    private Set<Long> extractTopicIds(Collection<MemberTopicKey> keys) {
-        return keys.stream()
-                .map(MemberTopicKey::topicId)
-                .collect(Collectors.toUnmodifiableSet());
+    private BooleanBuilder memberTopicCondition(
+            QMaeilMailSentContent sentContent,
+            Collection<MemberTopicKey> keys
+    ) {
+        BooleanBuilder condition = new BooleanBuilder();
+        keys.stream()
+                .distinct()
+                .forEach(key -> condition.or(
+                        sentContent.memberId.eq(key.memberId())
+                                .and(sentContent.topicId.eq(key.topicId()))
+                ));
+        return condition;
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSubscriptionTrackRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSubscriptionTrackRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 public interface MaeilMailSubscriptionTrackRepository extends JpaRepository<MaeilMailSubscriptionTrack, Long> {
 
@@ -35,7 +34,6 @@ public interface MaeilMailSubscriptionTrackRepository extends JpaRepository<Maei
             Pageable pageable
     );
 
-    @Transactional
     @Modifying
     @Query("""
             UPDATE MaeilMailSubscriptionTrack t

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSubscriptionTrackRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSubscriptionTrackRepository.java
@@ -1,0 +1,52 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.newsletter.domain.NewsletterPublicationStatus;
+import news.bombomemail.newsletter.domain.NewsletterSource;
+import news.bombomemail.subscribe.domain.SubscribeStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface MaeilMailSubscriptionTrackRepository extends JpaRepository<MaeilMailSubscriptionTrack, Long> {
+
+    @Query("""
+            SELECT t FROM MaeilMailSubscriptionTrack t
+            JOIN Subscribe s ON s.id = t.subscribeId
+            JOIN Newsletter n ON n.id = s.newsletterId
+            WHERE t.id > :lastTrackId
+            AND s.status = :subscribeStatus
+            AND n.source = :source
+            AND n.status = :newsletterStatus
+            AND (t.lastIssuedDate IS NULL OR t.lastIssuedDate <> :issueDate)
+            ORDER BY t.id
+            """)
+    List<MaeilMailSubscriptionTrack> findIssueTargetsAfterId(
+            @Param("issueDate") LocalDate issueDate,
+            @Param("subscribeStatus") SubscribeStatus subscribeStatus,
+            @Param("source") NewsletterSource source,
+            @Param("newsletterStatus") NewsletterPublicationStatus newsletterStatus,
+            @Param("lastTrackId") Long lastTrackId,
+            Pageable pageable
+    );
+
+    @Transactional
+    @Modifying
+    @Query("""
+            UPDATE MaeilMailSubscriptionTrack t
+            SET t.curriculumIndex = t.curriculumIndex + 1,
+                t.lastIssuedDate = :issueDate
+            WHERE t.id IN :ids
+            """)
+    void markIssuedByIds(
+            @Param("ids") List<Long> ids,
+            @Param("issueDate") LocalDate issueDate
+    );
+
+    List<MaeilMailSubscriptionTrack> findByMemberId(Long memberId);
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailTopicRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailTopicRepository.java
@@ -1,0 +1,10 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import java.util.List;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MaeilMailTopicRepository extends JpaRepository<MaeilMailTopic, Long> {
+
+    List<MaeilMailTopic> findAllByOrderByDisplayOrderAsc();
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailIssueStartupResumeExecutor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailIssueStartupResumeExecutor.java
@@ -1,0 +1,18 @@
+package news.bombomemail.nativenewsletter.maeilmail.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.nativenewsletter.maeilmail.service.MaeilMailIssueService;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MaeilMailIssueStartupResumeExecutor {
+
+    private final MaeilMailIssueService maeilMailIssueService;
+
+    @SchedulerLock(name = "maeil_mail_issue", lockAtMostFor = "PT30M")
+    public void resumeIncompleteMaeilMailIssueJob() {
+        maeilMailIssueService.resumeIncompleteTodayJob();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailIssueStartupResumeListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailIssueStartupResumeListener.java
@@ -1,0 +1,26 @@
+package news.bombomemail.nativenewsletter.maeilmail.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "maeil-mail.issue.resume-on-startup", havingValue = "true", matchIfMissing = true)
+public class MaeilMailIssueStartupResumeListener {
+
+    private final MaeilMailIssueStartupResumeExecutor startupResumeExecutor;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void resumeIncompleteMaeilMailIssueJob() {
+        try {
+            startupResumeExecutor.resumeIncompleteMaeilMailIssueJob();
+        } catch (RuntimeException e) {
+            log.error("매일메일 미완료 발행 job 자동 재개 실패", e);
+        }
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailScheduler.java
@@ -1,0 +1,23 @@
+package news.bombomemail.nativenewsletter.maeilmail.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.nativenewsletter.maeilmail.service.MaeilMailIssueService;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MaeilMailScheduler {
+
+    private static final String TIME_ZONE = "Asia/Seoul";
+    private static final String ISSUE_CRON = "0 0 7 * * MON-FRI";
+
+    private final MaeilMailIssueService maeilMailIssueService;
+
+    @Scheduled(cron = ISSUE_CRON, zone = TIME_ZONE)
+    @SchedulerLock(name = "maeil_mail_issue", lockAtMostFor = "PT30M")
+    public void issueMaeilMail() {
+        maeilMailIssueService.issue();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueService.java
@@ -1,0 +1,94 @@
+package news.bombomemail.nativenewsletter.maeilmail.service;
+
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
+import news.bombomemail.nativenewsletter.maeilmail.service.internal.MaeilMailIssueChunkProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MaeilMailIssueService {
+
+    private static final Long START_TRACK_ID = 0L;
+
+    private final Clock clock;
+    private final MaeilMailIssueChunkProcessor chunkProcessor;
+
+    @Value("${maeil-mail.issue.chunk-size:200}")
+    private int issueChunkSize = 200;
+
+    public void issue() {
+        long startedAt = System.currentTimeMillis();
+        LocalDate today = LocalDate.now(clock);
+        if (isWeekend(today)) {
+            log.info("매일메일 발행 스킵 - issueDate={}, reason=weekend", today);
+            return;
+        }
+
+        PageRequest pageRequest = issuePageRequest();
+        log.info("매일메일 발행 시작 - issueDate={}, chunkSize={}", today, pageRequest.getPageSize());
+        Long lastTrackId = START_TRACK_ID;
+        IssueProgress progress = IssueProgress.empty();
+        while (true) {
+            IssueChunkResult result;
+            try {
+                result = chunkProcessor.process(today, lastTrackId, pageRequest);
+            } catch (RuntimeException e) {
+                log.error("매일메일 발행 실패 - issueDate={}, lastTrackId={}", today, lastTrackId, e);
+                throw e;
+            }
+            if (!result.hasTracks()) {
+                log.info(
+                        "매일메일 발행 완료 - issueDate={}, chunkCount={}, trackCount={}, issuedArticleCount={}, previouslyIssuedTrackCount={}, elapsedMs={}",
+                        today,
+                        progress.chunkCount(),
+                        progress.trackCount(),
+                        progress.issuedArticleCount(),
+                        progress.previouslyIssuedTrackCount(),
+                        System.currentTimeMillis() - startedAt
+                );
+                return;
+            }
+
+            progress = progress.add(result);
+            lastTrackId = result.lastTrackId();
+        }
+    }
+
+    private PageRequest issuePageRequest() {
+        return PageRequest.of(0, Math.max(issueChunkSize, 1));
+    }
+
+    private boolean isWeekend(LocalDate date) {
+        DayOfWeek dayOfWeek = date.getDayOfWeek();
+        return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
+    }
+
+    private record IssueProgress(
+            int chunkCount,
+            int trackCount,
+            int issuedArticleCount,
+            int previouslyIssuedTrackCount
+    ) {
+
+        private static IssueProgress empty() {
+            return new IssueProgress(0, 0, 0, 0);
+        }
+
+        private IssueProgress add(IssueChunkResult result) {
+            return new IssueProgress(
+                    chunkCount + 1,
+                    trackCount + result.trackCount(),
+                    issuedArticleCount + result.issuedArticleCount(),
+                    previouslyIssuedTrackCount + result.previouslyIssuedTrackCount()
+            );
+        }
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueService.java
@@ -22,7 +22,7 @@ public class MaeilMailIssueService {
     private final MaeilMailIssueChunkProcessor chunkProcessor;
 
     @Value("${maeil-mail.issue.chunk-size:200}")
-    private int issueChunkSize = 200;
+    private int issueChunkSize;
 
     public void issue() {
         long startedAt = System.currentTimeMillis();

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueService.java
@@ -3,10 +3,13 @@ package news.bombomemail.nativenewsletter.maeilmail.service;
 import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
 import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
 import news.bombomemail.nativenewsletter.maeilmail.service.internal.MaeilMailIssueChunkProcessor;
+import news.bombomemail.nativenewsletter.maeilmail.service.internal.MaeilMailIssueJobManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -16,10 +19,9 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MaeilMailIssueService {
 
-    private static final Long START_TRACK_ID = 0L;
-
     private final Clock clock;
     private final MaeilMailIssueChunkProcessor chunkProcessor;
+    private final MaeilMailIssueJobManager issueJobManager;
 
     @Value("${maeil-mail.issue.chunk-size:200}")
     private int issueChunkSize;
@@ -33,31 +35,44 @@ public class MaeilMailIssueService {
         }
 
         PageRequest pageRequest = issuePageRequest();
-        log.info("매일메일 발행 시작 - issueDate={}, chunkSize={}", today, pageRequest.getPageSize());
-        Long lastTrackId = START_TRACK_ID;
-        IssueProgress progress = IssueProgress.empty();
+        MaeilMailIssueJob issueJob = issueJobManager.startOrResume(today, LocalDateTime.now(clock));
+        if (issueJob.isCompleted()) {
+            log.info("매일메일 발행 스킵 - issueDate={}, issueJobId={}, reason=already_completed", today, issueJob.getId());
+            return;
+        }
+
+        log.info(
+                "매일메일 발행 시작 - issueDate={}, issueJobId={}, chunkSize={}, lastProcessedTrackId={}",
+                today,
+                issueJob.getId(),
+                pageRequest.getPageSize(),
+                issueJob.getLastProcessedTrackId()
+        );
+        Long lastTrackId = issueJob.getLastProcessedTrackId();
         while (true) {
             IssueChunkResult result;
             try {
-                result = chunkProcessor.process(today, lastTrackId, pageRequest);
+                result = chunkProcessor.process(issueJob.getId(), today, lastTrackId, pageRequest);
             } catch (RuntimeException e) {
-                log.error("매일메일 발행 실패 - issueDate={}, lastTrackId={}", today, lastTrackId, e);
+                issueJobManager.fail(issueJob.getId(), e, LocalDateTime.now(clock));
+                log.error("매일메일 발행 실패 - issueDate={}, issueJobId={}, lastTrackId={}", today, issueJob.getId(), lastTrackId, e);
                 throw e;
             }
             if (!result.hasTracks()) {
+                MaeilMailIssueJob completedJob = issueJobManager.complete(issueJob.getId(), LocalDateTime.now(clock));
                 log.info(
-                        "매일메일 발행 완료 - issueDate={}, chunkCount={}, trackCount={}, issuedArticleCount={}, previouslyIssuedTrackCount={}, elapsedMs={}",
+                        "매일메일 발행 완료 - issueDate={}, issueJobId={}, chunkCount={}, trackCount={}, issuedArticleCount={}, previouslyIssuedTrackCount={}, elapsedMs={}",
                         today,
-                        progress.chunkCount(),
-                        progress.trackCount(),
-                        progress.issuedArticleCount(),
-                        progress.previouslyIssuedTrackCount(),
+                        completedJob.getId(),
+                        completedJob.getChunkCount(),
+                        completedJob.getProcessedTrackCount(),
+                        completedJob.getIssuedArticleCount(),
+                        completedJob.getPreviouslyIssuedTrackCount(),
                         System.currentTimeMillis() - startedAt
                 );
                 return;
             }
 
-            progress = progress.add(result);
             lastTrackId = result.lastTrackId();
         }
     }
@@ -69,26 +84,5 @@ public class MaeilMailIssueService {
     private boolean isWeekend(LocalDate date) {
         DayOfWeek dayOfWeek = date.getDayOfWeek();
         return dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY;
-    }
-
-    private record IssueProgress(
-            int chunkCount,
-            int trackCount,
-            int issuedArticleCount,
-            int previouslyIssuedTrackCount
-    ) {
-
-        private static IssueProgress empty() {
-            return new IssueProgress(0, 0, 0, 0);
-        }
-
-        private IssueProgress add(IssueChunkResult result) {
-            return new IssueProgress(
-                    chunkCount + 1,
-                    trackCount + result.trackCount(),
-                    issuedArticleCount + result.issuedArticleCount(),
-                    previouslyIssuedTrackCount + result.previouslyIssuedTrackCount()
-            );
-        }
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueService.java
@@ -27,23 +27,36 @@ public class MaeilMailIssueService {
     private int issueChunkSize;
 
     public void issue() {
-        long startedAt = System.currentTimeMillis();
         LocalDate today = LocalDate.now(clock);
         if (isWeekend(today)) {
             log.info("매일메일 발행 스킵 - issueDate={}, reason=weekend", today);
             return;
         }
 
-        PageRequest pageRequest = issuePageRequest();
         MaeilMailIssueJob issueJob = issueJobManager.startOrResume(today, LocalDateTime.now(clock));
+        runIssueJob(today, issueJob);
+    }
+
+    public void resumeIncompleteTodayJob() {
+        LocalDate today = LocalDate.now(clock);
+        issueJobManager.resumeIncomplete(today, LocalDateTime.now(clock))
+                .ifPresentOrElse(
+                        issueJob -> runIssueJob(today, issueJob),
+                        () -> log.info("매일메일 미완료 발행 job 없음 - issueDate={}", today)
+                );
+    }
+
+    private void runIssueJob(LocalDate issueDate, MaeilMailIssueJob issueJob) {
+        long startedAt = System.currentTimeMillis();
+        PageRequest pageRequest = issuePageRequest();
         if (issueJob.isCompleted()) {
-            log.info("매일메일 발행 스킵 - issueDate={}, issueJobId={}, reason=already_completed", today, issueJob.getId());
+            log.info("매일메일 발행 스킵 - issueDate={}, issueJobId={}, reason=already_completed", issueDate, issueJob.getId());
             return;
         }
 
         log.info(
                 "매일메일 발행 시작 - issueDate={}, issueJobId={}, chunkSize={}, lastProcessedTrackId={}",
-                today,
+                issueDate,
                 issueJob.getId(),
                 pageRequest.getPageSize(),
                 issueJob.getLastProcessedTrackId()
@@ -52,17 +65,17 @@ public class MaeilMailIssueService {
         while (true) {
             IssueChunkResult result;
             try {
-                result = chunkProcessor.process(issueJob.getId(), today, lastTrackId, pageRequest);
+                result = chunkProcessor.process(issueJob.getId(), issueDate, lastTrackId, pageRequest);
             } catch (RuntimeException e) {
                 issueJobManager.fail(issueJob.getId(), e, LocalDateTime.now(clock));
-                log.error("매일메일 발행 실패 - issueDate={}, issueJobId={}, lastTrackId={}", today, issueJob.getId(), lastTrackId, e);
+                log.error("매일메일 발행 실패 - issueDate={}, issueJobId={}, lastTrackId={}", issueDate, issueJob.getId(), lastTrackId, e);
                 throw e;
             }
             if (!result.hasTracks()) {
                 MaeilMailIssueJob completedJob = issueJobManager.complete(issueJob.getId(), LocalDateTime.now(clock));
                 log.info(
                         "매일메일 발행 완료 - issueDate={}, issueJobId={}, chunkCount={}, trackCount={}, issuedArticleCount={}, previouslyIssuedTrackCount={}, elapsedMs={}",
-                        today,
+                        issueDate,
                         completedJob.getId(),
                         completedJob.getChunkCount(),
                         completedJob.getProcessedTrackCount(),

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessor.java
@@ -26,9 +26,11 @@ public class MaeilMailIssueChunkProcessor {
     private final MaeilMailIssueDataLoader issueDataLoader;
     private final MaeilMailIssueEntryPreparer entryPreparer;
     private final MaeilMailIssuePublisher issuePublisher;
+    private final MaeilMailIssueJobManager issueJobManager;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public IssueChunkResult process(
+            Long issueJobId,
             LocalDate issueDate,
             Long lastTrackId,
             Pageable pageable
@@ -49,9 +51,11 @@ public class MaeilMailIssueChunkProcessor {
                 preparedEntries.entries().size(),
                 preparedEntries.previouslyIssuedTrackIds().size()
         );
+        issueJobManager.recordChunk(issueJobId, result);
         log.info(
-                "매일메일 발행 chunk 처리 완료 - issueDate={}, lastTrackId={}, trackCount={}, issuedArticleCount={}, previouslyIssuedTrackCount={}, elapsedMs={}",
+                "매일메일 발행 chunk 처리 완료 - issueDate={}, issueJobId={}, lastTrackId={}, trackCount={}, issuedArticleCount={}, previouslyIssuedTrackCount={}, elapsedMs={}",
                 issueDate,
+                issueJobId,
                 chunkLastTrackId,
                 result.trackCount(),
                 result.issuedArticleCount(),

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessor.java
@@ -51,7 +51,7 @@ public class MaeilMailIssueChunkProcessor {
                 preparedEntries.entries().size(),
                 preparedEntries.previouslyIssuedTrackIds().size()
         );
-        issueJobManager.recordChunk(issueJobId, result);
+        issueJobManager.recordPublishedChunk(issueJobId, result);
         log.info(
                 "매일메일 발행 chunk 처리 완료 - issueDate={}, issueJobId={}, lastTrackId={}, trackCount={}, issuedArticleCount={}, previouslyIssuedTrackCount={}, elapsedMs={}",
                 issueDate,

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessor.java
@@ -1,0 +1,78 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueData;
+import news.bombomemail.nativenewsletter.maeilmail.dto.PreparedIssueEntries;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSubscriptionTrackRepository;
+import news.bombomemail.newsletter.domain.NewsletterPublicationStatus;
+import news.bombomemail.newsletter.domain.NewsletterSource;
+import news.bombomemail.subscribe.domain.SubscribeStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class MaeilMailIssueChunkProcessor {
+
+    private final MaeilMailSubscriptionTrackRepository trackRepository;
+    private final MaeilMailIssueDataLoader issueDataLoader;
+    private final MaeilMailIssueEntryPreparer entryPreparer;
+    private final MaeilMailIssuePublisher issuePublisher;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public IssueChunkResult process(
+            LocalDate issueDate,
+            Long lastTrackId,
+            Pageable pageable
+    ) {
+        long startedAt = System.currentTimeMillis();
+        List<MaeilMailSubscriptionTrack> tracks = loadIssueTargetTracks(issueDate, lastTrackId, pageable);
+        if (tracks.isEmpty()) {
+            return IssueChunkResult.empty();
+        }
+
+        Long chunkLastTrackId = tracks.getLast().getId();
+        IssueData issueData = issueDataLoader.load(issueDate, tracks);
+        PreparedIssueEntries preparedEntries = entryPreparer.prepare(tracks, issueData);
+        issuePublisher.publish(preparedEntries, issueDate);
+        IssueChunkResult result = IssueChunkResult.of(
+                chunkLastTrackId,
+                tracks.size(),
+                preparedEntries.entries().size(),
+                preparedEntries.previouslyIssuedTrackIds().size()
+        );
+        log.info(
+                "매일메일 발행 chunk 처리 완료 - issueDate={}, lastTrackId={}, trackCount={}, issuedArticleCount={}, previouslyIssuedTrackCount={}, elapsedMs={}",
+                issueDate,
+                chunkLastTrackId,
+                result.trackCount(),
+                result.issuedArticleCount(),
+                result.previouslyIssuedTrackCount(),
+                System.currentTimeMillis() - startedAt
+        );
+        return result;
+    }
+
+    private List<MaeilMailSubscriptionTrack> loadIssueTargetTracks(
+            LocalDate issueDate,
+            Long lastTrackId,
+            Pageable pageable
+    ) {
+        return trackRepository.findIssueTargetsAfterId(
+                issueDate,
+                SubscribeStatus.SUBSCRIBED,
+                NewsletterSource.MAEIL_MAIL,
+                NewsletterPublicationStatus.ACTIVE,
+                lastTrackId,
+                pageable
+        );
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueContentAssigner.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueContentAssigner.java
@@ -1,0 +1,49 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MaeilMailIssueContentAssigner {
+
+    private final MaeilMailSentContentRepository sentContentRepository;
+    private final Random random = new Random();
+
+    public Optional<Long> assignContentIdOrRecycle(
+            Long memberId,
+            Long topicId,
+            Map<Long, List<Long>> contentIdsByTopicId,
+            Map<MemberTopicKey, List<Long>> sentContentIdsByMemberTopic
+    ) {
+        List<Long> contentIds = contentIdsByTopicId.getOrDefault(topicId, List.of());
+        if (contentIds.isEmpty()) {
+            return Optional.empty();
+        }
+
+        MemberTopicKey topicKey = new MemberTopicKey(memberId, topicId);
+        Set<Long> sentContentIds = new HashSet<>(sentContentIdsByMemberTopic.getOrDefault(topicKey, List.of()));
+        List<Long> availableContentIds = contentIds.stream()
+                .filter(contentId -> !sentContentIds.contains(contentId))
+                .toList();
+        if (!availableContentIds.isEmpty()) {
+            return Optional.of(pickRandom(availableContentIds));
+        }
+
+        sentContentRepository.deleteByMemberIdAndTopicId(memberId, topicId);
+        sentContentRepository.flush();
+        return Optional.of(pickRandom(contentIds));
+    }
+
+    private Long pickRandom(List<Long> candidates) {
+        return candidates.get(random.nextInt(candidates.size()));
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueContentAssigner.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueContentAssigner.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 public class MaeilMailIssueContentAssigner {
 
     private final MaeilMailSentContentRepository sentContentRepository;
-    private final Random random = new Random();
+    private final Random random;
 
     public Optional<Long> assignContentIdOrRecycle(
             Long memberId,

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueDataLoader.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueDataLoader.java
@@ -1,0 +1,159 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTrack;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueData;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+import news.bombomemail.nativenewsletter.maeilmail.dto.TopicContentId;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailContentRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueHistoryRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailTopicRepository;
+import news.bombomemail.subscribe.domain.Subscribe;
+import news.bombomemail.subscribe.repository.SubscribeRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MaeilMailIssueDataLoader {
+
+    private final MaeilMailTopicRepository topicRepository;
+    private final MaeilMailContentRepository contentRepository;
+    private final MaeilMailSentContentRepository sentContentRepository;
+    private final MaeilMailIssueHistoryRepository issueHistoryRepository;
+    private final SubscribeRepository subscribeRepository;
+
+    public IssueData load(LocalDate issueDate, List<MaeilMailSubscriptionTrack> tracks) {
+        Long newsletterId = loadNewsletterId(tracks);
+        Map<MaeilMailTrack, List<MaeilMailTopic>> orderedTopicsByTrack = loadOrderedTopicsByTrack();
+        Map<Long, MaeilMailTopic> issueTopicsByTrackId = resolveIssueTopicsByTrackId(tracks, orderedTopicsByTrack);
+        Map<Long, List<Long>> contentIdsByTopicId = loadContentIdsByTopicId(issueTopicsByTrackId.values());
+        List<MemberTopicKey> memberTopicKeys = resolveIssueMemberTopicKeys(tracks, issueTopicsByTrackId);
+        Map<MemberTopicKey, List<Long>> sentContentIdsByMemberTopic = loadSentContentIdsByMemberTopic(memberTopicKeys);
+        Set<MemberTopicKey> issuedMemberTopicKeys = loadIssuedMemberTopicKeys(issueDate, memberTopicKeys);
+
+        return new IssueData(
+                issueTopicsByTrackId,
+                contentIdsByTopicId,
+                sentContentIdsByMemberTopic,
+                issuedMemberTopicKeys,
+                newsletterId
+        );
+    }
+
+    private Long loadNewsletterId(List<MaeilMailSubscriptionTrack> tracks) {
+        List<Long> subscribeIds = tracks.stream()
+                .map(MaeilMailSubscriptionTrack::getSubscribeId)
+                .distinct()
+                .toList();
+        if (subscribeIds.isEmpty()) {
+            throw new IllegalStateException("매일메일 발행 대상 Subscribe가 없습니다.");
+        }
+
+        List<Subscribe> subscribes = subscribeRepository.findAllById(subscribeIds);
+        if (subscribes.size() != subscribeIds.size()) {
+            throw new IllegalStateException("매일메일 발행 track의 Subscribe를 찾을 수 없습니다. subscribeIds=" + subscribeIds);
+        }
+
+        List<Long> newsletterIds = subscribes.stream()
+                .map(Subscribe::getNewsletterId)
+                .distinct()
+                .toList();
+        if (newsletterIds.size() != 1) {
+            throw new IllegalStateException("발행 대상 track의 newsletterId가 하나가 아닙니다. newsletterIds=" + newsletterIds);
+        }
+        return newsletterIds.getFirst();
+    }
+
+    private Map<MaeilMailTrack, List<MaeilMailTopic>> loadOrderedTopicsByTrack() {
+        return topicRepository.findAllByOrderByDisplayOrderAsc()
+                .stream()
+                .collect(Collectors.groupingBy(MaeilMailTopic::getTrack));
+    }
+
+    private Map<Long, MaeilMailTopic> resolveIssueTopicsByTrackId(
+            List<MaeilMailSubscriptionTrack> tracks,
+            Map<MaeilMailTrack, List<MaeilMailTopic>> topicsByTrack
+    ) {
+        return tracks.stream()
+                .map(track -> Map.entry(track, topicsByTrack.getOrDefault(track.getField(), List.of())))
+                .filter(entry -> !entry.getValue().isEmpty())
+                .collect(Collectors.toMap(
+                        entry -> entry.getKey().getId(),
+                        entry -> pickIssueTopic(entry.getKey(), entry.getValue())
+                ));
+    }
+
+    private MaeilMailTopic pickIssueTopic(MaeilMailSubscriptionTrack track, List<MaeilMailTopic> topics) {
+        return topics.get(track.getCurriculumIndex() % topics.size());
+    }
+
+    private Map<Long, List<Long>> loadContentIdsByTopicId(Collection<MaeilMailTopic> topics) {
+        List<Long> topicIds = extractTopicIds(topics);
+        if (topicIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return contentRepository.findContentIdsByTopicIdIn(topicIds)
+                .stream()
+                .collect(Collectors.groupingBy(
+                        TopicContentId::topicId,
+                        Collectors.mapping(TopicContentId::contentId, Collectors.toList())
+                ));
+    }
+
+    private Map<MemberTopicKey, List<Long>> loadSentContentIdsByMemberTopic(
+            List<MemberTopicKey> memberTopicKeys
+    ) {
+        if (memberTopicKeys.isEmpty()) {
+            return Map.of();
+        }
+
+        return sentContentRepository.findAllByMemberTopicKeys(memberTopicKeys).stream()
+                .collect(Collectors.groupingBy(
+                        sentContent -> new MemberTopicKey(sentContent.getMemberId(), sentContent.getTopicId()),
+                        Collectors.mapping(MaeilMailSentContent::getContentId, Collectors.toList())
+                ));
+    }
+
+    private Set<MemberTopicKey> loadIssuedMemberTopicKeys(
+            LocalDate issueDate,
+            List<MemberTopicKey> memberTopicKeys
+    ) {
+        return issueHistoryRepository.findIssuedMemberTopicKeys(issueDate, memberTopicKeys);
+    }
+
+    private List<MemberTopicKey> resolveIssueMemberTopicKeys(
+            List<MaeilMailSubscriptionTrack> tracks,
+            Map<Long, MaeilMailTopic> issueTopicsByTrackId
+    ) {
+        return tracks.stream()
+                .map(track -> {
+                    MaeilMailTopic topic = issueTopicsByTrackId.get(track.getId());
+                    if (topic == null) {
+                        return null;
+                    }
+                    return new MemberTopicKey(track.getMemberId(), topic.getId());
+                })
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+    }
+
+    private List<Long> extractTopicIds(Collection<MaeilMailTopic> topics) {
+        return topics.stream()
+                .map(MaeilMailTopic::getId)
+                .distinct()
+                .toList();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
@@ -125,7 +125,8 @@ public class MaeilMailIssueEntryPreparer {
         return Optional.of(new IssueEntry(
                 buildArticle(content, pendingEntry.memberId(), pendingEntry.newsletterId(), arrivedAt),
                 pendingEntry.trackIds(),
-                buildSentContent(pendingEntry.memberId(), pendingEntry.topicId(), content.getId())
+                buildSentContent(pendingEntry.memberId(), pendingEntry.topicId(), content.getId()),
+                content.getId()
         ));
     }
 

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
@@ -125,8 +125,7 @@ public class MaeilMailIssueEntryPreparer {
         return Optional.of(new IssueEntry(
                 buildArticle(content, pendingEntry.memberId(), pendingEntry.newsletterId(), arrivedAt),
                 pendingEntry.trackIds(),
-                buildSentContent(pendingEntry.memberId(), pendingEntry.topicId(), content.getId()),
-                content.getId()
+                buildSentContent(pendingEntry.memberId(), pendingEntry.topicId(), content.getId())
         ));
     }
 

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
@@ -55,6 +55,7 @@ public class MaeilMailIssueEntryPreparer {
 
             MemberTopicKey memberTopicKey = new MemberTopicKey(track.getMemberId(), issueTopic.getId());
             if (issueData.issuedMemberTopicKeys().contains(memberTopicKey)) {
+                // 동일 member-topic이 같은 날 먼저 발행됐으면 Article은 만들지 않고 track 진행 상태만 맞춘다.
                 previouslyIssuedTrackIds.add(track.getId());
                 continue;
             }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
@@ -1,0 +1,186 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.article.domain.Article;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueData;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueEntry;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+import news.bombomemail.nativenewsletter.maeilmail.dto.PreparedIssueEntries;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailContentRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MaeilMailIssueEntryPreparer {
+
+    private final Clock clock;
+    private final MaeilMailContentRepository contentRepository;
+    private final MaeilMailIssueContentAssigner contentAssigner;
+
+    public PreparedIssueEntries prepare(
+            List<MaeilMailSubscriptionTrack> tracks,
+            IssueData issueData
+    ) {
+        EntrySelection selection = selectEntries(tracks, issueData);
+        LocalDateTime arrivedAt = LocalDateTime.now(clock);
+        return new PreparedIssueEntries(
+                buildIssueEntries(selection.pendingEntries(), arrivedAt),
+                selection.previouslyIssuedTrackIds()
+        );
+    }
+
+    private EntrySelection selectEntries(
+            List<MaeilMailSubscriptionTrack> tracks,
+            IssueData issueData
+    ) {
+        Map<MemberTopicKey, PendingEntry> entriesByMemberTopic = new LinkedHashMap<>();
+        List<Long> previouslyIssuedTrackIds = new ArrayList<>();
+        for (MaeilMailSubscriptionTrack track : tracks) {
+            MaeilMailTopic issueTopic = issueData.issueTopicsByTrackId().get(track.getId());
+            if (issueTopic == null) {
+                continue;
+            }
+
+            MemberTopicKey memberTopicKey = new MemberTopicKey(track.getMemberId(), issueTopic.getId());
+            if (issueData.issuedMemberTopicKeys().contains(memberTopicKey)) {
+                previouslyIssuedTrackIds.add(track.getId());
+                continue;
+            }
+
+            PendingEntry existingEntry = entriesByMemberTopic.get(memberTopicKey);
+            if (existingEntry != null) {
+                entriesByMemberTopic.put(memberTopicKey, existingEntry.withTrackId(track.getId()));
+                continue;
+            }
+
+            buildPendingEntryForTrack(track, issueTopic, issueData)
+                    .ifPresent(entry -> entriesByMemberTopic.put(memberTopicKey, entry));
+        }
+        return new EntrySelection(new ArrayList<>(entriesByMemberTopic.values()), previouslyIssuedTrackIds);
+    }
+
+    private Optional<PendingEntry> buildPendingEntryForTrack(
+            MaeilMailSubscriptionTrack track,
+            MaeilMailTopic issueTopic,
+            IssueData issueData
+    ) {
+        Optional<Long> contentId = contentAssigner.assignContentIdOrRecycle(
+                track.getMemberId(),
+                issueTopic.getId(),
+                issueData.contentIdsByTopicId(),
+                issueData.sentContentIdsByMemberTopic()
+        );
+        return contentId.map(pickedContentId -> new PendingEntry(
+                track.getMemberId(),
+                issueTopic.getId(),
+                issueData.newsletterId(),
+                pickedContentId,
+                List.of(track.getId())
+        ));
+    }
+
+    private List<IssueEntry> buildIssueEntries(
+            List<PendingEntry> pendingEntries,
+            LocalDateTime arrivedAt
+    ) {
+        if (pendingEntries.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> contentIds = pendingEntries.stream()
+                .map(PendingEntry::contentId)
+                .distinct()
+                .toList();
+        Map<Long, MaeilMailContent> contentById = contentRepository.findAllById(contentIds).stream()
+                .collect(Collectors.toMap(MaeilMailContent::getId, content -> content));
+
+        return pendingEntries.stream()
+                .map(pendingEntry -> toIssueEntry(pendingEntry, contentById, arrivedAt))
+                .flatMap(Optional::stream)
+                .toList();
+    }
+
+    private Optional<IssueEntry> toIssueEntry(
+            PendingEntry pendingEntry,
+            Map<Long, MaeilMailContent> contentById,
+            LocalDateTime arrivedAt
+    ) {
+        MaeilMailContent content = contentById.get(pendingEntry.contentId());
+        if (content == null) {
+            return Optional.empty();
+        }
+
+        return Optional.of(new IssueEntry(
+                buildArticle(content, pendingEntry.memberId(), pendingEntry.newsletterId(), arrivedAt),
+                pendingEntry.trackIds(),
+                buildSentContent(pendingEntry.memberId(), pendingEntry.topicId(), content.getId())
+        ));
+    }
+
+    private Article buildArticle(
+            MaeilMailContent content,
+            Long memberId,
+            Long newsletterId,
+            LocalDateTime arrivedAt
+    ) {
+        return Article.builder()
+                .title(content.getTitle())
+                .contents(content.getContent())
+                .contentsText(content.getContentsText())
+                .contentsSummary(content.getContentsSummary())
+                .expectedReadTime(content.getExpectedReadTime())
+                .memberId(memberId)
+                .newsletterId(newsletterId)
+                .arrivedDateTime(arrivedAt)
+                .build();
+    }
+
+    private MaeilMailSentContent buildSentContent(
+            Long memberId,
+            Long topicId,
+            Long contentId
+    ) {
+        return MaeilMailSentContent.builder()
+                .memberId(memberId)
+                .topicId(topicId)
+                .contentId(contentId)
+                .build();
+    }
+
+    private record EntrySelection(
+            List<PendingEntry> pendingEntries,
+            List<Long> previouslyIssuedTrackIds
+    ) {
+    }
+
+    private record PendingEntry(
+            Long memberId,
+            Long topicId,
+            Long newsletterId,
+            Long contentId,
+            List<Long> trackIds
+    ) {
+
+        private PendingEntry {
+            trackIds = List.copyOf(trackIds);
+        }
+
+        private PendingEntry withTrackId(Long trackId) {
+            List<Long> nextTrackIds = new ArrayList<>(trackIds);
+            nextTrackIds.add(trackId);
+            return new PendingEntry(memberId, topicId, newsletterId, contentId, nextTrackIds);
+        }
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparer.java
@@ -106,28 +106,37 @@ public class MaeilMailIssueEntryPreparer {
                 .toList();
         Map<Long, MaeilMailContent> contentById = contentRepository.findAllById(contentIds).stream()
                 .collect(Collectors.toMap(MaeilMailContent::getId, content -> content));
+        validateAllContentsLoaded(contentIds, contentById);
 
         return pendingEntries.stream()
                 .map(pendingEntry -> toIssueEntry(pendingEntry, contentById, arrivedAt))
-                .flatMap(Optional::stream)
                 .toList();
     }
 
-    private Optional<IssueEntry> toIssueEntry(
+    private void validateAllContentsLoaded(
+            List<Long> contentIds,
+            Map<Long, MaeilMailContent> contentById
+    ) {
+        List<Long> missingContentIds = contentIds.stream()
+                .filter(contentId -> !contentById.containsKey(contentId))
+                .toList();
+        if (!missingContentIds.isEmpty()) {
+            throw new IllegalStateException("매일메일 발행 content를 찾을 수 없습니다. contentIds=" + missingContentIds);
+        }
+    }
+
+    private IssueEntry toIssueEntry(
             PendingEntry pendingEntry,
             Map<Long, MaeilMailContent> contentById,
             LocalDateTime arrivedAt
     ) {
         MaeilMailContent content = contentById.get(pendingEntry.contentId());
-        if (content == null) {
-            return Optional.empty();
-        }
 
-        return Optional.of(new IssueEntry(
+        return new IssueEntry(
                 buildArticle(content, pendingEntry.memberId(), pendingEntry.newsletterId(), arrivedAt),
                 pendingEntry.trackIds(),
                 buildSentContent(pendingEntry.memberId(), pendingEntry.topicId(), content.getId())
-        ));
+        );
     }
 
     private Article buildArticle(

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManager.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManager.java
@@ -2,8 +2,11 @@ package news.bombomemail.nativenewsletter.maeilmail.service.internal;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJobStatus;
 import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
 import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueJobRepository;
 import org.springframework.stereotype.Component;
@@ -15,6 +18,10 @@ public class MaeilMailIssueJobManager {
 
     private static final Long START_TRACK_ID = 0L;
     private static final int MAX_FAILED_MESSAGE_LENGTH = 1000;
+    private static final List<MaeilMailIssueJobStatus> INCOMPLETE_STATUSES = List.of(
+            MaeilMailIssueJobStatus.RUNNING,
+            MaeilMailIssueJobStatus.FAILED
+    );
 
     private final MaeilMailIssueJobRepository issueJobRepository;
 
@@ -30,6 +37,15 @@ public class MaeilMailIssueJobManager {
                         START_TRACK_ID,
                         startedAt
                 )));
+    }
+
+    @Transactional
+    public Optional<MaeilMailIssueJob> resumeIncomplete(LocalDate issueDate, LocalDateTime startedAt) {
+        return issueJobRepository.findByIssueDateAndStatusIn(issueDate, INCOMPLETE_STATUSES)
+                .map(issueJob -> {
+                    issueJob.resume(startedAt);
+                    return issueJob;
+                });
     }
 
     @Transactional

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManager.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManager.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class MaeilMailIssueJobManager {
 
     private static final Long START_TRACK_ID = 0L;
-    private static final int MAX_FAILED_MESSAGE_LENGTH = 1000;
     private static final List<MaeilMailIssueJobStatus> INCOMPLETE_STATUSES = List.of(
             MaeilMailIssueJobStatus.RUNNING,
             MaeilMailIssueJobStatus.FAILED
@@ -77,9 +76,6 @@ public class MaeilMailIssueJobManager {
         if (message == null || message.isBlank()) {
             message = exception.getClass().getName();
         }
-        if (message.length() <= MAX_FAILED_MESSAGE_LENGTH) {
-            return message;
-        }
-        return message.substring(0, MAX_FAILED_MESSAGE_LENGTH);
+        return message;
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManager.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManager.java
@@ -1,0 +1,69 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueJobRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class MaeilMailIssueJobManager {
+
+    private static final Long START_TRACK_ID = 0L;
+    private static final int MAX_FAILED_MESSAGE_LENGTH = 1000;
+
+    private final MaeilMailIssueJobRepository issueJobRepository;
+
+    @Transactional
+    public MaeilMailIssueJob startOrResume(LocalDate issueDate, LocalDateTime startedAt) {
+        return issueJobRepository.findByIssueDate(issueDate)
+                .map(issueJob -> {
+                    issueJob.resume(startedAt);
+                    return issueJob;
+                })
+                .orElseGet(() -> issueJobRepository.save(MaeilMailIssueJob.start(
+                        issueDate,
+                        START_TRACK_ID,
+                        startedAt
+                )));
+    }
+
+    @Transactional
+    public void recordChunk(Long issueJobId, IssueChunkResult result) {
+        MaeilMailIssueJob issueJob = getIssueJob(issueJobId);
+        issueJob.recordChunk(result);
+    }
+
+    @Transactional
+    public MaeilMailIssueJob complete(Long issueJobId, LocalDateTime completedAt) {
+        MaeilMailIssueJob issueJob = getIssueJob(issueJobId);
+        issueJob.complete(completedAt);
+        return issueJob;
+    }
+
+    @Transactional
+    public void fail(Long issueJobId, RuntimeException exception, LocalDateTime failedAt) {
+        MaeilMailIssueJob issueJob = getIssueJob(issueJobId);
+        issueJob.fail(failedMessage(exception), failedAt);
+    }
+
+    private MaeilMailIssueJob getIssueJob(Long issueJobId) {
+        return issueJobRepository.findById(issueJobId)
+                .orElseThrow(() -> new IllegalStateException("매일메일 발행 job을 찾을 수 없습니다. jobId=" + issueJobId));
+    }
+
+    private String failedMessage(RuntimeException exception) {
+        String message = exception.getMessage();
+        if (message == null || message.isBlank()) {
+            message = exception.getClass().getName();
+        }
+        if (message.length() <= MAX_FAILED_MESSAGE_LENGTH) {
+            return message;
+        }
+        return message.substring(0, MAX_FAILED_MESSAGE_LENGTH);
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManager.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManager.java
@@ -48,9 +48,9 @@ public class MaeilMailIssueJobManager {
     }
 
     @Transactional
-    public void recordChunk(Long issueJobId, IssueChunkResult result) {
+    public void recordPublishedChunk(Long issueJobId, IssueChunkResult result) {
         MaeilMailIssueJob issueJob = getIssueJob(issueJobId);
-        issueJob.recordChunk(result);
+        issueJob.recordPublishedChunk(result);
     }
 
     @Transactional

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisher.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisher.java
@@ -41,7 +41,7 @@ public class MaeilMailIssuePublisher {
 
         List<IssueEntry> entries = preparedIssueEntries.entries();
         List<Article> savedArticles = saveArticles(entries);
-        saveIssueProgress(entries, preparedIssueEntries.previouslyIssuedTrackIds(), issueDate);
+        saveIssueProgress(entries, savedArticles, preparedIssueEntries.previouslyIssuedTrackIds(), issueDate);
         publishArticleArrivedEvents(savedArticles);
     }
 
@@ -91,22 +91,28 @@ public class MaeilMailIssuePublisher {
 
     private void saveIssueProgress(
             List<IssueEntry> entries,
+            List<Article> savedArticles,
             List<Long> previouslyIssuedTrackIds,
             LocalDate issueDate
     ) {
-        saveMemberTopicIssueHistories(entries, issueDate);
+        saveMemberTopicIssueHistories(entries, savedArticles);
         updateIssuedTracks(entries, previouslyIssuedTrackIds, issueDate);
     }
 
-    private void saveMemberTopicIssueHistories(List<IssueEntry> entries, LocalDate issueDate) {
+    private void saveMemberTopicIssueHistories(List<IssueEntry> entries, List<Article> savedArticles) {
         if (entries.isEmpty()) {
             return;
+        }
+
+        if (entries.size() != savedArticles.size()) {
+            throw new IllegalStateException("매일메일 발행 Article 저장 결과 수가 일치하지 않습니다. entryCount="
+                    + entries.size() + ", savedArticleCount=" + savedArticles.size());
         }
 
         sentContentRepository.saveAll(entries.stream()
                 .map(IssueEntry::sentContent)
                 .toList());
-        issueHistoryRepository.saveAll(toIssueHistories(issueDate, entries));
+        issueHistoryRepository.saveAll(toIssueHistories(entries, savedArticles));
     }
 
     private void updateIssuedTracks(
@@ -126,15 +132,18 @@ public class MaeilMailIssuePublisher {
     }
 
     private List<MaeilMailIssueHistory> toIssueHistories(
-            LocalDate issueDate,
-            List<IssueEntry> entries
+            List<IssueEntry> entries,
+            List<Article> savedArticles
     ) {
-        return entries.stream()
-                .map(entry -> MaeilMailIssueHistory.builder()
-                        .issueDate(issueDate)
-                        .memberId(entry.sentContent().getMemberId())
-                        .topicId(entry.sentContent().getTopicId())
-                        .build())
-                .toList();
+        List<MaeilMailIssueHistory> histories = new ArrayList<>();
+        for (int i = 0; i < entries.size(); i++) {
+            IssueEntry entry = entries.get(i);
+            Article savedArticle = savedArticles.get(i);
+            histories.add(MaeilMailIssueHistory.builder()
+                    .articleId(savedArticle.getId())
+                    .contentId(entry.contentId())
+                    .build());
+        }
+        return histories;
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisher.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisher.java
@@ -1,0 +1,140 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.article.domain.Article;
+import news.bombomemail.article.event.ArticleArrivedEvent;
+import news.bombomemail.article.event.ArticleSource;
+import news.bombomemail.article.repository.ArticleRepository;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueEntry;
+import news.bombomemail.nativenewsletter.maeilmail.dto.PreparedIssueEntries;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueHistoryRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSubscriptionTrackRepository;
+import news.bombomemail.newsletter.domain.Newsletter;
+import news.bombomemail.newsletter.repository.NewsletterRepository;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class MaeilMailIssuePublisher {
+
+    private final ArticleRepository articleRepository;
+    private final NewsletterRepository newsletterRepository;
+    private final MaeilMailSentContentRepository sentContentRepository;
+    private final MaeilMailIssueHistoryRepository issueHistoryRepository;
+    private final MaeilMailSubscriptionTrackRepository trackRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void publish(PreparedIssueEntries preparedIssueEntries, LocalDate issueDate) {
+        if (preparedIssueEntries.isEmpty()) {
+            return;
+        }
+
+        List<IssueEntry> entries = preparedIssueEntries.entries();
+        List<Article> savedArticles = saveArticles(entries);
+        saveIssueProgress(entries, preparedIssueEntries.previouslyIssuedTrackIds(), issueDate);
+        publishArticleArrivedEvents(savedArticles);
+    }
+
+    private List<Article> saveArticles(List<IssueEntry> entries) {
+        if (entries.isEmpty()) {
+            return List.of();
+        }
+
+        return articleRepository.saveAll(entries.stream()
+                .map(IssueEntry::article)
+                .toList());
+    }
+
+    private void publishArticleArrivedEvents(List<Article> articles) {
+        if (articles.isEmpty()) {
+            return;
+        }
+
+        Map<Long, String> newsletterNamesById = loadNewsletterNamesById(articles);
+        articles.forEach(article -> eventPublisher.publishEvent(ArticleArrivedEvent.of(
+                article.getNewsletterId(),
+                newsletterNamesById.get(article.getNewsletterId()),
+                article.getId(),
+                article.getTitle(),
+                article.getMemberId(),
+                null,
+                article.getContents(),
+                ArticleSource.MAEIL_MAIL_ISSUED
+        )));
+    }
+
+    private Map<Long, String> loadNewsletterNamesById(List<Article> articles) {
+        Set<Long> newsletterIds = articles.stream()
+                .map(Article::getNewsletterId)
+                .collect(Collectors.toUnmodifiableSet());
+        Map<Long, Newsletter> newslettersById = newsletterRepository.findAllById(newsletterIds)
+                .stream()
+                .collect(Collectors.toMap(Newsletter::getId, Function.identity()));
+        if (newslettersById.size() != newsletterIds.size()) {
+            throw new IllegalStateException("매일메일 발행 Article의 Newsletter를 찾을 수 없습니다. newsletterIds=" + newsletterIds);
+        }
+
+        return newslettersById.values()
+                .stream()
+                .collect(Collectors.toMap(Newsletter::getId, Newsletter::getName));
+    }
+
+    private void saveIssueProgress(
+            List<IssueEntry> entries,
+            List<Long> previouslyIssuedTrackIds,
+            LocalDate issueDate
+    ) {
+        saveMemberTopicIssueHistories(entries, issueDate);
+        updateIssuedTracks(entries, previouslyIssuedTrackIds, issueDate);
+    }
+
+    private void saveMemberTopicIssueHistories(List<IssueEntry> entries, LocalDate issueDate) {
+        if (entries.isEmpty()) {
+            return;
+        }
+
+        sentContentRepository.saveAll(entries.stream()
+                .map(IssueEntry::sentContent)
+                .toList());
+        issueHistoryRepository.saveAll(toIssueHistories(issueDate, entries));
+    }
+
+    private void updateIssuedTracks(
+            List<IssueEntry> entries,
+            List<Long> previouslyIssuedTrackIds,
+            LocalDate issueDate
+    ) {
+        List<Long> issuedTrackIds = entries.stream()
+                .flatMap(entry -> entry.trackIds().stream())
+                .collect(Collectors.toCollection(ArrayList::new));
+        issuedTrackIds.addAll(previouslyIssuedTrackIds);
+        if (issuedTrackIds.isEmpty()) {
+            return;
+        }
+
+        trackRepository.markIssuedByIds(issuedTrackIds.stream().distinct().toList(), issueDate);
+    }
+
+    private List<MaeilMailIssueHistory> toIssueHistories(
+            LocalDate issueDate,
+            List<IssueEntry> entries
+    ) {
+        return entries.stream()
+                .map(entry -> MaeilMailIssueHistory.builder()
+                        .issueDate(issueDate)
+                        .memberId(entry.sentContent().getMemberId())
+                        .topicId(entry.sentContent().getTopicId())
+                        .build())
+                .toList();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/newsletter/domain/Newsletter.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/newsletter/domain/Newsletter.java
@@ -2,6 +2,8 @@ package news.bombomemail.newsletter.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -39,6 +41,14 @@ public class Newsletter extends BaseEntity {
     @Column(nullable = false)
     private Long detailId;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NewsletterSource source = NewsletterSource.EXTERNAL;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private NewsletterPublicationStatus status = NewsletterPublicationStatus.ACTIVE;
+
     @Builder
     public Newsletter(
             Long id,
@@ -47,7 +57,9 @@ public class Newsletter extends BaseEntity {
             @NonNull String imageUrl,
             @NonNull String email,
             @NonNull Long categoryId,
-            @NonNull Long detailId
+            @NonNull Long detailId,
+            NewsletterSource source,
+            NewsletterPublicationStatus status
     ) {
         this.id = id;
         this.name = name;
@@ -56,5 +68,7 @@ public class Newsletter extends BaseEntity {
         this.email = email;
         this.categoryId = categoryId;
         this.detailId = detailId;
+        this.source = source == null ? NewsletterSource.EXTERNAL : source;
+        this.status = status == null ? NewsletterPublicationStatus.ACTIVE : status;
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/newsletter/domain/NewsletterPublicationStatus.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/newsletter/domain/NewsletterPublicationStatus.java
@@ -1,0 +1,8 @@
+package news.bombomemail.newsletter.domain;
+
+public enum NewsletterPublicationStatus {
+
+    ACTIVE,
+    SUSPENDED,
+    DISCONTINUED
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/newsletter/domain/NewsletterSource.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/newsletter/domain/NewsletterSource.java
@@ -1,0 +1,7 @@
+package news.bombomemail.newsletter.domain;
+
+public enum NewsletterSource {
+
+    EXTERNAL,
+    MAEIL_MAIL
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/Subscribe.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/Subscribe.java
@@ -2,6 +2,8 @@ package news.bombomemail.subscribe.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -31,6 +33,11 @@ public class Subscribe extends BaseEntity {
 
     @Column(length = 512)
     private String unsubscribeUrl;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SubscribeStatus status = SubscribeStatus.SUBSCRIBED;
 
     public void updateUnsubscribeUrl(String unsubscribeUrl) {
         this.unsubscribeUrl = unsubscribeUrl;

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/SubscribeStatus.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/SubscribeStatus.java
@@ -1,0 +1,8 @@
+package news.bombomemail.subscribe.domain;
+
+public enum SubscribeStatus {
+
+    SUBSCRIBED,
+    UNSUBSCRIBING,
+    UNSUBSCRIBE_FAILED
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListener.java
@@ -3,6 +3,7 @@ package news.bombomemail.subscribe.event;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import news.bombomemail.article.event.ArticleArrivedEvent;
+import news.bombomemail.article.event.ArticleSource;
 import news.bombomemail.subscribe.service.SubscribeService;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -16,6 +17,10 @@ public class SubscribeArticleArrivedListener {
 
     @TransactionalEventListener
     public void on(ArticleArrivedEvent event) {
+        if (event.source() != ArticleSource.EMAIL_RECEIVED) {
+            return;
+        }
+
         try {
             subscribeService.upsertSubscribe(event.newsletterId(), event.memberId(), event.unsubscribeUrl());
         } catch (Exception e) {

--- a/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
@@ -8,6 +8,8 @@ import jakarta.mail.internet.MimeMessage;
 import java.util.List;
 import java.util.Properties;
 import news.bombomemail.article.domain.Article;
+import news.bombomemail.article.event.ArticleArrivedEvent;
+import news.bombomemail.article.event.ArticleSource;
 import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
@@ -23,10 +25,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.event.ApplicationEvents;
+import org.springframework.test.context.event.RecordApplicationEvents;
 
 @DataJpaTest
 @ActiveProfiles("test")
 @Import({ArticleService.class, HtmlCleanerConfig.class})
+@RecordApplicationEvents
 class ArticleServiceTest {
 
     @Autowired
@@ -40,6 +45,9 @@ class ArticleServiceTest {
 
     @Autowired
     ArticleRepository articleRepository;
+
+    @Autowired
+    ApplicationEvents applicationEvents;
 
     private Session session;
 
@@ -108,6 +116,42 @@ class ArticleServiceTest {
             softly.assertThat(article.getContents()).contains("테스트용 이메일 본문입니다");
             softly.assertThat(article.getExpectedReadTime()).isOne();
             softly.assertThat(article.getContentsSummary()).isEqualTo("이것은 테스트용 이메일 본문입니다.");
+        });
+    }
+
+    @Test
+    void article_저장_후_EMAIL_RECEIVED_source와_제목_unsubscribeUrl을_이벤트로_발행한다() throws Exception {
+        // given
+        MimeMessage msg = new MimeMessage(session);
+        msg.addRecipient(MimeMessage.RecipientType.TO,
+                new InternetAddress("test-member@example.com"));
+        msg.setFrom(new InternetAddress("test-newsletter@example.com"));
+        msg.setSubject("테스트 이메일 제목");
+        String content = """
+                <p>이것은 테스트용 이메일 본문입니다.</p>
+                <a href="https://example.com/unsubscribe?id=123">구독 취소</a>
+                """;
+
+        // when
+        boolean result = articleService.save(msg, content);
+
+        // then
+        Article article = articleRepository.findAll().getFirst();
+        Member member = memberRepository.findByEmail("test-member@example.com").orElseThrow();
+        Newsletter newsletter = newsletterRepository.findByEmail("test-newsletter@example.com").orElseThrow();
+        ArticleArrivedEvent event = applicationEvents.stream(ArticleArrivedEvent.class)
+                .findFirst()
+                .orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(result).isTrue();
+            softly.assertThat(event.newsletterId()).isEqualTo(newsletter.getId());
+            softly.assertThat(event.newsletterName()).isEqualTo("테스트뉴스레터");
+            softly.assertThat(event.articleId()).isEqualTo(article.getId());
+            softly.assertThat(event.articleTitle()).isEqualTo("테스트 이메일 제목");
+            softly.assertThat(event.memberId()).isEqualTo(member.getId());
+            softly.assertThat(event.unsubscribeUrl()).isEqualTo("https://example.com/unsubscribe?id=123");
+            softly.assertThat(event.contents()).isEqualTo(content);
+            softly.assertThat(event.source()).isEqualTo(ArticleSource.EMAIL_RECEIVED);
         });
     }
 

--- a/backend/mail-server/src/test/java/news/bombomemail/article/event/RecentArticleEventListenerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/event/RecentArticleEventListenerTest.java
@@ -2,10 +2,7 @@ package news.bombomemail.article.event;
 
 import static org.assertj.core.api.SoftAssertions.*;
 
-import jakarta.mail.Session;
-import jakarta.mail.internet.MimeMessage;
 import java.util.List;
-import java.util.Properties;
 import news.bombomemail.article.domain.RecentArticle;
 import news.bombomemail.article.repository.RecentArticleRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,11 +24,8 @@ class RecentArticleEventListenerTest {
     @Autowired
     RecentArticleRepository recentArticleRepository;
 
-    private Session session;
-
     @BeforeEach
     void setup() {
-        session = Session.getDefaultInstance(new Properties());
         recentArticleRepository.deleteAll();
     }
 
@@ -45,14 +39,12 @@ class RecentArticleEventListenerTest {
         String articleTitle = "테스트 아티클";
         Long memberId = 1L;
         String unsubscribeUrl = "unsubscribeUrl";
-        MimeMessage message = new MimeMessage(session);
-        message.setSubject("테스트 이메일 제목");
-        message.setText("이것은 테스트용 이메일 본문입니다.");
         String contents = "이것은 테스트용 이메일 본문입니다.";
 
         // when
         eventPublisher.publishEvent(ArticleArrivedEvent.of(
-                newsletterId, newsletterName, articleId, articleTitle, memberId, unsubscribeUrl, message, contents));
+                newsletterId, newsletterName, articleId, articleTitle, memberId, unsubscribeUrl, contents,
+                ArticleSource.EMAIL_RECEIVED));
 
         TestTransaction.flagForCommit();
         TestTransaction.end();
@@ -63,7 +55,39 @@ class RecentArticleEventListenerTest {
             softly.assertThat(all).hasSize(1);
             RecentArticle recentArticle = all.get(0);
             softly.assertThat(recentArticle.getArticleId()).isEqualTo(articleId);
-            softly.assertThat(recentArticle.getTitle()).isEqualTo("테스트 이메일 제목");
+            softly.assertThat(recentArticle.getTitle()).isEqualTo(articleTitle);
+            softly.assertThat(recentArticle.getContents()).isEqualTo(contents);
+            softly.assertThat(recentArticle.getMemberId()).isEqualTo(memberId);
+            softly.assertThat(recentArticle.getNewsletterId()).isEqualTo(newsletterId);
+        });
+    }
+
+    @Test
+    @Transactional
+    void 매일메일_발행_이벤트도_RecentArticle을_저장한다() {
+        // given
+        Long newsletterId = 1L;
+        String newsletterName = "매일메일";
+        Long articleId = 10L;
+        String articleTitle = "매일메일 발행 제목";
+        Long memberId = 2L;
+        String contents = "<p>매일메일 본문입니다.</p>";
+
+        // when
+        eventPublisher.publishEvent(ArticleArrivedEvent.of(
+                newsletterId, newsletterName, articleId, articleTitle, memberId, null, contents,
+                ArticleSource.MAEIL_MAIL_ISSUED));
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then
+        assertSoftly(softly -> {
+            List<RecentArticle> all = recentArticleRepository.findAll();
+            softly.assertThat(all).hasSize(1);
+            RecentArticle recentArticle = all.get(0);
+            softly.assertThat(recentArticle.getArticleId()).isEqualTo(articleId);
+            softly.assertThat(recentArticle.getTitle()).isEqualTo(articleTitle);
             softly.assertThat(recentArticle.getContents()).isEqualTo(contents);
             softly.assertThat(recentArticle.getMemberId()).isEqualTo(memberId);
             softly.assertThat(recentArticle.getNewsletterId()).isEqualTo(newsletterId);
@@ -79,21 +103,17 @@ class RecentArticleEventListenerTest {
         Long memberId = 1L;
         String unsubscribeUrl = "unsubscribeUrl";
 
-        MimeMessage message1 = new MimeMessage(session);
-        message1.setSubject("첫 번째 제목");
-        message1.setText("첫 번째 본문");
         String contents1 = "첫 번째 본문";
 
-        MimeMessage message2 = new MimeMessage(session);
-        message2.setSubject("두 번째 제목");
-        message2.setText("두 번째 본문");
         String contents2 = "두 번째 본문";
 
         // when
         eventPublisher.publishEvent(ArticleArrivedEvent.of(
-                newsletterId, newsletterName, 1L, "첫 번째 제목", memberId, unsubscribeUrl, message1, contents1));
+                newsletterId, newsletterName, 1L, "첫 번째 제목", memberId, unsubscribeUrl, contents1,
+                ArticleSource.EMAIL_RECEIVED));
         eventPublisher.publishEvent(ArticleArrivedEvent.of(
-                newsletterId, newsletterName, 2L, "두 번째 제목", memberId, unsubscribeUrl, message2, contents2));
+                newsletterId, newsletterName, 2L, "두 번째 제목", memberId, unsubscribeUrl, contents2,
+                ArticleSource.EMAIL_RECEIVED));
 
         TestTransaction.flagForCommit();
         TestTransaction.end();

--- a/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
@@ -9,6 +9,7 @@ import java.util.Properties;
 import news.bombomemail.article.domain.RecentArticle;
 import news.bombomemail.article.repository.RecentArticleRepository;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
+import news.bombomemail.common.TimeConfig;
 import news.bombomemail.email.extractor.EmailContentExtractor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,7 +20,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({RecentArticleService.class, HtmlCleanerConfig.class})
+@Import({RecentArticleService.class, HtmlCleanerConfig.class, TimeConfig.class})
 class RecentArticleServiceTest {
 
     @Autowired

--- a/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
@@ -51,7 +51,7 @@ class RecentArticleServiceTest {
         String content = EmailContentExtractor.extractContents(msg);
 
         // when
-        recentArticleService.save(articleId, msg, content, memberId, newsletterId);
+        recentArticleService.save(articleId, msg.getSubject(), content, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
@@ -71,6 +71,26 @@ class RecentArticleServiceTest {
     }
 
     @Test
+    void MimeMessage_없이_전달받은_제목으로_RecentArticle을_저장한다() {
+        // given
+        String articleTitle = "매일메일 제목";
+        String content = "<p>매일메일 본문입니다.</p>";
+
+        // when
+        recentArticleService.save(articleId, articleTitle, content, memberId, newsletterId);
+
+        // then
+        assertSoftly(softly -> {
+            RecentArticle recentArticle = recentArticleRepository.findAll().get(0);
+            softly.assertThat(recentArticle.getTitle()).isEqualTo(articleTitle);
+            softly.assertThat(recentArticle.getContents()).isEqualTo(content);
+            softly.assertThat(recentArticle.getContentsText()).isEqualTo("매일메일 본문입니다.");
+            softly.assertThat(recentArticle.getMemberId()).isEqualTo(memberId);
+            softly.assertThat(recentArticle.getNewsletterId()).isEqualTo(newsletterId);
+        });
+    }
+
+    @Test
     void HTML_본문에서_텍스트가_제대로_추출되어_저장() throws Exception {
         // given
         MimeMessage msg = new MimeMessage(session);
@@ -79,7 +99,7 @@ class RecentArticleServiceTest {
         String content = EmailContentExtractor.extractContents(msg);
 
         // when
-        recentArticleService.save(articleId, msg, content, memberId, newsletterId);
+        recentArticleService.save(articleId, msg.getSubject(), content, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
@@ -100,7 +120,7 @@ class RecentArticleServiceTest {
         String content = EmailContentExtractor.extractContents(msg);
 
         // when
-        recentArticleService.save(articleId, msg, content, memberId, newsletterId);
+        recentArticleService.save(articleId, msg.getSubject(), content, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
@@ -128,7 +148,7 @@ class RecentArticleServiceTest {
         String content = EmailContentExtractor.extractContents(msg);
 
         // when
-        recentArticleService.save(articleId, msg, content, memberId, newsletterId);
+        recentArticleService.save(articleId, msg.getSubject(), content, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {
@@ -153,8 +173,8 @@ class RecentArticleServiceTest {
         String content2 = EmailContentExtractor.extractContents(msg2);
 
         // when
-        recentArticleService.save(1L, msg1, content1, memberId, newsletterId);
-        recentArticleService.save(2L, msg2, content2, memberId, newsletterId);
+        recentArticleService.save(1L, msg1.getSubject(), content1, memberId, newsletterId);
+        recentArticleService.save(2L, msg2.getSubject(), content2, memberId, newsletterId);
 
         // then
         assertSoftly(softly -> {

--- a/backend/mail-server/src/test/java/news/bombomemail/common/SchedulingConfigTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/common/SchedulingConfigTest.java
@@ -1,0 +1,23 @@
+package news.bombomemail.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DataJpaTest
+@Import(SchedulingConfig.class)
+class SchedulingConfigTest {
+
+    @Autowired
+    private LockProvider lockProvider;
+
+    @Test
+    void scheduler_lock_provider_bean을_로딩한다() {
+        assertThat(lockProvider).isInstanceOf(JdbcTemplateLockProvider.class);
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobTest.java
@@ -1,0 +1,79 @@
+package news.bombomemail.nativenewsletter.maeilmail.domain;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
+import org.junit.jupiter.api.Test;
+
+class MaeilMailIssueJobTest {
+
+    @Test
+    void chunk_기록시_cursor와_발행_count를_누적한다() {
+        // given
+        MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(
+                LocalDate.of(2026, 4, 27),
+                0L,
+                LocalDateTime.of(2026, 4, 27, 7, 0)
+        );
+
+        // when
+        issueJob.recordChunk(IssueChunkResult.of(10L, 2, 1, 0));
+        issueJob.recordChunk(IssueChunkResult.of(20L, 3, 2, 1));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issueJob.getStatus()).isEqualTo(MaeilMailIssueJobStatus.RUNNING);
+            softly.assertThat(issueJob.getLastProcessedTrackId()).isEqualTo(20L);
+            softly.assertThat(issueJob.getChunkCount()).isEqualTo(2);
+            softly.assertThat(issueJob.getProcessedTrackCount()).isEqualTo(5);
+            softly.assertThat(issueJob.getIssuedArticleCount()).isEqualTo(3);
+            softly.assertThat(issueJob.getPreviouslyIssuedTrackCount()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void 실패한_job을_resume하면_cursor를_유지하고_running으로_돌린다() {
+        // given
+        MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(
+                LocalDate.of(2026, 4, 27),
+                0L,
+                LocalDateTime.of(2026, 4, 27, 7, 0)
+        );
+        issueJob.recordChunk(IssueChunkResult.of(10L, 2, 1, 0));
+        issueJob.fail("fail", LocalDateTime.of(2026, 4, 27, 7, 10));
+
+        // when
+        issueJob.resume(LocalDateTime.of(2026, 4, 27, 7, 20));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issueJob.getStatus()).isEqualTo(MaeilMailIssueJobStatus.RUNNING);
+            softly.assertThat(issueJob.getLastProcessedTrackId()).isEqualTo(10L);
+            softly.assertThat(issueJob.getFailedMessage()).isNull();
+            softly.assertThat(issueJob.getFailedAt()).isNull();
+        });
+    }
+
+    @Test
+    void complete하면_완료상태와_완료시각을_기록한다() {
+        // given
+        LocalDateTime completedAt = LocalDateTime.of(2026, 4, 27, 7, 30);
+        MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(
+                LocalDate.of(2026, 4, 27),
+                0L,
+                LocalDateTime.of(2026, 4, 27, 7, 0)
+        );
+
+        // when
+        issueJob.complete(completedAt);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issueJob.getStatus()).isEqualTo(MaeilMailIssueJobStatus.COMPLETED);
+            softly.assertThat(issueJob.getCompletedAt()).isEqualTo(completedAt);
+            softly.assertThat(issueJob.isCompleted()).isTrue();
+        });
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobTest.java
@@ -57,6 +57,28 @@ class MaeilMailIssueJobTest {
     }
 
     @Test
+    void fail하면_실패메시지를_최대_1000자로_저장한다() {
+        // given
+        MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(
+                LocalDate.of(2026, 4, 27),
+                0L,
+                LocalDateTime.of(2026, 4, 27, 7, 0)
+        );
+        String failedMessage = "a".repeat(1001);
+        LocalDateTime failedAt = LocalDateTime.of(2026, 4, 27, 7, 10);
+
+        // when
+        issueJob.fail(failedMessage, failedAt);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issueJob.getStatus()).isEqualTo(MaeilMailIssueJobStatus.FAILED);
+            softly.assertThat(issueJob.getFailedMessage()).hasSize(1000);
+            softly.assertThat(issueJob.getFailedAt()).isEqualTo(failedAt);
+        });
+    }
+
+    @Test
     void complete하면_완료상태와_완료시각을_기록한다() {
         // given
         LocalDateTime completedAt = LocalDateTime.of(2026, 4, 27, 7, 30);

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobTest.java
@@ -1,5 +1,6 @@
 package news.bombomemail.nativenewsletter.maeilmail.domain;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.time.LocalDate;
@@ -97,5 +98,43 @@ class MaeilMailIssueJobTest {
             softly.assertThat(issueJob.getCompletedAt()).isEqualTo(completedAt);
             softly.assertThat(issueJob.isCompleted()).isTrue();
         });
+    }
+
+    @Test
+    void 이미_완료된_job을_complete하면_완료시각을_덮어쓰지_않는다() {
+        // given
+        MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(
+                LocalDate.of(2026, 4, 27),
+                0L,
+                LocalDateTime.of(2026, 4, 27, 7, 0)
+        );
+        LocalDateTime firstCompletedAt = LocalDateTime.of(2026, 4, 27, 7, 30);
+        LocalDateTime secondCompletedAt = LocalDateTime.of(2026, 4, 27, 8, 0);
+        issueJob.complete(firstCompletedAt);
+
+        // when
+        issueJob.complete(secondCompletedAt);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issueJob.getStatus()).isEqualTo(MaeilMailIssueJobStatus.COMPLETED);
+            softly.assertThat(issueJob.getCompletedAt()).isEqualTo(firstCompletedAt);
+        });
+    }
+
+    @Test
+    void running이_아닌_job은_complete할_수_없다() {
+        // given
+        MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(
+                LocalDate.of(2026, 4, 27),
+                0L,
+                LocalDateTime.of(2026, 4, 27, 7, 0)
+        );
+        issueJob.fail("fail", LocalDateTime.of(2026, 4, 27, 7, 10));
+
+        // when & then
+        assertThatThrownBy(() -> issueJob.complete(LocalDateTime.of(2026, 4, 27, 7, 30)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("실행 중인 매일메일 발행 job만 완료할 수 있습니다.");
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/domain/MaeilMailIssueJobTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class MaeilMailIssueJobTest {
 
     @Test
-    void chunk_기록시_cursor와_발행_count를_누적한다() {
+    void 발행_chunk_기록시_cursor와_발행_count를_누적한다() {
         // given
         MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(
                 LocalDate.of(2026, 4, 27),
@@ -20,8 +20,8 @@ class MaeilMailIssueJobTest {
         );
 
         // when
-        issueJob.recordChunk(IssueChunkResult.of(10L, 2, 1, 0));
-        issueJob.recordChunk(IssueChunkResult.of(20L, 3, 2, 1));
+        issueJob.recordPublishedChunk(IssueChunkResult.of(10L, 2, 1, 0));
+        issueJob.recordPublishedChunk(IssueChunkResult.of(20L, 3, 2, 1));
 
         // then
         assertSoftly(softly -> {
@@ -42,7 +42,7 @@ class MaeilMailIssueJobTest {
                 0L,
                 LocalDateTime.of(2026, 4, 27, 7, 0)
         );
-        issueJob.recordChunk(IssueChunkResult.of(10L, 2, 1, 0));
+        issueJob.recordPublishedChunk(IssueChunkResult.of(10L, 2, 1, 0));
         issueJob.fail("fail", LocalDateTime.of(2026, 4, 27, 7, 10));
 
         // when

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueJobRepositoryTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailIssueJobRepositoryTest.java
@@ -1,0 +1,71 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJobStatus;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class MaeilMailIssueJobRepositoryTest {
+
+    @Autowired
+    private MaeilMailIssueJobRepository issueJobRepository;
+
+    @Test
+    void 미완료_job_재개_조회는_오늘_issueDate에_해당하는_job만_조회한다() {
+        // given
+        LocalDate today = LocalDate.of(2026, 4, 27);
+        LocalDate yesterday = today.minusDays(1);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob yesterdayJob = issueJobRepository.save(MaeilMailIssueJob.start(
+                yesterday,
+                10L,
+                startedAt.minusDays(1)
+        ));
+        MaeilMailIssueJob todayJob = issueJobRepository.save(MaeilMailIssueJob.start(
+                today,
+                20L,
+                startedAt
+        ));
+
+        // when
+        Optional<MaeilMailIssueJob> result = issueJobRepository.findByIssueDateAndStatusIn(today, List.of(
+                MaeilMailIssueJobStatus.RUNNING,
+                MaeilMailIssueJobStatus.FAILED
+        ));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result).isPresent();
+            softly.assertThat(result.get().getId()).isEqualTo(todayJob.getId());
+            softly.assertThat(result.get().getId()).isNotEqualTo(yesterdayJob.getId());
+            softly.assertThat(result.get().getIssueDate()).isEqualTo(today);
+        });
+    }
+
+    @Test
+    void 오늘_job이어도_completed이면_미완료_재개_조회에서_제외한다() {
+        // given
+        LocalDate today = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob completedJob = MaeilMailIssueJob.start(today, 20L, startedAt);
+        completedJob.complete(startedAt.plusMinutes(10));
+        issueJobRepository.save(completedJob);
+
+        // when
+        Optional<MaeilMailIssueJob> result = issueJobRepository.findByIssueDateAndStatusIn(today, List.of(
+                MaeilMailIssueJobStatus.RUNNING,
+                MaeilMailIssueJobStatus.FAILED
+        ));
+
+        // then
+        assertSoftly(softly -> softly.assertThat(result).isEmpty());
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailMemberTopicRepositoryTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailMemberTopicRepositoryTest.java
@@ -1,0 +1,117 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class MaeilMailMemberTopicRepositoryTest {
+
+    @Autowired
+    private MaeilMailSentContentRepository sentContentRepository;
+
+    @Autowired
+    private MaeilMailIssueHistoryRepository issueHistoryRepository;
+
+    @BeforeEach
+    void setup() {
+        sentContentRepository.deleteAll();
+        issueHistoryRepository.deleteAll();
+    }
+
+    @Test
+    void sent_content는_member_topic_pair를_정확히_조회한다() {
+        // given
+        MaeilMailSentContent target = createSentContent(1L, 10L, 100L);
+        MaeilMailSentContent crossProduct = createSentContent(1L, 20L, 200L);
+        MaeilMailSentContent other = createSentContent(2L, 10L, 300L);
+        sentContentRepository.saveAll(List.of(target, crossProduct, other));
+
+        // when
+        List<MaeilMailSentContent> sentContents = sentContentRepository.findAllByMemberTopicKeys(List.of(
+                new MemberTopicKey(1L, 10L),
+                new MemberTopicKey(2L, 20L)
+        ));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(sentContents).hasSize(1);
+            softly.assertThat(sentContents.getFirst().getMemberId()).isEqualTo(1L);
+            softly.assertThat(sentContents.getFirst().getTopicId()).isEqualTo(10L);
+            softly.assertThat(sentContents.getFirst().getContentId()).isEqualTo(100L);
+        });
+    }
+
+    @Test
+    void issue_history는_issue_date와_member_topic_pair를_정확히_조회한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 26);
+        issueHistoryRepository.saveAll(List.of(
+                createIssueHistory(issueDate, 1L, 10L),
+                createIssueHistory(issueDate, 1L, 20L),
+                createIssueHistory(issueDate.minusDays(1), 2L, 20L)
+        ));
+
+        // when
+        Set<MemberTopicKey> issuedKeys = issueHistoryRepository.findIssuedMemberTopicKeys(issueDate, List.of(
+                new MemberTopicKey(1L, 10L),
+                new MemberTopicKey(2L, 20L)
+        ));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issuedKeys).hasSize(1);
+            softly.assertThat(issuedKeys).containsExactly(new MemberTopicKey(1L, 10L));
+        });
+    }
+
+    @Test
+    void issue_history는_100개_이상의_member_topic_key를_정확히_조회한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 26);
+        List<MemberTopicKey> keys = new ArrayList<>();
+        List<MaeilMailIssueHistory> histories = new ArrayList<>();
+        for (long i = 1; i <= 120; i++) {
+            keys.add(new MemberTopicKey(i, i + 1000));
+            if (i % 2 == 0) {
+                histories.add(createIssueHistory(issueDate, i, i + 1000));
+            }
+        }
+        issueHistoryRepository.saveAll(histories);
+
+        // when
+        Set<MemberTopicKey> issuedKeys = issueHistoryRepository.findIssuedMemberTopicKeys(issueDate, keys);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issuedKeys).hasSize(60);
+            softly.assertThat(issuedKeys).allMatch(key -> key.memberId() % 2 == 0);
+        });
+    }
+
+    private MaeilMailSentContent createSentContent(Long memberId, Long topicId, Long contentId) {
+        return MaeilMailSentContent.builder()
+                .memberId(memberId)
+                .topicId(topicId)
+                .contentId(contentId)
+                .build();
+    }
+
+    private MaeilMailIssueHistory createIssueHistory(LocalDate issueDate, Long memberId, Long topicId) {
+        return MaeilMailIssueHistory.builder()
+                .issueDate(issueDate)
+                .memberId(memberId)
+                .topicId(topicId)
+                .build();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailMemberTopicRepositoryTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailMemberTopicRepositoryTest.java
@@ -44,10 +44,16 @@ class MaeilMailMemberTopicRepositoryTest {
     @Test
     void sent_content는_member_topic_pair를_정확히_조회한다() {
         // given
-        MaeilMailSentContent target = createSentContent(1L, 10L, 100L);
-        MaeilMailSentContent crossProduct = createSentContent(1L, 20L, 200L);
-        MaeilMailSentContent other = createSentContent(2L, 10L, 300L);
-        sentContentRepository.saveAll(List.of(target, crossProduct, other));
+        MaeilMailSentContent firstTarget = createSentContent(1L, 10L, 100L);
+        MaeilMailSentContent secondTarget = createSentContent(2L, 20L, 200L);
+        MaeilMailSentContent firstCrossProduct = createSentContent(1L, 20L, 300L);
+        MaeilMailSentContent secondCrossProduct = createSentContent(2L, 10L, 400L);
+        sentContentRepository.saveAll(List.of(
+                firstTarget,
+                secondTarget,
+                firstCrossProduct,
+                secondCrossProduct
+        ));
 
         // when
         List<MaeilMailSentContent> sentContents = sentContentRepository.findAllByMemberTopicKeys(List.of(
@@ -57,10 +63,10 @@ class MaeilMailMemberTopicRepositoryTest {
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(sentContents).hasSize(1);
-            softly.assertThat(sentContents.getFirst().getMemberId()).isEqualTo(1L);
-            softly.assertThat(sentContents.getFirst().getTopicId()).isEqualTo(10L);
-            softly.assertThat(sentContents.getFirst().getContentId()).isEqualTo(100L);
+            softly.assertThat(sentContents).hasSize(2);
+            softly.assertThat(sentContents)
+                    .extracting(MaeilMailSentContent::getContentId)
+                    .containsExactlyInAnyOrder(100L, 200L);
         });
     }
 
@@ -70,20 +76,26 @@ class MaeilMailMemberTopicRepositoryTest {
         LocalDate issueDate = LocalDate.of(2026, 4, 26);
         issueHistoryRepository.saveAll(List.of(
                 createIssueHistory(issueDate, 1L, 10L),
+                createIssueHistory(issueDate, 2L, 20L),
                 createIssueHistory(issueDate, 1L, 20L),
-                createIssueHistory(issueDate.minusDays(1), 2L, 20L)
+                createIssueHistory(issueDate, 2L, 10L),
+                createIssueHistory(issueDate.minusDays(1), 3L, 30L)
         ));
 
         // when
         Set<MemberTopicKey> issuedKeys = issueHistoryRepository.findIssuedMemberTopicKeys(issueDate, List.of(
                 new MemberTopicKey(1L, 10L),
-                new MemberTopicKey(2L, 20L)
+                new MemberTopicKey(2L, 20L),
+                new MemberTopicKey(3L, 30L)
         ));
 
         // then
         assertSoftly(softly -> {
-            softly.assertThat(issuedKeys).hasSize(1);
-            softly.assertThat(issuedKeys).containsExactly(new MemberTopicKey(1L, 10L));
+            softly.assertThat(issuedKeys).hasSize(2);
+            softly.assertThat(issuedKeys).containsExactlyInAnyOrder(
+                    new MemberTopicKey(1L, 10L),
+                    new MemberTopicKey(2L, 20L)
+            );
         });
     }
 

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailMemberTopicRepositoryTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailMemberTopicRepositoryTest.java
@@ -3,9 +3,13 @@ package news.bombomemail.nativenewsletter.maeilmail.repository;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import news.bombomemail.article.domain.Article;
+import news.bombomemail.article.repository.ArticleRepository;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailContent;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
 import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
@@ -23,10 +27,18 @@ class MaeilMailMemberTopicRepositoryTest {
     @Autowired
     private MaeilMailIssueHistoryRepository issueHistoryRepository;
 
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private MaeilMailContentRepository contentRepository;
+
     @BeforeEach
     void setup() {
-        sentContentRepository.deleteAll();
         issueHistoryRepository.deleteAll();
+        sentContentRepository.deleteAll();
+        contentRepository.deleteAll();
+        articleRepository.deleteAll();
     }
 
     @Test
@@ -53,7 +65,7 @@ class MaeilMailMemberTopicRepositoryTest {
     }
 
     @Test
-    void issue_history는_issue_date와_member_topic_pair를_정확히_조회한다() {
+    void issue_history는_article_arrivedDateTime과_content_topic으로_member_topic_pair를_조회한다() {
         // given
         LocalDate issueDate = LocalDate.of(2026, 4, 26);
         issueHistoryRepository.saveAll(List.of(
@@ -108,10 +120,35 @@ class MaeilMailMemberTopicRepositoryTest {
     }
 
     private MaeilMailIssueHistory createIssueHistory(LocalDate issueDate, Long memberId, Long topicId) {
+        Article article = articleRepository.save(createArticle(memberId, issueDate.atTime(7, 0)));
+        MaeilMailContent content = contentRepository.save(createContent(topicId));
         return MaeilMailIssueHistory.builder()
-                .issueDate(issueDate)
+                .articleId(article.getId())
+                .contentId(content.getId())
+                .build();
+    }
+
+    private Article createArticle(Long memberId, LocalDateTime arrivedDateTime) {
+        return Article.builder()
+                .title("매일메일 제목")
+                .contents("<p>본문</p>")
+                .contentsText("본문")
+                .contentsSummary("요약")
+                .expectedReadTime(1)
                 .memberId(memberId)
+                .newsletterId(1L)
+                .arrivedDateTime(arrivedDateTime)
+                .build();
+    }
+
+    private MaeilMailContent createContent(Long topicId) {
+        return MaeilMailContent.builder()
                 .topicId(topicId)
+                .title("매일메일 제목")
+                .content("<p>본문</p>")
+                .contentsText("본문")
+                .contentsSummary("요약")
+                .expectedReadTime(1)
                 .build();
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSubscriptionTrackRepositoryTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/repository/MaeilMailSubscriptionTrackRepositoryTest.java
@@ -1,0 +1,155 @@
+package news.bombomemail.nativenewsletter.maeilmail.repository;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.util.List;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTrack;
+import news.bombomemail.newsletter.domain.Newsletter;
+import news.bombomemail.newsletter.domain.NewsletterPublicationStatus;
+import news.bombomemail.newsletter.domain.NewsletterSource;
+import news.bombomemail.newsletter.repository.NewsletterRepository;
+import news.bombomemail.subscribe.domain.Subscribe;
+import news.bombomemail.subscribe.domain.SubscribeStatus;
+import news.bombomemail.subscribe.repository.SubscribeRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DataJpaTest
+class MaeilMailSubscriptionTrackRepositoryTest {
+
+    @Autowired
+    private MaeilMailSubscriptionTrackRepository trackRepository;
+
+    @Autowired
+    private NewsletterRepository newsletterRepository;
+
+    @Autowired
+    private SubscribeRepository subscribeRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    void 발행대상은_subscribed_maeil_mail_active이고_오늘_미발행_track만_id순으로_조회한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        Newsletter maeilMail = saveNewsletter("maeil", NewsletterSource.MAEIL_MAIL,
+                NewsletterPublicationStatus.ACTIVE);
+        Newsletter externalNewsletter = saveNewsletter("external", NewsletterSource.EXTERNAL,
+                NewsletterPublicationStatus.ACTIVE);
+        Newsletter suspendedMaeilMail = saveNewsletter("suspended", NewsletterSource.MAEIL_MAIL,
+                NewsletterPublicationStatus.SUSPENDED);
+
+        MaeilMailSubscriptionTrack firstTarget = saveTrack(maeilMail, 1L, SubscribeStatus.SUBSCRIBED, null, 0);
+        MaeilMailSubscriptionTrack secondTarget = saveTrack(maeilMail, 2L, SubscribeStatus.SUBSCRIBED,
+                issueDate.minusDays(1), 0);
+        saveTrack(maeilMail, 3L, SubscribeStatus.SUBSCRIBED, issueDate, 0);
+        saveTrack(maeilMail, 4L, SubscribeStatus.UNSUBSCRIBING, null, 0);
+        saveTrack(externalNewsletter, 5L, SubscribeStatus.SUBSCRIBED, null, 0);
+        saveTrack(suspendedMaeilMail, 6L, SubscribeStatus.SUBSCRIBED, null, 0);
+        flushAndClear();
+
+        // when
+        List<MaeilMailSubscriptionTrack> tracks = trackRepository.findIssueTargetsAfterId(
+                issueDate,
+                SubscribeStatus.SUBSCRIBED,
+                NewsletterSource.MAEIL_MAIL,
+                NewsletterPublicationStatus.ACTIVE,
+                0L,
+                PageRequest.of(0, 10)
+        );
+        List<MaeilMailSubscriptionTrack> nextPage = trackRepository.findIssueTargetsAfterId(
+                issueDate,
+                SubscribeStatus.SUBSCRIBED,
+                NewsletterSource.MAEIL_MAIL,
+                NewsletterPublicationStatus.ACTIVE,
+                firstTarget.getId(),
+                PageRequest.of(0, 1)
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(tracks)
+                    .extracting(MaeilMailSubscriptionTrack::getId)
+                    .containsExactly(firstTarget.getId(), secondTarget.getId());
+            softly.assertThat(nextPage)
+                    .extracting(MaeilMailSubscriptionTrack::getId)
+                    .containsExactly(secondTarget.getId());
+        });
+    }
+
+    @Test
+    void markIssuedByIds는_curriculumIndex와_lastIssuedDate를_갱신한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        Newsletter newsletter = saveNewsletter("maeil", NewsletterSource.MAEIL_MAIL,
+                NewsletterPublicationStatus.ACTIVE);
+        MaeilMailSubscriptionTrack firstTrack = saveTrack(newsletter, 1L, SubscribeStatus.SUBSCRIBED, null, 2);
+        MaeilMailSubscriptionTrack secondTrack = saveTrack(newsletter, 2L, SubscribeStatus.SUBSCRIBED, null, 0);
+        flushAndClear();
+
+        // when
+        trackRepository.markIssuedByIds(List.of(firstTrack.getId(), secondTrack.getId()), issueDate);
+        flushAndClear();
+
+        // then
+        MaeilMailSubscriptionTrack updatedFirstTrack = trackRepository.findById(firstTrack.getId()).orElseThrow();
+        MaeilMailSubscriptionTrack updatedSecondTrack = trackRepository.findById(secondTrack.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(updatedFirstTrack.getCurriculumIndex()).isEqualTo(3);
+            softly.assertThat(updatedFirstTrack.getLastIssuedDate()).isEqualTo(issueDate);
+            softly.assertThat(updatedSecondTrack.getCurriculumIndex()).isEqualTo(1);
+            softly.assertThat(updatedSecondTrack.getLastIssuedDate()).isEqualTo(issueDate);
+        });
+    }
+
+    private Newsletter saveNewsletter(
+            String name,
+            NewsletterSource source,
+            NewsletterPublicationStatus status
+    ) {
+        return newsletterRepository.save(Newsletter.builder()
+                .name(name)
+                .description(name + " description")
+                .imageUrl("image")
+                .email(name + "@example.com")
+                .categoryId(1L)
+                .detailId(1L)
+                .source(source)
+                .status(status)
+                .build());
+    }
+
+    private MaeilMailSubscriptionTrack saveTrack(
+            Newsletter newsletter,
+            Long memberId,
+            SubscribeStatus subscribeStatus,
+            LocalDate lastIssuedDate,
+            int curriculumIndex
+    ) {
+        Subscribe subscribe = subscribeRepository.save(Subscribe.builder()
+                .newsletterId(newsletter.getId())
+                .memberId(memberId)
+                .status(subscribeStatus)
+                .build());
+        MaeilMailSubscriptionTrack track = MaeilMailSubscriptionTrack.builder()
+                .subscribeId(subscribe.getId())
+                .memberId(memberId)
+                .field(MaeilMailTrack.BE)
+                .build();
+        ReflectionTestUtils.setField(track, "lastIssuedDate", lastIssuedDate);
+        ReflectionTestUtils.setField(track, "curriculumIndex", curriculumIndex);
+        return trackRepository.save(track);
+    }
+
+    private void flushAndClear() {
+        entityManager.flush();
+        entityManager.clear();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailIssueStartupResumeExecutorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailIssueStartupResumeExecutorTest.java
@@ -1,0 +1,51 @@
+package news.bombomemail.nativenewsletter.maeilmail.scheduler;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+import news.bombomemail.nativenewsletter.maeilmail.service.MaeilMailIssueService;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssueStartupResumeExecutorTest {
+
+    @Mock
+    private MaeilMailIssueService maeilMailIssueService;
+
+    private MaeilMailIssueStartupResumeExecutor startupResumeExecutor;
+
+    @BeforeEach
+    void setup() {
+        startupResumeExecutor = new MaeilMailIssueStartupResumeExecutor(maeilMailIssueService);
+    }
+
+    @Test
+    void 미완료_매일메일_발행_job_재개를_실행한다() {
+        // when
+        startupResumeExecutor.resumeIncompleteMaeilMailIssueJob();
+
+        // then
+        verify(maeilMailIssueService).resumeIncompleteTodayJob();
+    }
+
+    @Test
+    void 서버_시작_재개_executor는_스케줄러와_같은_락을_사용한다() throws NoSuchMethodException {
+        // given
+        Method method = MaeilMailIssueStartupResumeExecutor.class
+                .getDeclaredMethod("resumeIncompleteMaeilMailIssueJob");
+        SchedulerLock schedulerLock = method.getAnnotation(SchedulerLock.class);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(schedulerLock).isNotNull();
+            softly.assertThat(schedulerLock.name()).isEqualTo("maeil_mail_issue");
+            softly.assertThat(schedulerLock.lockAtMostFor()).isEqualTo("PT30M");
+        });
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailIssueStartupResumeListenerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailIssueStartupResumeListenerTest.java
@@ -1,0 +1,67 @@
+package news.bombomemail.nativenewsletter.maeilmail.scheduler;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.doThrow;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.event.EventListener;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssueStartupResumeListenerTest {
+
+    @Mock
+    private MaeilMailIssueStartupResumeExecutor startupResumeExecutor;
+
+    private MaeilMailIssueStartupResumeListener listener;
+
+    @BeforeEach
+    void setup() {
+        listener = new MaeilMailIssueStartupResumeListener(startupResumeExecutor);
+    }
+
+    @Test
+    void 서버_시작시_미완료_매일메일_발행_job_재개를_시도한다() {
+        // when
+        listener.resumeIncompleteMaeilMailIssueJob();
+
+        // then
+        verify(startupResumeExecutor).resumeIncompleteMaeilMailIssueJob();
+    }
+
+    @Test
+    void 서버_시작시_자동_재개에_실패해도_예외를_전파하지_않는다() {
+        // given
+        doThrow(new RuntimeException("fail")).when(startupResumeExecutor).resumeIncompleteMaeilMailIssueJob();
+
+        // when & then
+        assertThatCode(() -> listener.resumeIncompleteMaeilMailIssueJob())
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void 서버_시작_재개_listener는_설정_없이도_활성화된다() throws NoSuchMethodException {
+        // given
+        ConditionalOnProperty conditionalOnProperty = MaeilMailIssueStartupResumeListener.class
+                .getAnnotation(ConditionalOnProperty.class);
+        Method method = MaeilMailIssueStartupResumeListener.class
+                .getDeclaredMethod("resumeIncompleteMaeilMailIssueJob");
+        EventListener eventListener = method.getAnnotation(EventListener.class);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(conditionalOnProperty).isNotNull();
+            softly.assertThat(conditionalOnProperty.name()).containsExactly("maeil-mail.issue.resume-on-startup");
+            softly.assertThat(conditionalOnProperty.havingValue()).isEqualTo("true");
+            softly.assertThat(conditionalOnProperty.matchIfMissing()).isTrue();
+            softly.assertThat(eventListener).isNotNull();
+        });
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailSchedulerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/scheduler/MaeilMailSchedulerTest.java
@@ -1,0 +1,55 @@
+package news.bombomemail.nativenewsletter.maeilmail.scheduler;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Method;
+import news.bombomemail.nativenewsletter.maeilmail.service.MaeilMailIssueService;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailSchedulerTest {
+
+    @Mock
+    private MaeilMailIssueService maeilMailIssueService;
+
+    private MaeilMailScheduler scheduler;
+
+    @BeforeEach
+    void setup() {
+        scheduler = new MaeilMailScheduler(maeilMailIssueService);
+    }
+
+    @Test
+    void 매일메일_발행_service를_호출한다() {
+        // when
+        scheduler.issueMaeilMail();
+
+        // then
+        verify(maeilMailIssueService).issue();
+    }
+
+    @Test
+    void 매일메일_발행_scheduler_설정이_운영_스케줄과_락을_사용한다() throws NoSuchMethodException {
+        // given
+        Method method = MaeilMailScheduler.class.getDeclaredMethod("issueMaeilMail");
+        Scheduled scheduled = method.getAnnotation(Scheduled.class);
+        SchedulerLock schedulerLock = method.getAnnotation(SchedulerLock.class);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(scheduled).isNotNull();
+            softly.assertThat(scheduled.cron()).isEqualTo("0 0 7 * * MON-FRI");
+            softly.assertThat(scheduled.zone()).isEqualTo("Asia/Seoul");
+            softly.assertThat(schedulerLock).isNotNull();
+            softly.assertThat(schedulerLock.name()).isEqualTo("maeil_mail_issue");
+            softly.assertThat(schedulerLock.lockAtMostFor()).isEqualTo("PT30M");
+        });
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueIntegrationTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueIntegrationTest.java
@@ -1,0 +1,275 @@
+package news.bombomemail.nativenewsletter.maeilmail.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import news.bombomemail.article.domain.Article;
+import news.bombomemail.article.domain.RecentArticle;
+import news.bombomemail.article.repository.ArticleRepository;
+import news.bombomemail.article.repository.RecentArticleRepository;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTrack;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailContentRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueHistoryRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSubscriptionTrackRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailTopicRepository;
+import news.bombomemail.newsletter.domain.Newsletter;
+import news.bombomemail.newsletter.domain.NewsletterPublicationStatus;
+import news.bombomemail.newsletter.domain.NewsletterSource;
+import news.bombomemail.newsletter.repository.NewsletterRepository;
+import news.bombomemail.notification.domain.ArticleArrivalNotification;
+import news.bombomemail.notification.repository.ArticleArrivalNotificationRepository;
+import news.bombomemail.reading.domain.TodayReading;
+import news.bombomemail.reading.repository.TodayReadingRepository;
+import news.bombomemail.subscribe.domain.Subscribe;
+import news.bombomemail.subscribe.repository.SubscribeRepository;
+import news.bombomemail.subscribe.service.SubscribeService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class MaeilMailIssueIntegrationTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+    private static final LocalDate ISSUE_DATE = LocalDate.of(2026, 4, 27);
+
+    @Autowired
+    private MaeilMailIssueService issueService;
+
+    @Autowired
+    private NewsletterRepository newsletterRepository;
+
+    @Autowired
+    private SubscribeRepository subscribeRepository;
+
+    @Autowired
+    private MaeilMailTopicRepository topicRepository;
+
+    @Autowired
+    private MaeilMailContentRepository contentRepository;
+
+    @Autowired
+    private MaeilMailSubscriptionTrackRepository trackRepository;
+
+    @Autowired
+    private MaeilMailSentContentRepository sentContentRepository;
+
+    @Autowired
+    private MaeilMailIssueHistoryRepository issueHistoryRepository;
+
+    @Autowired
+    private ArticleRepository articleRepository;
+
+    @Autowired
+    private RecentArticleRepository recentArticleRepository;
+
+    @Autowired
+    private ArticleArrivalNotificationRepository notificationRepository;
+
+    @Autowired
+    private TodayReadingRepository todayReadingRepository;
+
+    @MockitoBean
+    private SubscribeService subscribeService;
+
+    @BeforeEach
+    void setup() {
+        issueHistoryRepository.deleteAll();
+        sentContentRepository.deleteAll();
+        trackRepository.deleteAll();
+        contentRepository.deleteAll();
+        topicRepository.deleteAll();
+        todayReadingRepository.deleteAll();
+        notificationRepository.deleteAll();
+        recentArticleRepository.deleteAll();
+        articleRepository.deleteAll();
+        subscribeRepository.deleteAll();
+        newsletterRepository.deleteAll();
+    }
+
+    @Test
+    void 매일메일_발행결과를_article로_저장하고_기존_article_이벤트_흐름을_탄다() {
+        // given
+        Long memberId = 100L;
+        Newsletter newsletter = newsletterRepository.save(Newsletter.builder()
+                .name("매일메일")
+                .description("매일메일 설명")
+                .imageUrl("image")
+                .email("maeil@example.com")
+                .categoryId(1L)
+                .detailId(1L)
+                .source(NewsletterSource.MAEIL_MAIL)
+                .status(NewsletterPublicationStatus.ACTIVE)
+                .build());
+        Subscribe firstSubscribe = subscribeRepository.save(createSubscribe(newsletter.getId(), memberId));
+        Subscribe secondSubscribe = subscribeRepository.save(createSubscribe(newsletter.getId(), memberId));
+        MaeilMailTopic topic = topicRepository.save(MaeilMailTopic.builder()
+                .track(MaeilMailTrack.BE)
+                .name("Spring")
+                .displayOrder(1)
+                .build());
+        contentRepository.save(MaeilMailContent.builder()
+                .topicId(topic.getId())
+                .title("매일메일 제목")
+                .content("<p>매일메일 본문</p>")
+                .contentsText("매일메일 본문")
+                .contentsSummary("매일메일 요약")
+                .expectedReadTime(3)
+                .build());
+        trackRepository.saveAll(List.of(
+                createTrack(firstSubscribe.getId(), memberId, MaeilMailTrack.BE),
+                createTrack(secondSubscribe.getId(), memberId, MaeilMailTrack.BE)
+        ));
+        todayReadingRepository.save(TodayReading.builder()
+                .memberId(memberId)
+                .totalCount(0)
+                .currentCount(0)
+                .build());
+
+        // when
+        issueService.issue();
+
+        // then
+        List<Article> articles = articleRepository.findAll();
+        List<RecentArticle> recentArticles = recentArticleRepository.findAll();
+        List<ArticleArrivalNotification> notifications = notificationRepository.findAll();
+        List<MaeilMailSentContent> sentContents = sentContentRepository.findAll();
+        List<MaeilMailIssueHistory> issueHistories = issueHistoryRepository.findAll();
+        List<MaeilMailSubscriptionTrack> tracks = trackRepository.findAll();
+        TodayReading todayReading = todayReadingRepository.findByMemberId(memberId).orElseThrow();
+
+        assertSoftly(softly -> {
+            softly.assertThat(articles).hasSize(1);
+            Article article = articles.getFirst();
+            softly.assertThat(article.getTitle()).isEqualTo("매일메일 제목");
+            softly.assertThat(article.getContents()).isEqualTo("<p>매일메일 본문</p>");
+            softly.assertThat(article.getMemberId()).isEqualTo(memberId);
+            softly.assertThat(article.getNewsletterId()).isEqualTo(newsletter.getId());
+
+            softly.assertThat(recentArticles).hasSize(1);
+            softly.assertThat(recentArticles.getFirst().getArticleId()).isEqualTo(article.getId());
+            softly.assertThat(recentArticles.getFirst().getTitle()).isEqualTo("매일메일 제목");
+
+            softly.assertThat(notifications).hasSize(1);
+            softly.assertThat(notifications.getFirst().getArticleId()).isEqualTo(article.getId());
+            softly.assertThat(notifications.getFirst().getNewsletterName()).isEqualTo("매일메일");
+
+            softly.assertThat(todayReading.getTotalCount()).isEqualTo(1);
+            softly.assertThat(sentContents).hasSize(1);
+            softly.assertThat(sentContents.getFirst().getMemberId()).isEqualTo(memberId);
+            softly.assertThat(sentContents.getFirst().getTopicId()).isEqualTo(topic.getId());
+
+            softly.assertThat(issueHistories).hasSize(1);
+            softly.assertThat(issueHistories.getFirst().getIssueDate()).isEqualTo(ISSUE_DATE);
+            softly.assertThat(issueHistories.getFirst().getMemberId()).isEqualTo(memberId);
+            softly.assertThat(issueHistories.getFirst().getTopicId()).isEqualTo(topic.getId());
+
+            softly.assertThat(tracks).hasSize(2);
+            softly.assertThat(tracks).allSatisfy(track -> {
+                softly.assertThat(track.getCurriculumIndex()).isEqualTo(1);
+                softly.assertThat(track.getLastIssuedDate()).isEqualTo(ISSUE_DATE);
+            });
+        });
+        verifyNoInteractions(subscribeService);
+    }
+
+    @Test
+    void 같은_날_재실행해도_article과_발행이력을_중복_생성하지_않는다() {
+        // given
+        Long memberId = 100L;
+        Newsletter newsletter = newsletterRepository.save(Newsletter.builder()
+                .name("매일메일")
+                .description("매일메일 설명")
+                .imageUrl("image")
+                .email("maeil@example.com")
+                .categoryId(1L)
+                .detailId(1L)
+                .source(NewsletterSource.MAEIL_MAIL)
+                .status(NewsletterPublicationStatus.ACTIVE)
+                .build());
+        Subscribe subscribe = subscribeRepository.save(createSubscribe(newsletter.getId(), memberId));
+        MaeilMailTopic topic = topicRepository.save(MaeilMailTopic.builder()
+                .track(MaeilMailTrack.BE)
+                .name("Spring")
+                .displayOrder(1)
+                .build());
+        contentRepository.save(MaeilMailContent.builder()
+                .topicId(topic.getId())
+                .title("매일메일 제목")
+                .content("<p>매일메일 본문</p>")
+                .contentsText("매일메일 본문")
+                .contentsSummary("매일메일 요약")
+                .expectedReadTime(3)
+                .build());
+        trackRepository.save(createTrack(subscribe.getId(), memberId, MaeilMailTrack.BE));
+        todayReadingRepository.save(TodayReading.builder()
+                .memberId(memberId)
+                .totalCount(0)
+                .currentCount(0)
+                .build());
+
+        // when
+        issueService.issue();
+        issueService.issue();
+
+        // then
+        List<MaeilMailSubscriptionTrack> tracks = trackRepository.findAll();
+        TodayReading todayReading = todayReadingRepository.findByMemberId(memberId).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(articleRepository.findAll()).hasSize(1);
+            softly.assertThat(recentArticleRepository.findAll()).hasSize(1);
+            softly.assertThat(notificationRepository.findAll()).hasSize(1);
+            softly.assertThat(sentContentRepository.findAll()).hasSize(1);
+            softly.assertThat(issueHistoryRepository.findAll()).hasSize(1);
+            softly.assertThat(todayReading.getTotalCount()).isEqualTo(1);
+            softly.assertThat(tracks).hasSize(1);
+            softly.assertThat(tracks.getFirst().getCurriculumIndex()).isEqualTo(1);
+            softly.assertThat(tracks.getFirst().getLastIssuedDate()).isEqualTo(ISSUE_DATE);
+        });
+        verifyNoInteractions(subscribeService);
+    }
+
+    private Subscribe createSubscribe(Long newsletterId, Long memberId) {
+        return Subscribe.builder()
+                .newsletterId(newsletterId)
+                .memberId(memberId)
+                .build();
+    }
+
+    private MaeilMailSubscriptionTrack createTrack(Long subscribeId, Long memberId, MaeilMailTrack field) {
+        return MaeilMailSubscriptionTrack.builder()
+                .subscribeId(subscribeId)
+                .memberId(memberId)
+                .field(field)
+                .build();
+    }
+
+    @TestConfiguration
+    static class FixedClockConfig {
+
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            LocalDateTime fixedDateTime = LocalDateTime.of(2026, 4, 27, 7, 0);
+            return Clock.fixed(fixedDateTime.atZone(SEOUL).toInstant(), SEOUL);
+        }
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueIntegrationTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueIntegrationTest.java
@@ -14,12 +14,15 @@ import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.repository.RecentArticleRepository;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailContent;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJobStatus;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTrack;
 import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailContentRepository;
 import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueHistoryRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueJobRepository;
 import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
 import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSubscriptionTrackRepository;
 import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailTopicRepository;
@@ -76,6 +79,9 @@ class MaeilMailIssueIntegrationTest {
     private MaeilMailIssueHistoryRepository issueHistoryRepository;
 
     @Autowired
+    private MaeilMailIssueJobRepository issueJobRepository;
+
+    @Autowired
     private ArticleRepository articleRepository;
 
     @Autowired
@@ -92,6 +98,7 @@ class MaeilMailIssueIntegrationTest {
 
     @BeforeEach
     void setup() {
+        issueJobRepository.deleteAll();
         issueHistoryRepository.deleteAll();
         sentContentRepository.deleteAll();
         trackRepository.deleteAll();
@@ -134,7 +141,7 @@ class MaeilMailIssueIntegrationTest {
                 .contentsSummary("매일메일 요약")
                 .expectedReadTime(3)
                 .build());
-        trackRepository.saveAll(List.of(
+        List<MaeilMailSubscriptionTrack> savedTracks = trackRepository.saveAll(List.of(
                 createTrack(firstSubscribe.getId(), memberId, MaeilMailTrack.BE),
                 createTrack(secondSubscribe.getId(), memberId, MaeilMailTrack.BE)
         ));
@@ -153,6 +160,7 @@ class MaeilMailIssueIntegrationTest {
         List<ArticleArrivalNotification> notifications = notificationRepository.findAll();
         List<MaeilMailSentContent> sentContents = sentContentRepository.findAll();
         List<MaeilMailIssueHistory> issueHistories = issueHistoryRepository.findAll();
+        List<MaeilMailIssueJob> issueJobs = issueJobRepository.findAll();
         List<MaeilMailSubscriptionTrack> tracks = trackRepository.findAll();
         TodayReading todayReading = todayReadingRepository.findByMemberId(memberId).orElseThrow();
 
@@ -187,6 +195,17 @@ class MaeilMailIssueIntegrationTest {
                 softly.assertThat(track.getCurriculumIndex()).isEqualTo(1);
                 softly.assertThat(track.getLastIssuedDate()).isEqualTo(ISSUE_DATE);
             });
+
+            softly.assertThat(issueJobs).hasSize(1);
+            softly.assertThat(issueJobs.getFirst().getIssueDate()).isEqualTo(ISSUE_DATE);
+            softly.assertThat(issueJobs.getFirst().getStatus()).isEqualTo(MaeilMailIssueJobStatus.COMPLETED);
+            softly.assertThat(issueJobs.getFirst().getLastProcessedTrackId())
+                    .isEqualTo(savedTracks.getLast().getId());
+            softly.assertThat(issueJobs.getFirst().getChunkCount()).isEqualTo(1);
+            softly.assertThat(issueJobs.getFirst().getProcessedTrackCount()).isEqualTo(2);
+            softly.assertThat(issueJobs.getFirst().getIssuedArticleCount()).isEqualTo(1);
+            softly.assertThat(issueJobs.getFirst().getPreviouslyIssuedTrackCount()).isZero();
+            softly.assertThat(issueJobs.getFirst().getCompletedAt()).isNotNull();
         });
         verifyNoInteractions(subscribeService);
     }
@@ -232,6 +251,7 @@ class MaeilMailIssueIntegrationTest {
 
         // then
         List<MaeilMailSubscriptionTrack> tracks = trackRepository.findAll();
+        List<MaeilMailIssueJob> issueJobs = issueJobRepository.findAll();
         TodayReading todayReading = todayReadingRepository.findByMemberId(memberId).orElseThrow();
         assertSoftly(softly -> {
             softly.assertThat(articleRepository.findAll()).hasSize(1);
@@ -243,6 +263,10 @@ class MaeilMailIssueIntegrationTest {
             softly.assertThat(tracks).hasSize(1);
             softly.assertThat(tracks.getFirst().getCurriculumIndex()).isEqualTo(1);
             softly.assertThat(tracks.getFirst().getLastIssuedDate()).isEqualTo(ISSUE_DATE);
+            softly.assertThat(issueJobs).hasSize(1);
+            softly.assertThat(issueJobs.getFirst().getStatus()).isEqualTo(MaeilMailIssueJobStatus.COMPLETED);
+            softly.assertThat(issueJobs.getFirst().getChunkCount()).isEqualTo(1);
+            softly.assertThat(issueJobs.getFirst().getIssuedArticleCount()).isEqualTo(1);
         });
         verifyNoInteractions(subscribeService);
     }

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueIntegrationTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueIntegrationTest.java
@@ -126,7 +126,7 @@ class MaeilMailIssueIntegrationTest {
                 .name("Spring")
                 .displayOrder(1)
                 .build());
-        contentRepository.save(MaeilMailContent.builder()
+        MaeilMailContent content = contentRepository.save(MaeilMailContent.builder()
                 .topicId(topic.getId())
                 .title("매일메일 제목")
                 .content("<p>매일메일 본문</p>")
@@ -176,11 +176,11 @@ class MaeilMailIssueIntegrationTest {
             softly.assertThat(sentContents).hasSize(1);
             softly.assertThat(sentContents.getFirst().getMemberId()).isEqualTo(memberId);
             softly.assertThat(sentContents.getFirst().getTopicId()).isEqualTo(topic.getId());
+            softly.assertThat(sentContents.getFirst().getContentId()).isEqualTo(content.getId());
 
             softly.assertThat(issueHistories).hasSize(1);
-            softly.assertThat(issueHistories.getFirst().getIssueDate()).isEqualTo(ISSUE_DATE);
-            softly.assertThat(issueHistories.getFirst().getMemberId()).isEqualTo(memberId);
-            softly.assertThat(issueHistories.getFirst().getTopicId()).isEqualTo(topic.getId());
+            softly.assertThat(issueHistories.getFirst().getArticleId()).isEqualTo(article.getId());
+            softly.assertThat(issueHistories.getFirst().getContentId()).isEqualTo(content.getId());
 
             softly.assertThat(tracks).hasSize(2);
             softly.assertThat(tracks).allSatisfy(track -> {

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueServiceTest.java
@@ -31,6 +31,7 @@ class MaeilMailIssueServiceTest {
     @BeforeEach
     void setup() {
         issueService = new MaeilMailIssueService(clockAt(LocalDateTime.of(2026, 4, 27, 7, 0)), chunkProcessor);
+        ReflectionTestUtils.setField(issueService, "issueChunkSize", 200);
     }
 
     @Test

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueServiceTest.java
@@ -1,0 +1,88 @@
+package news.bombomemail.nativenewsletter.maeilmail.service;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
+import news.bombomemail.nativenewsletter.maeilmail.service.internal.MaeilMailIssueChunkProcessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssueServiceTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private MaeilMailIssueChunkProcessor chunkProcessor;
+
+    private MaeilMailIssueService issueService;
+
+    @BeforeEach
+    void setup() {
+        issueService = new MaeilMailIssueService(clockAt(LocalDateTime.of(2026, 4, 27, 7, 0)), chunkProcessor);
+    }
+
+    @Test
+    void 주말이면_발행하지_않는다() {
+        // given
+        MaeilMailIssueService weekendIssueService = new MaeilMailIssueService(
+                clockAt(LocalDateTime.of(2026, 4, 26, 7, 0)),
+                chunkProcessor
+        );
+
+        // when
+        weekendIssueService.issue();
+
+        // then
+        verifyNoInteractions(chunkProcessor);
+    }
+
+    @Test
+    void 평일이면_chunk가_없을_때까지_순차적으로_처리한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        PageRequest pageRequest = PageRequest.of(0, 200);
+        given(chunkProcessor.process(issueDate, 0L, pageRequest))
+                .willReturn(IssueChunkResult.of(10L, 2, 1, 0));
+        given(chunkProcessor.process(issueDate, 10L, pageRequest))
+                .willReturn(IssueChunkResult.empty());
+
+        // when
+        issueService.issue();
+
+        // then
+        verify(chunkProcessor).process(issueDate, 0L, pageRequest);
+        verify(chunkProcessor).process(issueDate, 10L, pageRequest);
+    }
+
+    @Test
+    void chunkSize가_1보다_작으면_1로_보정한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        ReflectionTestUtils.setField(issueService, "issueChunkSize", 0);
+        given(chunkProcessor.process(issueDate, 0L, pageRequest))
+                .willReturn(IssueChunkResult.empty());
+
+        // when
+        issueService.issue();
+
+        // then
+        verify(chunkProcessor).process(issueDate, 0L, pageRequest);
+    }
+
+    private Clock clockAt(LocalDateTime localDateTime) {
+        return Clock.fixed(localDateTime.atZone(SEOUL).toInstant(), SEOUL);
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueServiceTest.java
@@ -8,8 +8,10 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
 import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
 import news.bombomemail.nativenewsletter.maeilmail.service.internal.MaeilMailIssueChunkProcessor;
+import news.bombomemail.nativenewsletter.maeilmail.service.internal.MaeilMailIssueJobManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,11 +28,18 @@ class MaeilMailIssueServiceTest {
     @Mock
     private MaeilMailIssueChunkProcessor chunkProcessor;
 
+    @Mock
+    private MaeilMailIssueJobManager issueJobManager;
+
     private MaeilMailIssueService issueService;
 
     @BeforeEach
     void setup() {
-        issueService = new MaeilMailIssueService(clockAt(LocalDateTime.of(2026, 4, 27, 7, 0)), chunkProcessor);
+        issueService = new MaeilMailIssueService(
+                clockAt(LocalDateTime.of(2026, 4, 27, 7, 0)),
+                chunkProcessor,
+                issueJobManager
+        );
         ReflectionTestUtils.setField(issueService, "issueChunkSize", 200);
     }
 
@@ -39,51 +48,125 @@ class MaeilMailIssueServiceTest {
         // given
         MaeilMailIssueService weekendIssueService = new MaeilMailIssueService(
                 clockAt(LocalDateTime.of(2026, 4, 26, 7, 0)),
-                chunkProcessor
+                chunkProcessor,
+                issueJobManager
         );
 
         // when
         weekendIssueService.issue();
 
         // then
-        verifyNoInteractions(chunkProcessor);
+        verifyNoInteractions(chunkProcessor, issueJobManager);
     }
 
     @Test
     void 평일이면_chunk가_없을_때까지_순차적으로_처리한다() {
         // given
         LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, 0L, startedAt);
         PageRequest pageRequest = PageRequest.of(0, 200);
-        given(chunkProcessor.process(issueDate, 0L, pageRequest))
+        given(issueJobManager.startOrResume(issueDate, startedAt)).willReturn(issueJob);
+        given(chunkProcessor.process(1L, issueDate, 0L, pageRequest))
                 .willReturn(IssueChunkResult.of(10L, 2, 1, 0));
-        given(chunkProcessor.process(issueDate, 10L, pageRequest))
+        given(chunkProcessor.process(1L, issueDate, 10L, pageRequest))
                 .willReturn(IssueChunkResult.empty());
+        given(issueJobManager.complete(1L, startedAt)).willReturn(issueJob);
 
         // when
         issueService.issue();
 
         // then
-        verify(chunkProcessor).process(issueDate, 0L, pageRequest);
-        verify(chunkProcessor).process(issueDate, 10L, pageRequest);
+        verify(chunkProcessor).process(1L, issueDate, 0L, pageRequest);
+        verify(chunkProcessor).process(1L, issueDate, 10L, pageRequest);
+        verify(issueJobManager).complete(1L, startedAt);
     }
 
     @Test
     void chunkSize가_1보다_작으면_1로_보정한다() {
         // given
         LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, 0L, startedAt);
         PageRequest pageRequest = PageRequest.of(0, 1);
         ReflectionTestUtils.setField(issueService, "issueChunkSize", 0);
-        given(chunkProcessor.process(issueDate, 0L, pageRequest))
+        given(issueJobManager.startOrResume(issueDate, startedAt)).willReturn(issueJob);
+        given(chunkProcessor.process(1L, issueDate, 0L, pageRequest))
                 .willReturn(IssueChunkResult.empty());
+        given(issueJobManager.complete(1L, startedAt)).willReturn(issueJob);
 
         // when
         issueService.issue();
 
         // then
-        verify(chunkProcessor).process(issueDate, 0L, pageRequest);
+        verify(chunkProcessor).process(1L, issueDate, 0L, pageRequest);
+    }
+
+    @Test
+    void 완료된_job이면_발행하지_않는다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, 0L, startedAt);
+        issueJob.complete(startedAt);
+        given(issueJobManager.startOrResume(issueDate, startedAt)).willReturn(issueJob);
+
+        // when
+        issueService.issue();
+
+        // then
+        verifyNoInteractions(chunkProcessor);
+    }
+
+    @Test
+    void 기존_job의_cursor부터_chunk를_이어간다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, 10L, startedAt);
+        PageRequest pageRequest = PageRequest.of(0, 200);
+        given(issueJobManager.startOrResume(issueDate, startedAt)).willReturn(issueJob);
+        given(chunkProcessor.process(1L, issueDate, 10L, pageRequest))
+                .willReturn(IssueChunkResult.empty());
+        given(issueJobManager.complete(1L, startedAt)).willReturn(issueJob);
+
+        // when
+        issueService.issue();
+
+        // then
+        verify(chunkProcessor).process(1L, issueDate, 10L, pageRequest);
+    }
+
+    @Test
+    void chunk_처리_실패시_job을_failed로_변경한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, 0L, startedAt);
+        RuntimeException exception = new RuntimeException("fail");
+        PageRequest pageRequest = PageRequest.of(0, 200);
+        given(issueJobManager.startOrResume(issueDate, startedAt)).willReturn(issueJob);
+        given(chunkProcessor.process(1L, issueDate, 0L, pageRequest)).willThrow(exception);
+
+        // when & then
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> issueService.issue())
+                .isSameAs(exception);
+        verify(issueJobManager).fail(1L, exception, startedAt);
     }
 
     private Clock clockAt(LocalDateTime localDateTime) {
         return Clock.fixed(localDateTime.atZone(SEOUL).toInstant(), SEOUL);
+    }
+
+    private MaeilMailIssueJob issueJob(
+            Long id,
+            LocalDate issueDate,
+            Long lastProcessedTrackId,
+            LocalDateTime startedAt
+    ) {
+        MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(issueDate, 0L, startedAt);
+        ReflectionTestUtils.setField(issueJob, "id", id);
+        ReflectionTestUtils.setField(issueJob, "lastProcessedTrackId", lastProcessedTrackId);
+        return issueJob;
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/MaeilMailIssueServiceTest.java
@@ -8,6 +8,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Optional;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
 import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
 import news.bombomemail.nativenewsletter.maeilmail.service.internal.MaeilMailIssueChunkProcessor;
@@ -152,6 +153,40 @@ class MaeilMailIssueServiceTest {
         org.assertj.core.api.Assertions.assertThatThrownBy(() -> issueService.issue())
                 .isSameAs(exception);
         verify(issueJobManager).fail(1L, exception, startedAt);
+    }
+
+    @Test
+    void 미완료_job이_있으면_cursor부터_재개한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, 10L, startedAt);
+        PageRequest pageRequest = PageRequest.of(0, 200);
+        given(issueJobManager.resumeIncomplete(issueDate, startedAt)).willReturn(Optional.of(issueJob));
+        given(chunkProcessor.process(1L, issueDate, 10L, pageRequest))
+                .willReturn(IssueChunkResult.empty());
+        given(issueJobManager.complete(1L, startedAt)).willReturn(issueJob);
+
+        // when
+        issueService.resumeIncompleteTodayJob();
+
+        // then
+        verify(chunkProcessor).process(1L, issueDate, 10L, pageRequest);
+        verify(issueJobManager).complete(1L, startedAt);
+    }
+
+    @Test
+    void 미완료_job이_없으면_재개하지_않는다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        given(issueJobManager.resumeIncomplete(issueDate, startedAt)).willReturn(Optional.empty());
+
+        // when
+        issueService.resumeIncompleteTodayJob();
+
+        // then
+        verifyNoInteractions(chunkProcessor);
     }
 
     private Clock clockAt(LocalDateTime localDateTime) {

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
@@ -144,7 +144,7 @@ class MaeilMailIssueChunkProcessorTest {
             softly.assertThat(result.previouslyIssuedTrackCount()).isEqualTo(1);
         });
         verify(issuePublisher).publish(preparedEntries, issueDate);
-        verify(issueJobManager).recordChunk(1L, result);
+        verify(issueJobManager).recordPublishedChunk(1L, result);
     }
 
     private MaeilMailSubscriptionTrack createTrack(Long id, Long subscribeId, Long memberId) {

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
@@ -42,6 +42,9 @@ class MaeilMailIssueChunkProcessorTest {
     @Mock
     private MaeilMailIssuePublisher issuePublisher;
 
+    @Mock
+    private MaeilMailIssueJobManager issueJobManager;
+
     private MaeilMailIssueChunkProcessor chunkProcessor;
 
     @BeforeEach
@@ -50,7 +53,8 @@ class MaeilMailIssueChunkProcessorTest {
                 trackRepository,
                 issueDataLoader,
                 entryPreparer,
-                issuePublisher
+                issuePublisher,
+                issueJobManager
         );
     }
 
@@ -69,7 +73,7 @@ class MaeilMailIssueChunkProcessorTest {
         )).willReturn(List.of());
 
         // when
-        IssueChunkResult result = chunkProcessor.process(issueDate, 0L, pageRequest);
+        IssueChunkResult result = chunkProcessor.process(1L, issueDate, 0L, pageRequest);
 
         // then
         assertSoftly(softly -> {
@@ -78,7 +82,7 @@ class MaeilMailIssueChunkProcessorTest {
             softly.assertThat(result.issuedArticleCount()).isZero();
             softly.assertThat(result.previouslyIssuedTrackCount()).isZero();
         });
-        verifyNoInteractions(issueDataLoader, entryPreparer, issuePublisher);
+        verifyNoInteractions(issueDataLoader, entryPreparer, issuePublisher, issueJobManager);
     }
 
     @Test
@@ -129,7 +133,7 @@ class MaeilMailIssueChunkProcessorTest {
         given(entryPreparer.prepare(tracks, issueData)).willReturn(preparedEntries);
 
         // when
-        IssueChunkResult result = chunkProcessor.process(issueDate, 0L, pageRequest);
+        IssueChunkResult result = chunkProcessor.process(1L, issueDate, 0L, pageRequest);
 
         // then
         assertSoftly(softly -> {
@@ -140,6 +144,7 @@ class MaeilMailIssueChunkProcessorTest {
             softly.assertThat(result.previouslyIssuedTrackCount()).isEqualTo(1);
         });
         verify(issuePublisher).publish(preparedEntries, issueDate);
+        verify(issueJobManager).recordChunk(1L, result);
     }
 
     private MaeilMailSubscriptionTrack createTrack(Long id, Long subscribeId, Long memberId) {

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
@@ -112,8 +112,7 @@ class MaeilMailIssueChunkProcessorTest {
                                 .memberId(100L)
                                 .topicId(1000L)
                                 .contentId(9000L)
-                                .build(),
-                        9000L
+                                .build()
                 )),
                 List.of(2L)
         );

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
@@ -1,0 +1,154 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.LocalDate;
+import java.util.List;
+import news.bombomemail.article.domain.Article;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTrack;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueData;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueEntry;
+import news.bombomemail.nativenewsletter.maeilmail.dto.PreparedIssueEntries;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSubscriptionTrackRepository;
+import news.bombomemail.newsletter.domain.NewsletterPublicationStatus;
+import news.bombomemail.newsletter.domain.NewsletterSource;
+import news.bombomemail.subscribe.domain.SubscribeStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssueChunkProcessorTest {
+
+    @Mock
+    private MaeilMailSubscriptionTrackRepository trackRepository;
+
+    @Mock
+    private MaeilMailIssueDataLoader issueDataLoader;
+
+    @Mock
+    private MaeilMailIssueEntryPreparer entryPreparer;
+
+    @Mock
+    private MaeilMailIssuePublisher issuePublisher;
+
+    private MaeilMailIssueChunkProcessor chunkProcessor;
+
+    @BeforeEach
+    void setup() {
+        chunkProcessor = new MaeilMailIssueChunkProcessor(
+                trackRepository,
+                issueDataLoader,
+                entryPreparer,
+                issuePublisher
+        );
+    }
+
+    @Test
+    void 발행대상_track이_없으면_empty_result를_반환한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        PageRequest pageRequest = PageRequest.of(0, 200);
+        given(trackRepository.findIssueTargetsAfterId(
+                issueDate,
+                SubscribeStatus.SUBSCRIBED,
+                NewsletterSource.MAEIL_MAIL,
+                NewsletterPublicationStatus.ACTIVE,
+                0L,
+                pageRequest
+        )).willReturn(List.of());
+
+        // when
+        IssueChunkResult result = chunkProcessor.process(issueDate, 0L, pageRequest);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.hasTracks()).isFalse();
+            softly.assertThat(result.trackCount()).isZero();
+            softly.assertThat(result.issuedArticleCount()).isZero();
+            softly.assertThat(result.previouslyIssuedTrackCount()).isZero();
+        });
+        verifyNoInteractions(issueDataLoader, entryPreparer, issuePublisher);
+    }
+
+    @Test
+    void 발행대상_track을_로딩하고_선택_조립_기록까지_처리한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        PageRequest pageRequest = PageRequest.of(0, 200);
+        MaeilMailSubscriptionTrack firstTrack = createTrack(1L, 10L, 100L);
+        MaeilMailSubscriptionTrack secondTrack = createTrack(2L, 11L, 200L);
+        List<MaeilMailSubscriptionTrack> tracks = List.of(firstTrack, secondTrack);
+        IssueData issueData = new IssueData(
+                java.util.Map.of(),
+                java.util.Map.of(),
+                java.util.Map.of(),
+                java.util.Set.of(),
+                50L
+        );
+        PreparedIssueEntries preparedEntries = new PreparedIssueEntries(
+                List.of(new IssueEntry(
+                        Article.builder()
+                                .title("title")
+                                .contents("contents")
+                                .contentsText("contentsText")
+                                .contentsSummary("summary")
+                                .memberId(100L)
+                                .newsletterId(50L)
+                                .arrivedDateTime(java.time.LocalDateTime.of(2026, 4, 27, 7, 0))
+                                .build(),
+                        List.of(1L),
+                        MaeilMailSentContent.builder()
+                                .memberId(100L)
+                                .topicId(1000L)
+                                .contentId(9000L)
+                                .build()
+                )),
+                List.of(2L)
+        );
+
+        given(trackRepository.findIssueTargetsAfterId(
+                issueDate,
+                SubscribeStatus.SUBSCRIBED,
+                NewsletterSource.MAEIL_MAIL,
+                NewsletterPublicationStatus.ACTIVE,
+                0L,
+                pageRequest
+        )).willReturn(tracks);
+        given(issueDataLoader.load(issueDate, tracks)).willReturn(issueData);
+        given(entryPreparer.prepare(tracks, issueData)).willReturn(preparedEntries);
+
+        // when
+        IssueChunkResult result = chunkProcessor.process(issueDate, 0L, pageRequest);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.hasTracks()).isTrue();
+            softly.assertThat(result.lastTrackId()).isEqualTo(2L);
+            softly.assertThat(result.trackCount()).isEqualTo(2);
+            softly.assertThat(result.issuedArticleCount()).isEqualTo(1);
+            softly.assertThat(result.previouslyIssuedTrackCount()).isEqualTo(1);
+        });
+        verify(issuePublisher).publish(preparedEntries, issueDate);
+    }
+
+    private MaeilMailSubscriptionTrack createTrack(Long id, Long subscribeId, Long memberId) {
+        MaeilMailSubscriptionTrack track = MaeilMailSubscriptionTrack.builder()
+                .subscribeId(subscribeId)
+                .memberId(memberId)
+                .field(MaeilMailTrack.BE)
+                .build();
+        ReflectionTestUtils.setField(track, "id", id);
+        return track;
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueChunkProcessorTest.java
@@ -112,7 +112,8 @@ class MaeilMailIssueChunkProcessorTest {
                                 .memberId(100L)
                                 .topicId(1000L)
                                 .contentId(9000L)
-                                .build()
+                                .build(),
+                        9000L
                 )),
                 List.of(2L)
         );

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueContentAssignerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueContentAssignerTest.java
@@ -1,17 +1,19 @@
 package news.bombomemail.nativenewsletter.maeilmail.service.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
 import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
 import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -21,8 +23,15 @@ class MaeilMailIssueContentAssignerTest {
     @Mock
     private MaeilMailSentContentRepository sentContentRepository;
 
-    @InjectMocks
+    @Mock
+    private Random random;
+
     private MaeilMailIssueContentAssigner contentAssigner;
+
+    @BeforeEach
+    void setup() {
+        contentAssigner = new MaeilMailIssueContentAssigner(sentContentRepository, random);
+    }
 
     @Test
     void topic_content가_없으면_선택하지_않는다() {
@@ -76,6 +85,7 @@ class MaeilMailIssueContentAssignerTest {
         );
 
         // when
+        given(random.nextInt(2)).willReturn(1);
         Optional<Long> result = contentAssigner.assignContentIdOrRecycle(
                 memberId,
                 topicId,
@@ -84,7 +94,7 @@ class MaeilMailIssueContentAssignerTest {
         );
 
         // then
-        assertThat(result).hasValueSatisfying(contentId -> assertThat(contentIds).contains(contentId));
+        assertThat(result).hasValue(200L);
         verify(sentContentRepository).deleteByMemberIdAndTopicId(memberId, topicId);
         verify(sentContentRepository).flush();
     }

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueContentAssignerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueContentAssignerTest.java
@@ -1,0 +1,91 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssueContentAssignerTest {
+
+    @Mock
+    private MaeilMailSentContentRepository sentContentRepository;
+
+    @InjectMocks
+    private MaeilMailIssueContentAssigner contentAssigner;
+
+    @Test
+    void topic_content가_없으면_선택하지_않는다() {
+        // when
+        Optional<Long> result = contentAssigner.assignContentIdOrRecycle(
+                1L,
+                10L,
+                Map.of(),
+                Map.of()
+        );
+
+        // then
+        assertThat(result).isEmpty();
+        verifyNoInteractions(sentContentRepository);
+    }
+
+    @Test
+    void 이미_보낸_content를_제외하고_선택한다() {
+        // given
+        Long memberId = 1L;
+        Long topicId = 10L;
+        Map<Long, List<Long>> contentIdsByTopicId = Map.of(topicId, List.of(100L, 200L, 300L));
+        Map<MemberTopicKey, List<Long>> sentContentIdsByMemberTopic = Map.of(
+                new MemberTopicKey(memberId, topicId),
+                List.of(100L, 200L)
+        );
+
+        // when
+        Optional<Long> result = contentAssigner.assignContentIdOrRecycle(
+                memberId,
+                topicId,
+                contentIdsByTopicId,
+                sentContentIdsByMemberTopic
+        );
+
+        // then
+        assertThat(result).hasValue(300L);
+        verifyNoInteractions(sentContentRepository);
+    }
+
+    @Test
+    void content를_모두_보냈으면_전송_기록을_삭제하고_다시_선택한다() {
+        // given
+        Long memberId = 1L;
+        Long topicId = 10L;
+        List<Long> contentIds = List.of(100L, 200L);
+        Map<Long, List<Long>> contentIdsByTopicId = Map.of(topicId, contentIds);
+        Map<MemberTopicKey, List<Long>> sentContentIdsByMemberTopic = Map.of(
+                new MemberTopicKey(memberId, topicId),
+                contentIds
+        );
+
+        // when
+        Optional<Long> result = contentAssigner.assignContentIdOrRecycle(
+                memberId,
+                topicId,
+                contentIdsByTopicId,
+                sentContentIdsByMemberTopic
+        );
+
+        // then
+        assertThat(result).hasValueSatisfying(contentId -> assertThat(contentIds).contains(contentId));
+        verify(sentContentRepository).deleteByMemberIdAndTopicId(memberId, topicId);
+        verify(sentContentRepository).flush();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueDataLoaderTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueDataLoaderTest.java
@@ -132,6 +132,42 @@ class MaeilMailIssueDataLoaderTest {
     }
 
     @Test
+    void 발행_topic이_없는_track은_로딩결과에서_제외한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        MaeilMailSubscriptionTrack topicMissingTrack = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
+        MaeilMailSubscriptionTrack targetTrack = createTrack(2L, 11L, 200L, MaeilMailTrack.FE, 0);
+        MaeilMailTopic feTopic = createTopic(2000L, MaeilMailTrack.FE, "react", 1);
+
+        given(subscribeRepository.findAllById(List.of(10L, 11L))).willReturn(List.of(
+                createSubscribe(10L, 50L, 100L),
+                createSubscribe(11L, 50L, 200L)
+        ));
+        given(topicRepository.findAllByOrderByDisplayOrderAsc()).willReturn(List.of(feTopic));
+        given(contentRepository.findContentIdsByTopicIdIn(anyCollection())).willReturn(List.of(
+                new TopicContentId(feTopic.getId(), 9200L)
+        ));
+        given(sentContentRepository.findAllByMemberTopicKeys(List.of(
+                new MemberTopicKey(200L, feTopic.getId())
+        ))).willReturn(List.of());
+        given(issueHistoryRepository.findIssuedMemberTopicKeys(issueDate, List.of(
+                new MemberTopicKey(200L, feTopic.getId())
+        ))).willReturn(Set.of());
+
+        // when
+        IssueData result = dataLoader.load(issueDate, List.of(topicMissingTrack, targetTrack));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.issueTopicsByTrackId()).doesNotContainKey(topicMissingTrack.getId());
+            softly.assertThat(result.issueTopicsByTrackId()).containsEntry(targetTrack.getId(), feTopic);
+            softly.assertThat(result.contentIdsByTopicId()).containsOnlyKeys(feTopic.getId());
+            softly.assertThat(result.sentContentIdsByMemberTopic()).isEmpty();
+            softly.assertThat(result.issuedMemberTopicKeys()).isEmpty();
+        });
+    }
+
+    @Test
     void track의_subscribe를_찾지_못하면_예외가_발생한다() {
         // given
         MaeilMailSubscriptionTrack track = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueDataLoaderTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueDataLoaderTest.java
@@ -1,0 +1,204 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTrack;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueData;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+import news.bombomemail.nativenewsletter.maeilmail.dto.TopicContentId;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailContentRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueHistoryRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailTopicRepository;
+import news.bombomemail.subscribe.domain.Subscribe;
+import news.bombomemail.subscribe.repository.SubscribeRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssueDataLoaderTest {
+
+    @Mock
+    private MaeilMailTopicRepository topicRepository;
+
+    @Mock
+    private MaeilMailContentRepository contentRepository;
+
+    @Mock
+    private MaeilMailSentContentRepository sentContentRepository;
+
+    @Mock
+    private MaeilMailIssueHistoryRepository issueHistoryRepository;
+
+    @Mock
+    private SubscribeRepository subscribeRepository;
+
+    @InjectMocks
+    private MaeilMailIssueDataLoader dataLoader;
+
+    @Test
+    void track의_curriculumIndex로_발행_topic을_고르고_필요한_데이터를_로딩한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        MaeilMailSubscriptionTrack beTrack = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 1);
+        MaeilMailSubscriptionTrack feTrack = createTrack(2L, 11L, 200L, MaeilMailTrack.FE, 0);
+        MaeilMailTopic beFirstTopic = createTopic(1000L, MaeilMailTrack.BE, "java", 1);
+        MaeilMailTopic beSecondTopic = createTopic(1001L, MaeilMailTrack.BE, "spring", 2);
+        MaeilMailTopic feTopic = createTopic(2000L, MaeilMailTrack.FE, "react", 1);
+        MaeilMailSentContent sentContent = createSentContent(100L, beSecondTopic.getId(), 9000L);
+        Set<MemberTopicKey> issuedKeys = Set.of(new MemberTopicKey(200L, feTopic.getId()));
+
+        given(subscribeRepository.findAllById(List.of(10L, 11L))).willReturn(List.of(
+                createSubscribe(10L, 50L, 100L),
+                createSubscribe(11L, 50L, 200L)
+        ));
+        given(topicRepository.findAllByOrderByDisplayOrderAsc()).willReturn(List.of(
+                beFirstTopic,
+                beSecondTopic,
+                feTopic
+        ));
+        given(contentRepository.findContentIdsByTopicIdIn(anyCollection())).willReturn(List.of(
+                new TopicContentId(beSecondTopic.getId(), 9100L),
+                new TopicContentId(feTopic.getId(), 9200L)
+        ));
+        given(sentContentRepository.findAllByMemberTopicKeys(List.of(
+                new MemberTopicKey(100L, beSecondTopic.getId()),
+                new MemberTopicKey(200L, feTopic.getId())
+        ))).willReturn(List.of(sentContent));
+        given(issueHistoryRepository.findIssuedMemberTopicKeys(issueDate, List.of(
+                new MemberTopicKey(100L, beSecondTopic.getId()),
+                new MemberTopicKey(200L, feTopic.getId())
+        ))).willReturn(issuedKeys);
+
+        // when
+        IssueData result = dataLoader.load(issueDate, List.of(beTrack, feTrack));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.newsletterId()).isEqualTo(50L);
+            softly.assertThat(result.issueTopicsByTrackId()).containsEntry(beTrack.getId(), beSecondTopic);
+            softly.assertThat(result.issueTopicsByTrackId()).containsEntry(feTrack.getId(), feTopic);
+            softly.assertThat(result.contentIdsByTopicId().get(beSecondTopic.getId())).containsExactly(9100L);
+            softly.assertThat(result.contentIdsByTopicId().get(feTopic.getId())).containsExactly(9200L);
+            softly.assertThat(result.sentContentIdsByMemberTopic().get(new MemberTopicKey(100L, beSecondTopic.getId())))
+                    .containsExactly(9000L);
+            softly.assertThat(result.issuedMemberTopicKeys()).containsExactlyInAnyOrderElementsOf(issuedKeys);
+        });
+    }
+
+    @Test
+    void curriculumIndex가_topic_size보다_커도_나머지로_발행_topic을_순환_선택한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        MaeilMailSubscriptionTrack track = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 3);
+        MaeilMailTopic firstTopic = createTopic(1000L, MaeilMailTrack.BE, "java", 1);
+        MaeilMailTopic secondTopic = createTopic(1001L, MaeilMailTrack.BE, "spring", 2);
+
+        given(subscribeRepository.findAllById(List.of(10L))).willReturn(List.of(
+                createSubscribe(10L, 50L, 100L)
+        ));
+        given(topicRepository.findAllByOrderByDisplayOrderAsc()).willReturn(List.of(firstTopic, secondTopic));
+        given(contentRepository.findContentIdsByTopicIdIn(anyCollection())).willReturn(List.of(
+                new TopicContentId(secondTopic.getId(), 9100L)
+        ));
+        given(sentContentRepository.findAllByMemberTopicKeys(List.of(
+                new MemberTopicKey(100L, secondTopic.getId())
+        ))).willReturn(List.of());
+        given(issueHistoryRepository.findIssuedMemberTopicKeys(issueDate, List.of(
+                new MemberTopicKey(100L, secondTopic.getId())
+        ))).willReturn(Set.of());
+
+        // when
+        IssueData result = dataLoader.load(issueDate, List.of(track));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.issueTopicsByTrackId()).containsEntry(track.getId(), secondTopic);
+            softly.assertThat(result.contentIdsByTopicId().get(secondTopic.getId())).containsExactly(9100L);
+        });
+    }
+
+    @Test
+    void track의_subscribe를_찾지_못하면_예외가_발생한다() {
+        // given
+        MaeilMailSubscriptionTrack track = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
+        given(subscribeRepository.findAllById(List.of(10L))).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> dataLoader.load(LocalDate.of(2026, 4, 27), List.of(track)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Subscribe");
+    }
+
+    @Test
+    void 발행대상_track의_newsletterId가_하나가_아니면_예외가_발생한다() {
+        // given
+        MaeilMailSubscriptionTrack firstTrack = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
+        MaeilMailSubscriptionTrack secondTrack = createTrack(2L, 11L, 200L, MaeilMailTrack.FE, 0);
+        given(subscribeRepository.findAllById(List.of(10L, 11L))).willReturn(List.of(
+                createSubscribe(10L, 50L, 100L),
+                createSubscribe(11L, 60L, 200L)
+        ));
+
+        // when & then
+        assertThatThrownBy(() -> dataLoader.load(LocalDate.of(2026, 4, 27), List.of(firstTrack, secondTrack)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("newsletterId");
+    }
+
+    private MaeilMailSubscriptionTrack createTrack(
+            Long id,
+            Long subscribeId,
+            Long memberId,
+            MaeilMailTrack field,
+            int curriculumIndex
+    ) {
+        MaeilMailSubscriptionTrack track = MaeilMailSubscriptionTrack.builder()
+                .subscribeId(subscribeId)
+                .memberId(memberId)
+                .field(field)
+                .build();
+        ReflectionTestUtils.setField(track, "id", id);
+        ReflectionTestUtils.setField(track, "curriculumIndex", curriculumIndex);
+        return track;
+    }
+
+    private MaeilMailTopic createTopic(Long id, MaeilMailTrack track, String name, int displayOrder) {
+        MaeilMailTopic topic = MaeilMailTopic.builder()
+                .track(track)
+                .name(name)
+                .displayOrder(displayOrder)
+                .build();
+        ReflectionTestUtils.setField(topic, "id", id);
+        return topic;
+    }
+
+    private MaeilMailSentContent createSentContent(Long memberId, Long topicId, Long contentId) {
+        return MaeilMailSentContent.builder()
+                .memberId(memberId)
+                .topicId(topicId)
+                .contentId(contentId)
+                .build();
+    }
+
+    private Subscribe createSubscribe(Long id, Long newsletterId, Long memberId) {
+        return Subscribe.builder()
+                .id(id)
+                .newsletterId(newsletterId)
+                .memberId(memberId)
+                .build();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparerTest.java
@@ -1,0 +1,270 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import news.bombomemail.article.domain.Article;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSubscriptionTrack;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTrack;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueData;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueEntry;
+import news.bombomemail.nativenewsletter.maeilmail.dto.MemberTopicKey;
+import news.bombomemail.nativenewsletter.maeilmail.dto.PreparedIssueEntries;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailContentRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssueEntryPreparerTest {
+
+    private static final ZoneId SEOUL = ZoneId.of("Asia/Seoul");
+
+    @Mock
+    private MaeilMailContentRepository contentRepository;
+
+    @Mock
+    private MaeilMailIssueContentAssigner contentAssigner;
+
+    private MaeilMailIssueEntryPreparer entryPreparer;
+
+    @BeforeEach
+    void setup() {
+        LocalDateTime arrivedAt = LocalDateTime.of(2026, 4, 26, 7, 0);
+        Clock clock = Clock.fixed(arrivedAt.atZone(SEOUL).toInstant(), SEOUL);
+        entryPreparer = new MaeilMailIssueEntryPreparer(clock, contentRepository, contentAssigner);
+    }
+
+    @Test
+    void 같은_member_topic은_하나의_issue_entry로_합친다() {
+        // given
+        MaeilMailSubscriptionTrack firstTrack = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
+        MaeilMailSubscriptionTrack secondTrack = createTrack(2L, 11L, 100L, MaeilMailTrack.BE, 0);
+        MaeilMailTopic topic = createTopic(1000L, MaeilMailTrack.BE, "java", 1);
+        MaeilMailContent content = createContent(
+                9000L,
+                topic.getId(),
+                "매일메일 제목",
+                "<p>본문</p>",
+                "본문",
+                "요약",
+                3
+        );
+        IssueData issueData = createIssueData(
+                Map.of(1L, topic, 2L, topic),
+                Map.of(topic.getId(), List.of(content.getId())),
+                Map.of(),
+                Set.of(),
+                50L
+        );
+        given(contentAssigner.assignContentIdOrRecycle(100L, topic.getId(), issueData.contentIdsByTopicId(),
+                issueData.sentContentIdsByMemberTopic()))
+                .willReturn(Optional.of(content.getId()));
+        given(contentRepository.findAllById(List.of(content.getId()))).willReturn(List.of(content));
+
+        // when
+        PreparedIssueEntries result = entryPreparer.prepare(List.of(firstTrack, secondTrack), issueData);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.entries()).hasSize(1);
+            softly.assertThat(result.previouslyIssuedTrackIds()).isEmpty();
+
+            IssueEntry entry = result.entries().getFirst();
+            softly.assertThat(entry.trackIds()).containsExactly(1L, 2L);
+
+            Article article = entry.article();
+            softly.assertThat(article.getTitle()).isEqualTo("매일메일 제목");
+            softly.assertThat(article.getContents()).isEqualTo("<p>본문</p>");
+            softly.assertThat(article.getContentsText()).isEqualTo("본문");
+            softly.assertThat(article.getContentsSummary()).isEqualTo("요약");
+            softly.assertThat(article.getExpectedReadTime()).isEqualTo(3);
+            softly.assertThat(article.getMemberId()).isEqualTo(100L);
+            softly.assertThat(article.getNewsletterId()).isEqualTo(50L);
+            softly.assertThat(article.getArrivedDateTime()).isEqualTo(LocalDateTime.of(2026, 4, 26, 7, 0));
+
+            MaeilMailSentContent sentContent = entry.sentContent();
+            softly.assertThat(sentContent.getMemberId()).isEqualTo(100L);
+            softly.assertThat(sentContent.getTopicId()).isEqualTo(topic.getId());
+            softly.assertThat(sentContent.getContentId()).isEqualTo(content.getId());
+        });
+        verify(contentAssigner).assignContentIdOrRecycle(100L, topic.getId(), issueData.contentIdsByTopicId(),
+                issueData.sentContentIdsByMemberTopic());
+    }
+
+    @Test
+    void 이미_발행된_member_topic은_entry를_만들지_않고_track_id만_반환한다() {
+        // given
+        MaeilMailSubscriptionTrack track = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
+        MaeilMailTopic topic = createTopic(1000L, MaeilMailTrack.BE, "java", 1);
+        IssueData issueData = createIssueData(
+                Map.of(track.getId(), topic),
+                Map.of(topic.getId(), List.of(9000L)),
+                Map.of(),
+                Set.of(new MemberTopicKey(100L, topic.getId())),
+                50L
+        );
+
+        // when
+        PreparedIssueEntries result = entryPreparer.prepare(List.of(track), issueData);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.entries()).isEmpty();
+            softly.assertThat(result.previouslyIssuedTrackIds()).containsExactly(1L);
+        });
+        verifyNoInteractions(contentAssigner, contentRepository);
+    }
+
+    @Test
+    void 선택할_content가_없으면_entry를_만들지_않는다() {
+        // given
+        MaeilMailSubscriptionTrack track = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
+        MaeilMailTopic topic = createTopic(1000L, MaeilMailTrack.BE, "java", 1);
+        IssueData issueData = createIssueData(
+                Map.of(track.getId(), topic),
+                Map.of(),
+                Map.of(),
+                Set.of(),
+                50L
+        );
+        given(contentAssigner.assignContentIdOrRecycle(100L, topic.getId(), issueData.contentIdsByTopicId(),
+                issueData.sentContentIdsByMemberTopic()))
+                .willReturn(Optional.empty());
+
+        // when
+        PreparedIssueEntries result = entryPreparer.prepare(List.of(track), issueData);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.entries()).isEmpty();
+            softly.assertThat(result.previouslyIssuedTrackIds()).isEmpty();
+        });
+        verifyNoInteractions(contentRepository);
+    }
+
+    @Test
+    void 발행_topic이_없는_track은_건너뛴다() {
+        // given
+        MaeilMailSubscriptionTrack track = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
+        IssueData issueData = createIssueData(Map.of(), Map.of(), Map.of(), Set.of(), 50L);
+
+        // when
+        PreparedIssueEntries result = entryPreparer.prepare(List.of(track), issueData);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.entries()).isEmpty();
+            softly.assertThat(result.previouslyIssuedTrackIds()).isEmpty();
+        });
+        verifyNoInteractions(contentAssigner, contentRepository);
+    }
+
+    @Test
+    void 선택된_content가_조회되지_않으면_entry를_만들지_않고_previouslyIssuedTrackIds는_유지한다() {
+        // given
+        MaeilMailSubscriptionTrack pendingTrack = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
+        MaeilMailSubscriptionTrack issuedTrack = createTrack(2L, 11L, 200L, MaeilMailTrack.BE, 0);
+        MaeilMailTopic pendingTopic = createTopic(1000L, MaeilMailTrack.BE, "java", 1);
+        MaeilMailTopic issuedTopic = createTopic(2000L, MaeilMailTrack.BE, "spring", 2);
+        IssueData issueData = createIssueData(
+                Map.of(pendingTrack.getId(), pendingTopic, issuedTrack.getId(), issuedTopic),
+                Map.of(pendingTopic.getId(), List.of(9000L)),
+                Map.of(),
+                Set.of(new MemberTopicKey(200L, issuedTopic.getId())),
+                50L
+        );
+        given(contentAssigner.assignContentIdOrRecycle(100L, pendingTopic.getId(), issueData.contentIdsByTopicId(),
+                issueData.sentContentIdsByMemberTopic()))
+                .willReturn(Optional.of(9000L));
+        given(contentRepository.findAllById(List.of(9000L))).willReturn(List.of());
+
+        // when
+        PreparedIssueEntries result = entryPreparer.prepare(List.of(pendingTrack, issuedTrack), issueData);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.entries()).isEmpty();
+            softly.assertThat(result.previouslyIssuedTrackIds()).containsExactly(2L);
+        });
+    }
+
+    private IssueData createIssueData(
+            Map<Long, MaeilMailTopic> issueTopicsByTrackId,
+            Map<Long, List<Long>> contentIdsByTopicId,
+            Map<MemberTopicKey, List<Long>> sentContentIdsByMemberTopic,
+            Set<MemberTopicKey> issuedMemberTopicKeys,
+            Long newsletterId
+    ) {
+        return new IssueData(
+                issueTopicsByTrackId,
+                contentIdsByTopicId,
+                sentContentIdsByMemberTopic,
+                issuedMemberTopicKeys,
+                newsletterId
+        );
+    }
+
+    private MaeilMailSubscriptionTrack createTrack(
+            Long id,
+            Long subscribeId,
+            Long memberId,
+            MaeilMailTrack field,
+            int curriculumIndex
+    ) {
+        MaeilMailSubscriptionTrack track = MaeilMailSubscriptionTrack.builder()
+                .subscribeId(subscribeId)
+                .memberId(memberId)
+                .field(field)
+                .build();
+        ReflectionTestUtils.setField(track, "id", id);
+        ReflectionTestUtils.setField(track, "curriculumIndex", curriculumIndex);
+        return track;
+    }
+
+    private MaeilMailTopic createTopic(Long id, MaeilMailTrack track, String name, int displayOrder) {
+        MaeilMailTopic topic = MaeilMailTopic.builder()
+                .track(track)
+                .name(name)
+                .displayOrder(displayOrder)
+                .build();
+        ReflectionTestUtils.setField(topic, "id", id);
+        return topic;
+    }
+
+    private MaeilMailContent createContent(
+            Long id,
+            Long topicId,
+            String title,
+            String contentBody,
+            String contentsText,
+            String contentsSummary,
+            int expectedReadTime
+    ) {
+        MaeilMailContent content = MaeilMailContent.builder()
+                .topicId(topicId)
+                .title(title)
+                .content(contentBody)
+                .contentsText(contentsText)
+                .contentsSummary(contentsSummary)
+                .expectedReadTime(expectedReadTime)
+                .build();
+        ReflectionTestUtils.setField(content, "id", id);
+        return content;
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparerTest.java
@@ -102,6 +102,7 @@ class MaeilMailIssueEntryPreparerTest {
             softly.assertThat(sentContent.getMemberId()).isEqualTo(100L);
             softly.assertThat(sentContent.getTopicId()).isEqualTo(topic.getId());
             softly.assertThat(sentContent.getContentId()).isEqualTo(content.getId());
+            softly.assertThat(entry.contentId()).isEqualTo(content.getId());
         });
         verify(contentAssigner).assignContentIdOrRecycle(100L, topic.getId(), issueData.contentIdsByTopicId(),
                 issueData.sentContentIdsByMemberTopic());

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueEntryPreparerTest.java
@@ -1,5 +1,6 @@
 package news.bombomemail.nativenewsletter.maeilmail.service.internal;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -177,7 +178,7 @@ class MaeilMailIssueEntryPreparerTest {
     }
 
     @Test
-    void 선택된_content가_조회되지_않으면_entry를_만들지_않고_previouslyIssuedTrackIds는_유지한다() {
+    void 선택된_content가_조회되지_않으면_예외를_던진다() {
         // given
         MaeilMailSubscriptionTrack pendingTrack = createTrack(1L, 10L, 100L, MaeilMailTrack.BE, 0);
         MaeilMailSubscriptionTrack issuedTrack = createTrack(2L, 11L, 200L, MaeilMailTrack.BE, 0);
@@ -195,14 +196,11 @@ class MaeilMailIssueEntryPreparerTest {
                 .willReturn(Optional.of(9000L));
         given(contentRepository.findAllById(List.of(9000L))).willReturn(List.of());
 
-        // when
-        PreparedIssueEntries result = entryPreparer.prepare(List.of(pendingTrack, issuedTrack), issueData);
-
-        // then
-        assertSoftly(softly -> {
-            softly.assertThat(result.entries()).isEmpty();
-            softly.assertThat(result.previouslyIssuedTrackIds()).containsExactly(2L);
-        });
+        // when & then
+        assertThatThrownBy(() -> entryPreparer.prepare(List.of(pendingTrack, issuedTrack), issueData))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("매일메일 발행 content를 찾을 수 없습니다.")
+                .hasMessageContaining("9000");
     }
 
     private IssueData createIssueData(

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManagerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManagerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJobStatus;
@@ -72,6 +73,49 @@ class MaeilMailIssueJobManagerTest {
             softly.assertThat(result.getFailedMessage()).isNull();
             softly.assertThat(result.getFailedAt()).isNull();
         });
+    }
+
+    @Test
+    void 미완료_job만_재개한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, startedAt);
+        issueJob.recordChunk(IssueChunkResult.of(10L, 2, 1, 0));
+        issueJob.fail("fail", startedAt.plusMinutes(10));
+        given(issueJobRepository.findByIssueDateAndStatusIn(issueDate, List.of(
+                MaeilMailIssueJobStatus.RUNNING,
+                MaeilMailIssueJobStatus.FAILED
+        ))).willReturn(Optional.of(issueJob));
+
+        // when
+        Optional<MaeilMailIssueJob> result = issueJobManager.resumeIncomplete(issueDate, startedAt.plusMinutes(20));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result).isPresent();
+            softly.assertThat(result.get().getStatus()).isEqualTo(MaeilMailIssueJobStatus.RUNNING);
+            softly.assertThat(result.get().getLastProcessedTrackId()).isEqualTo(10L);
+            softly.assertThat(result.get().getFailedMessage()).isNull();
+            softly.assertThat(result.get().getFailedAt()).isNull();
+        });
+    }
+
+    @Test
+    void 미완료_job이_없으면_재개하지_않는다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        given(issueJobRepository.findByIssueDateAndStatusIn(issueDate, List.of(
+                MaeilMailIssueJobStatus.RUNNING,
+                MaeilMailIssueJobStatus.FAILED
+        ))).willReturn(Optional.empty());
+
+        // when
+        Optional<MaeilMailIssueJob> result = issueJobManager.resumeIncomplete(issueDate, startedAt);
+
+        // then
+        assertSoftly(softly -> softly.assertThat(result).isEmpty());
     }
 
     @Test

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManagerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManagerTest.java
@@ -1,0 +1,142 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJob;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueJobStatus;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueChunkResult;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueJobRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssueJobManagerTest {
+
+    @Mock
+    private MaeilMailIssueJobRepository issueJobRepository;
+
+    private MaeilMailIssueJobManager issueJobManager;
+
+    @BeforeEach
+    void setup() {
+        issueJobManager = new MaeilMailIssueJobManager(issueJobRepository);
+    }
+
+    @Test
+    void 당일_job이_없으면_running_job을_생성한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        given(issueJobRepository.findByIssueDate(issueDate)).willReturn(Optional.empty());
+        given(issueJobRepository.save(org.mockito.ArgumentMatchers.any(MaeilMailIssueJob.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        MaeilMailIssueJob issueJob = issueJobManager.startOrResume(issueDate, startedAt);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issueJob.getIssueDate()).isEqualTo(issueDate);
+            softly.assertThat(issueJob.getStatus()).isEqualTo(MaeilMailIssueJobStatus.RUNNING);
+            softly.assertThat(issueJob.getLastProcessedTrackId()).isZero();
+            softly.assertThat(issueJob.getStartedAt()).isEqualTo(startedAt);
+        });
+    }
+
+    @Test
+    void 실패한_job이_있으면_cursor를_유지하고_resume한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, startedAt);
+        issueJob.recordChunk(IssueChunkResult.of(10L, 2, 1, 0));
+        issueJob.fail("fail", startedAt.plusMinutes(10));
+        given(issueJobRepository.findByIssueDate(issueDate)).willReturn(Optional.of(issueJob));
+
+        // when
+        MaeilMailIssueJob result = issueJobManager.startOrResume(issueDate, startedAt.plusMinutes(20));
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getStatus()).isEqualTo(MaeilMailIssueJobStatus.RUNNING);
+            softly.assertThat(result.getLastProcessedTrackId()).isEqualTo(10L);
+            softly.assertThat(result.getFailedMessage()).isNull();
+            softly.assertThat(result.getFailedAt()).isNull();
+        });
+    }
+
+    @Test
+    void chunk_결과를_job에_기록한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, startedAt);
+        IssueChunkResult chunkResult = IssueChunkResult.of(10L, 2, 1, 0);
+        given(issueJobRepository.findById(1L)).willReturn(Optional.of(issueJob));
+
+        // when
+        issueJobManager.recordChunk(1L, chunkResult);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issueJob.getLastProcessedTrackId()).isEqualTo(10L);
+            softly.assertThat(issueJob.getChunkCount()).isEqualTo(1);
+            softly.assertThat(issueJob.getProcessedTrackCount()).isEqualTo(2);
+            softly.assertThat(issueJob.getIssuedArticleCount()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void 실패시_failed_상태와_실패메시지를_기록한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime failedAt = LocalDateTime.of(2026, 4, 27, 7, 10);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, LocalDateTime.of(2026, 4, 27, 7, 0));
+        RuntimeException exception = new RuntimeException("발행 실패");
+        given(issueJobRepository.findById(1L)).willReturn(Optional.of(issueJob));
+
+        // when
+        issueJobManager.fail(1L, exception, failedAt);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(issueJob.getStatus()).isEqualTo(MaeilMailIssueJobStatus.FAILED);
+            softly.assertThat(issueJob.getFailedMessage()).isEqualTo("발행 실패");
+            softly.assertThat(issueJob.getFailedAt()).isEqualTo(failedAt);
+        });
+    }
+
+    @Test
+    void 완료시_completed_상태로_변경한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        LocalDateTime completedAt = LocalDateTime.of(2026, 4, 27, 7, 10);
+        MaeilMailIssueJob issueJob = issueJob(1L, issueDate, LocalDateTime.of(2026, 4, 27, 7, 0));
+        given(issueJobRepository.findById(1L)).willReturn(Optional.of(issueJob));
+
+        // when
+        MaeilMailIssueJob result = issueJobManager.complete(1L, completedAt);
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getStatus()).isEqualTo(MaeilMailIssueJobStatus.COMPLETED);
+            softly.assertThat(result.getCompletedAt()).isEqualTo(completedAt);
+        });
+        verify(issueJobRepository).findById(1L);
+    }
+
+    private MaeilMailIssueJob issueJob(Long id, LocalDate issueDate, LocalDateTime startedAt) {
+        MaeilMailIssueJob issueJob = MaeilMailIssueJob.start(issueDate, 0L, startedAt);
+        ReflectionTestUtils.setField(issueJob, "id", id);
+        return issueJob;
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManagerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssueJobManagerTest.java
@@ -59,7 +59,7 @@ class MaeilMailIssueJobManagerTest {
         LocalDate issueDate = LocalDate.of(2026, 4, 27);
         LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
         MaeilMailIssueJob issueJob = issueJob(1L, issueDate, startedAt);
-        issueJob.recordChunk(IssueChunkResult.of(10L, 2, 1, 0));
+        issueJob.recordPublishedChunk(IssueChunkResult.of(10L, 2, 1, 0));
         issueJob.fail("fail", startedAt.plusMinutes(10));
         given(issueJobRepository.findByIssueDate(issueDate)).willReturn(Optional.of(issueJob));
 
@@ -81,7 +81,7 @@ class MaeilMailIssueJobManagerTest {
         LocalDate issueDate = LocalDate.of(2026, 4, 27);
         LocalDateTime startedAt = LocalDateTime.of(2026, 4, 27, 7, 0);
         MaeilMailIssueJob issueJob = issueJob(1L, issueDate, startedAt);
-        issueJob.recordChunk(IssueChunkResult.of(10L, 2, 1, 0));
+        issueJob.recordPublishedChunk(IssueChunkResult.of(10L, 2, 1, 0));
         issueJob.fail("fail", startedAt.plusMinutes(10));
         given(issueJobRepository.findByIssueDateAndStatusIn(issueDate, List.of(
                 MaeilMailIssueJobStatus.RUNNING,
@@ -128,7 +128,7 @@ class MaeilMailIssueJobManagerTest {
         given(issueJobRepository.findById(1L)).willReturn(Optional.of(issueJob));
 
         // when
-        issueJobManager.recordChunk(1L, chunkResult);
+        issueJobManager.recordPublishedChunk(1L, chunkResult);
 
         // then
         assertSoftly(softly -> {

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisherTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisherTest.java
@@ -1,5 +1,6 @@
 package news.bombomemail.nativenewsletter.maeilmail.service.internal;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -73,7 +74,7 @@ class MaeilMailIssuePublisherTest {
         LocalDate issueDate = LocalDate.of(2026, 4, 27);
         Article article = createArticle(100L, 50L, 1L, "매일메일 제목", "<p>본문</p>");
         MaeilMailSentContent sentContent = createSentContent(1L, 10L, 9000L);
-        IssueEntry entry = new IssueEntry(article, List.of(1L, 2L), sentContent);
+        IssueEntry entry = new IssueEntry(article, List.of(1L, 2L), sentContent, 9000L);
         PreparedIssueEntries preparedIssueEntries = new PreparedIssueEntries(List.of(entry), List.of(9L));
         Newsletter newsletter = createNewsletter(50L, "매일메일");
 
@@ -105,10 +106,27 @@ class MaeilMailIssuePublisherTest {
             softly.assertThat(event.contents()).isEqualTo("<p>본문</p>");
             softly.assertThat(event.source()).isEqualTo(ArticleSource.MAEIL_MAIL_ISSUED);
             softly.assertThat(histories).hasSize(1);
-            softly.assertThat(histories.getFirst().getIssueDate()).isEqualTo(issueDate);
-            softly.assertThat(histories.getFirst().getMemberId()).isEqualTo(1L);
-            softly.assertThat(histories.getFirst().getTopicId()).isEqualTo(10L);
+            softly.assertThat(histories.getFirst().getArticleId()).isEqualTo(100L);
+            softly.assertThat(histories.getFirst().getContentId()).isEqualTo(9000L);
         });
+    }
+
+    @Test
+    void 저장된_article_수와_entry_수가_다르면_예외가_발생한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        Article article = createArticle(null, 50L, 1L, "매일메일 제목", "<p>본문</p>");
+        MaeilMailSentContent sentContent = createSentContent(1L, 10L, 9000L);
+        IssueEntry entry = new IssueEntry(article, List.of(1L), sentContent, 9000L);
+        PreparedIssueEntries preparedIssueEntries = new PreparedIssueEntries(List.of(entry), List.of());
+
+        given(articleRepository.saveAll(List.of(article))).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> issuePublisher.publish(preparedIssueEntries, issueDate))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Article 저장 결과 수");
+        verifyNoInteractions(newsletterRepository, sentContentRepository, issueHistoryRepository, trackRepository, eventPublisher);
     }
 
     @Test

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisherTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisherTest.java
@@ -74,7 +74,7 @@ class MaeilMailIssuePublisherTest {
         LocalDate issueDate = LocalDate.of(2026, 4, 27);
         Article article = createArticle(100L, 50L, 1L, "매일메일 제목", "<p>본문</p>");
         MaeilMailSentContent sentContent = createSentContent(1L, 10L, 9000L);
-        IssueEntry entry = new IssueEntry(article, List.of(1L, 2L), sentContent, 9000L);
+        IssueEntry entry = new IssueEntry(article, List.of(1L, 2L), sentContent);
         PreparedIssueEntries preparedIssueEntries = new PreparedIssueEntries(List.of(entry), List.of(9L));
         Newsletter newsletter = createNewsletter(50L, "매일메일");
 
@@ -117,7 +117,7 @@ class MaeilMailIssuePublisherTest {
         LocalDate issueDate = LocalDate.of(2026, 4, 27);
         Article article = createArticle(null, 50L, 1L, "매일메일 제목", "<p>본문</p>");
         MaeilMailSentContent sentContent = createSentContent(1L, 10L, 9000L);
-        IssueEntry entry = new IssueEntry(article, List.of(1L), sentContent, 9000L);
+        IssueEntry entry = new IssueEntry(article, List.of(1L), sentContent);
         PreparedIssueEntries preparedIssueEntries = new PreparedIssueEntries(List.of(entry), List.of());
 
         given(articleRepository.saveAll(List.of(article))).willReturn(List.of());

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisherTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisherTest.java
@@ -2,7 +2,9 @@ package news.bombomemail.nativenewsletter.maeilmail.service.internal;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -112,6 +114,44 @@ class MaeilMailIssuePublisherTest {
     }
 
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void 여러_article을_저장하면_entry_순서대로_article_content_history를_기록한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        Article firstArticle = createArticle(100L, 50L, 1L, "첫 번째 제목", "<p>첫 번째 본문</p>");
+        Article secondArticle = createArticle(101L, 50L, 2L, "두 번째 제목", "<p>두 번째 본문</p>");
+        MaeilMailSentContent firstSentContent = createSentContent(1L, 10L, 9000L);
+        MaeilMailSentContent secondSentContent = createSentContent(2L, 20L, 9001L);
+        IssueEntry firstEntry = new IssueEntry(firstArticle, List.of(1L), firstSentContent);
+        IssueEntry secondEntry = new IssueEntry(secondArticle, List.of(2L), secondSentContent);
+        PreparedIssueEntries preparedIssueEntries = new PreparedIssueEntries(List.of(firstEntry, secondEntry), List.of());
+        Newsletter newsletter = createNewsletter(50L, "매일메일");
+
+        given(articleRepository.saveAll(List.of(firstArticle, secondArticle)))
+                .willReturn(List.of(firstArticle, secondArticle));
+        given(newsletterRepository.findAllById(Set.of(50L))).willReturn(List.of(newsletter));
+
+        // when
+        issuePublisher.publish(preparedIssueEntries, issueDate);
+
+        // then
+        ArgumentCaptor<Iterable> historyCaptor = ArgumentCaptor.forClass(Iterable.class);
+        verify(issueHistoryRepository).saveAll(historyCaptor.capture());
+        verify(eventPublisher, times(2)).publishEvent(any(ArticleArrivedEvent.class));
+
+        List<MaeilMailIssueHistory> histories = StreamSupport.stream(historyCaptor.getValue().spliterator(), false)
+                .map(MaeilMailIssueHistory.class::cast)
+                .toList();
+        assertSoftly(softly -> {
+            softly.assertThat(histories).hasSize(2);
+            softly.assertThat(histories.get(0).getArticleId()).isEqualTo(100L);
+            softly.assertThat(histories.get(0).getContentId()).isEqualTo(9000L);
+            softly.assertThat(histories.get(1).getArticleId()).isEqualTo(101L);
+            softly.assertThat(histories.get(1).getContentId()).isEqualTo(9001L);
+        });
+    }
+
+    @Test
     void 저장된_article_수와_entry_수가_다르면_예외가_발생한다() {
         // given
         LocalDate issueDate = LocalDate.of(2026, 4, 27);
@@ -127,6 +167,28 @@ class MaeilMailIssuePublisherTest {
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("Article 저장 결과 수");
         verifyNoInteractions(newsletterRepository, sentContentRepository, issueHistoryRepository, trackRepository, eventPublisher);
+    }
+
+    @Test
+    void article의_newsletter를_찾지_못하면_이벤트를_발행하지_않고_예외가_발생한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        Article article = createArticle(100L, 50L, 1L, "매일메일 제목", "<p>본문</p>");
+        MaeilMailSentContent sentContent = createSentContent(1L, 10L, 9000L);
+        IssueEntry entry = new IssueEntry(article, List.of(1L), sentContent);
+        PreparedIssueEntries preparedIssueEntries = new PreparedIssueEntries(List.of(entry), List.of());
+
+        given(articleRepository.saveAll(List.of(article))).willReturn(List.of(article));
+        given(newsletterRepository.findAllById(Set.of(50L))).willReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> issuePublisher.publish(preparedIssueEntries, issueDate))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Newsletter");
+        verify(sentContentRepository).saveAll(List.of(sentContent));
+        verify(issueHistoryRepository).saveAll(any());
+        verify(trackRepository).markIssuedByIds(List.of(1L), issueDate);
+        verifyNoInteractions(eventPublisher);
     }
 
     @Test

--- a/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisherTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/nativenewsletter/maeilmail/service/internal/MaeilMailIssuePublisherTest.java
@@ -1,0 +1,167 @@
+package news.bombomemail.nativenewsletter.maeilmail.service.internal;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.StreamSupport;
+import news.bombomemail.article.domain.Article;
+import news.bombomemail.article.event.ArticleArrivedEvent;
+import news.bombomemail.article.event.ArticleSource;
+import news.bombomemail.article.repository.ArticleRepository;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailIssueHistory;
+import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
+import news.bombomemail.nativenewsletter.maeilmail.dto.IssueEntry;
+import news.bombomemail.nativenewsletter.maeilmail.dto.PreparedIssueEntries;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailIssueHistoryRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSentContentRepository;
+import news.bombomemail.nativenewsletter.maeilmail.repository.MaeilMailSubscriptionTrackRepository;
+import news.bombomemail.newsletter.domain.Newsletter;
+import news.bombomemail.newsletter.repository.NewsletterRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class MaeilMailIssuePublisherTest {
+
+    @Mock
+    private ArticleRepository articleRepository;
+
+    @Mock
+    private NewsletterRepository newsletterRepository;
+
+    @Mock
+    private MaeilMailSentContentRepository sentContentRepository;
+
+    @Mock
+    private MaeilMailIssueHistoryRepository issueHistoryRepository;
+
+    @Mock
+    private MaeilMailSubscriptionTrackRepository trackRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private MaeilMailIssuePublisher issuePublisher;
+
+    @BeforeEach
+    void setup() {
+        issuePublisher = new MaeilMailIssuePublisher(
+                articleRepository,
+                newsletterRepository,
+                sentContentRepository,
+                issueHistoryRepository,
+                trackRepository,
+                eventPublisher
+        );
+    }
+
+    @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void article을_저장하고_매일메일_발행_이벤트와_발행결과를_기록한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        Article article = createArticle(100L, 50L, 1L, "매일메일 제목", "<p>본문</p>");
+        MaeilMailSentContent sentContent = createSentContent(1L, 10L, 9000L);
+        IssueEntry entry = new IssueEntry(article, List.of(1L, 2L), sentContent);
+        PreparedIssueEntries preparedIssueEntries = new PreparedIssueEntries(List.of(entry), List.of(9L));
+        Newsletter newsletter = createNewsletter(50L, "매일메일");
+
+        given(articleRepository.saveAll(List.of(article))).willReturn(List.of(article));
+        given(newsletterRepository.findAllById(Set.of(50L))).willReturn(List.of(newsletter));
+
+        // when
+        issuePublisher.publish(preparedIssueEntries, issueDate);
+
+        // then
+        ArgumentCaptor<ArticleArrivedEvent> eventCaptor = ArgumentCaptor.forClass(ArticleArrivedEvent.class);
+        ArgumentCaptor<Iterable> historyCaptor = ArgumentCaptor.forClass(Iterable.class);
+        verify(eventPublisher).publishEvent(eventCaptor.capture());
+        verify(sentContentRepository).saveAll(List.of(sentContent));
+        verify(issueHistoryRepository).saveAll(historyCaptor.capture());
+        verify(trackRepository).markIssuedByIds(List.of(1L, 2L, 9L), issueDate);
+
+        ArticleArrivedEvent event = eventCaptor.getValue();
+        List<MaeilMailIssueHistory> histories = StreamSupport.stream(historyCaptor.getValue().spliterator(), false)
+                .map(MaeilMailIssueHistory.class::cast)
+                .toList();
+        assertSoftly(softly -> {
+            softly.assertThat(event.newsletterId()).isEqualTo(50L);
+            softly.assertThat(event.newsletterName()).isEqualTo("매일메일");
+            softly.assertThat(event.articleId()).isEqualTo(100L);
+            softly.assertThat(event.articleTitle()).isEqualTo("매일메일 제목");
+            softly.assertThat(event.memberId()).isEqualTo(1L);
+            softly.assertThat(event.unsubscribeUrl()).isNull();
+            softly.assertThat(event.contents()).isEqualTo("<p>본문</p>");
+            softly.assertThat(event.source()).isEqualTo(ArticleSource.MAEIL_MAIL_ISSUED);
+            softly.assertThat(histories).hasSize(1);
+            softly.assertThat(histories.getFirst().getIssueDate()).isEqualTo(issueDate);
+            softly.assertThat(histories.getFirst().getMemberId()).isEqualTo(1L);
+            softly.assertThat(histories.getFirst().getTopicId()).isEqualTo(10L);
+        });
+    }
+
+    @Test
+    void 이미_발행된_track만_있으면_article_저장없이_track만_갱신한다() {
+        // given
+        LocalDate issueDate = LocalDate.of(2026, 4, 27);
+        PreparedIssueEntries preparedIssueEntries = new PreparedIssueEntries(List.of(), List.of(9L, 10L));
+
+        // when
+        issuePublisher.publish(preparedIssueEntries, issueDate);
+
+        // then
+        verify(trackRepository).markIssuedByIds(List.of(9L, 10L), issueDate);
+        verifyNoInteractions(articleRepository, newsletterRepository, sentContentRepository, issueHistoryRepository, eventPublisher);
+    }
+
+    private Article createArticle(
+            Long id,
+            Long newsletterId,
+            Long memberId,
+            String title,
+            String contents
+    ) {
+        return Article.builder()
+                .id(id)
+                .title(title)
+                .contents(contents)
+                .contentsText("본문")
+                .contentsSummary("요약")
+                .expectedReadTime(1)
+                .memberId(memberId)
+                .newsletterId(newsletterId)
+                .arrivedDateTime(LocalDateTime.of(2026, 4, 27, 7, 0))
+                .build();
+    }
+
+    private MaeilMailSentContent createSentContent(Long memberId, Long topicId, Long contentId) {
+        return MaeilMailSentContent.builder()
+                .memberId(memberId)
+                .topicId(topicId)
+                .contentId(contentId)
+                .build();
+    }
+
+    private Newsletter createNewsletter(Long id, String name) {
+        return Newsletter.builder()
+                .id(id)
+                .name(name)
+                .description("설명")
+                .imageUrl("image")
+                .email("maeil@example.com")
+                .categoryId(1L)
+                .detailId(1L)
+                .build();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/newsletter/domain/NewsletterTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/newsletter/domain/NewsletterTest.java
@@ -1,0 +1,41 @@
+package news.bombomemail.newsletter.domain;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import org.junit.jupiter.api.Test;
+
+class NewsletterTest {
+
+    @Test
+    void source와_status를_지정하지_않으면_기본값을_사용한다() {
+        Newsletter newsletter = createNewsletterBuilder().build();
+
+        assertSoftly(softly -> {
+            softly.assertThat(newsletter.getSource()).isEqualTo(NewsletterSource.EXTERNAL);
+            softly.assertThat(newsletter.getStatus()).isEqualTo(NewsletterPublicationStatus.ACTIVE);
+        });
+    }
+
+    @Test
+    void source와_status를_명시할_수_있다() {
+        Newsletter newsletter = createNewsletterBuilder()
+                .source(NewsletterSource.MAEIL_MAIL)
+                .status(NewsletterPublicationStatus.SUSPENDED)
+                .build();
+
+        assertSoftly(softly -> {
+            softly.assertThat(newsletter.getSource()).isEqualTo(NewsletterSource.MAEIL_MAIL);
+            softly.assertThat(newsletter.getStatus()).isEqualTo(NewsletterPublicationStatus.SUSPENDED);
+        });
+    }
+
+    private Newsletter.NewsletterBuilder createNewsletterBuilder() {
+        return Newsletter.builder()
+                .name("테스트뉴스레터")
+                .description("설명")
+                .imageUrl("이미지")
+                .email("test-newsletter@example.com")
+                .categoryId(1L)
+                .detailId(1L);
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/reading/event/TodayReadingListenerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/reading/event/TodayReadingListenerTest.java
@@ -1,9 +1,7 @@
 package news.bombomemail.reading.event;
 
-import jakarta.mail.Session;
-import jakarta.mail.internet.MimeMessage;
-import java.util.Properties;
 import news.bombomemail.article.event.ArticleArrivedEvent;
+import news.bombomemail.article.event.ArticleSource;
 import news.bombomemail.reading.service.TodayReadingService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,12 +33,12 @@ class TodayReadingListenerTest {
         String articleTitle = "테스트 아티클";
         Long memberId = 1L;
         String unsubscribeUrl = "unsubscribeUrl";
-        MimeMessage message = new MimeMessage(Session.getDefaultInstance(new Properties()));
         String contents = "테스트 본문";
 
         // when
         eventPublisher.publishEvent(ArticleArrivedEvent.of(
-                newsletterId, newsletterName, articleId, articleTitle, memberId, unsubscribeUrl, message, contents));
+                newsletterId, newsletterName, articleId, articleTitle, memberId, unsubscribeUrl, contents,
+                ArticleSource.EMAIL_RECEIVED));
 
         TestTransaction.flagForCommit();
         TestTransaction.end();

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListenerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListenerTest.java
@@ -1,6 +1,7 @@
 package news.bombomemail.subscribe.event;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import news.bombomemail.article.event.ArticleArrivedEvent;
 import news.bombomemail.article.event.ArticleSource;
@@ -44,5 +45,28 @@ class SubscribeArticleArrivedListenerTest {
 
         // then
         verify(subscribeService).upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+    }
+
+    @Test
+    @Transactional
+    void 매일메일_발행_이벤트는_구독_저장을_호출하지_않는다() {
+        // given
+        Long newsletterId = 1L;
+        String newsletterName = "매일메일";
+        Long articleId = 1L;
+        String articleTitle = "매일메일 아티클";
+        Long memberId = 2L;
+        String contents = "매일메일 본문";
+
+        // when
+        eventPublisher.publishEvent(ArticleArrivedEvent.of(
+                newsletterId, newsletterName, articleId, articleTitle, memberId, null, contents,
+                ArticleSource.MAEIL_MAIL_ISSUED));
+
+        TestTransaction.flagForCommit();
+        TestTransaction.end();
+
+        // then
+        verifyNoInteractions(subscribeService);
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListenerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListenerTest.java
@@ -2,10 +2,8 @@ package news.bombomemail.subscribe.event;
 
 import static org.mockito.Mockito.verify;
 
-import jakarta.mail.Session;
-import jakarta.mail.internet.MimeMessage;
-import java.util.Properties;
 import news.bombomemail.article.event.ArticleArrivedEvent;
+import news.bombomemail.article.event.ArticleSource;
 import news.bombomemail.subscribe.service.SubscribeService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,12 +32,12 @@ class SubscribeArticleArrivedListenerTest {
         String articleTitle = "테스트 아티클";
         Long memberId = 2L;
         String unsubscribeUrl = "unsubscribeUrl";
-        MimeMessage message = new MimeMessage(Session.getDefaultInstance(new Properties()));
         String contents = "테스트 본문";
         
         // when
         eventPublisher.publishEvent(ArticleArrivedEvent.of(
-                newsletterId, newsletterName, articleId, articleTitle, memberId, unsubscribeUrl, message, contents));
+                newsletterId, newsletterName, articleId, articleTitle, memberId, unsubscribeUrl, contents,
+                ArticleSource.EMAIL_RECEIVED));
 
         TestTransaction.flagForCommit();
         TestTransaction.end();

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/SubscribeServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/SubscribeServiceTest.java
@@ -1,5 +1,7 @@
 package news.bombomemail.subscribe.service;
 
+import news.bombomemail.subscribe.domain.Subscribe;
+import news.bombomemail.subscribe.domain.SubscribeStatus;
 import news.bombomemail.subscribe.repository.SubscribeRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,6 +33,22 @@ class SubscribeServiceTest {
         // then
         boolean exists = subscribeRepository.existsByNewsletterIdAndMemberId(newsletterId, memberId);
         assertThat(exists).isTrue();
+    }
+
+    @Test
+    void 새로_저장된_구독은_SUBSCRIBED_상태를_기본값으로_가진다() {
+        // given
+        Long newsletterId = 1L;
+        Long memberId = 2L;
+        String unsubscribeUrl = "unsubscribeUrl";
+
+        // when
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+
+        // then
+        Subscribe subscribe = subscribeRepository.findByMemberIdAndNewsletterId(memberId, newsletterId)
+                .orElseThrow();
+        assertThat(subscribe.getStatus()).isEqualTo(SubscribeStatus.SUBSCRIBED);
     }
 
     @Test


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

mail-server에 **매일메일 발행 로직**을 추가했습니다.

매일메일은 외부 뉴스레터 이메일을 파싱해서 저장하는 흐름이 아니라, 서버가 보유한 `MaeilMailContent`를 회원별로 하나씩 골라 `Article`로 발행하는 기능입니다.

이번 PR에서 구현한 전체 흐름은 다음과 같습니다.

1. 발행 대상 회원의 매일메일 track을 조회한다.
2. 회원의 track 상태에 맞는 topic을 고른다.
3. 해당 topic에서 아직 보내지 않은 content를 선택한다.
4. 선택된 content를 `Article`로 저장한다.
5. 저장된 Article 기준으로 기존 `ArticleArrivedEvent`를 발행한다.
6. 기존 RecentArticle, 알림, TodayReading 흐름을 그대로 태운다.
7. 발행 이력과 다음 발행을 위한 진행 상태를 저장한다.
8. 평일 오전 7시에 스케줄러로 발행한다.

#### 주의사항
- 같은 날 같은 회원/topic에 중복 발행되면 안 됨
- 이미 보낸 content는 다시 보내지 않아야 함
- topic의 content를 모두 보낸 뒤에는 다시 순환할 수 있어야 함
- 발행된 Article이 어떤 MaeilMailContent에서 만들어졌는지 추적 가능해야 함
- 여러 서버에서 스케줄러가 떠도 중복 실행되면 안 됨(추후 email 서버 확장 사전 대비)

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
매일메일 발행 결과도 사용자가 읽는 글이라는 점에서는 기존 뉴스레터 Article과 동일합니다.
따라서 매일메일 전용 후속 로직을 새로 만들기보다, 발행 결과를 `Article`로 저장하고 기존 Article 이벤트 흐름을 재사용하도록 했습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

**❓왜 이메일 서버에 구현하셨나요**
원래는 운영서버에 구현을 하려고 했으나 생각해보니 이메일을 받고나서 이뤄지는 부가 로직들이 전부 이메일서버에 있기에 매일메일만을 위해 그 부가 로직 전체를 운영 서버에 가져오는 건 비효율이라고 생각했습니다.  그래서 기존 이메일 서버에 구현했습니다.  
처음 운영서버를 염두해둔 이유는 분산서버라 안정성이 높아서인데 어차피 곧 이메일 서버도 추가될 예정이라 상관없을 것 같습니다.

**❓왜 이렇게 코드가 많나요?**
저도 이렇게 까지 커질줄은 몰랐습니다. 
고려해야할 점들이 많았습니다.
- 일단 기존 운영서버에 있는 매일메일 관련 코드를 가져와야 했습니다.
- 완전 새로운 기능이라 기존 코드 활용도가 많이 떨어졌고 service, repository, domain에 새롭게 추가되는 코드가 많았습니다.
- 처음에 하나의 클래스에 했을 때 500줄이 넘어서 "이건 유지보수가 불가능이다"라는 생각이 들어서 코드가 조금 많아지지만 쪼갰습니다.
- 장애 발생시 고려해야할 점들이 많았습니다.


**❓왜 content 발행이 랜덤인가요?**
>현재 로직은 FE/BE을 확인 하고 주제를 확인하고 그 주제에서 랜덤으로 뽑아서 1개를 메일로 보내게 되어있습니다. 

사실 이 부분은 순차 방식이 기술적인 측면에서 압도적으로 좋습니다. 컨텐츠 관리만 조금 신경쓴다면 코드도 더 적고, 메모리도 덜 쓸 수 있습니다. 하지만 비즈니스 적인 측면이 더 가치가 높다고 생각해서 랜덤 방식으로 진행했습니다.

먼저 사용자 경험 측면에서, 순차 방식은 구현이 간단하다는 장점이 있지만 시간이 지날수록 사용자에게 일정한 패턴을 노출하게 됩니다. 학습이나 구독형 서비스에서 다음 문제가 예측 가능하다는 점은 사용자에게 긴장감을 떨어뜨리고 지루함을 줄 수 있는 요인이 됩니다. 반면 랜덤 방식은 매일 어떤 문제가 나올지 모르는 기대감을 주어 조금 더 흥미를 일으킨다고 생각했습니다.  예를들어 같은날 두 명의 개발자가 같이 구독을 해도 문제가 서로 다를 확률이 매우 높기 때문에 서로 문제를 풀어보며 공부할 수도 있습니다.

기술적인 측면으로는 순차 방식을 채택할 경우 콘텐츠를 수정하거나 삭제할 때마다 해당 문제 뒤에 오는 데이터의 순번을 신경써줘야합니다. 반면 랜덤 방식은 사용자가 이미 받은 문제 ID를 제외하고 남은 문제에서 무작위로 추출하는 방식을 통해, 데이터의 추가나 삭제가 전체 로직에 영향을 주지 않습니다. 따라서 운영할 때 순서에 얽매이지 않고 자유롭게 콘텐츠를 관리할 수 있으며, 시스템은 어떤 상황에서도 끊김 없이 안정적으로 문제를 제공할 수 있습니다.

주제도 랜덤으로 할 수 있지만 주제까지 랜덤으로 하면 코드 복잡성이 더 올라가기에 일단 순차적으로 적용했고 추후 모니터링을 통해 필요하다고 생각되면 변경할 예정입니다.

### 주요 도메인 정리
<details>
<summary>주요 도메인 정리</summary>

- `MaeilMailIssueJob`
  - 하루 발행 작업 하나를 의미합니다.
  - `lastProcessedTrackId`를 저장해서 서버가 중간에 종료되어도 이어서 처리할 수 있습니다.

- `MaeilMailSubscriptionTrack`
  - 한 사용자가 어떤 매일메일 track을 어디까지 받았는지 나타냅니다.
  - `curriculumIndex`로 다음 topic을 고르고, `lastIssuedDate`로 오늘 이미 발행됐는지 판단합니다.

- `MaeilMailSentContent`
  - 특정 member/topic에게 이미 보낸 content를 기록합니다.
  - 다음 발행 때 같은 content를 다시 보내지 않기 위한 상태입니다.

- `MaeilMailIssueHistory`
  - 발행된 Article과 MaeilMailContent의 매핑입니다.
  - 같은 날 같은 member/topic Article이 중복 생성되는 것을 막는 기준으로도 사용합니다.

- `ArticleArrivedEvent`
  - 매일메일 발행 결과를 기존 후속 로직에 연결하는 이벤트입니다.
  - 매일메일은 `MAEIL_MAIL_ISSUED` source로 발행됩니다.

</details>



### 주요 서비스 정리

<details>
<summary>주요 서비스 정리</summary>

#### 발행 시작 지점

- `MaeilMailScheduler`
  - 평일 오전 7시에 매일메일 발행을 시작합니다.
  - `ShedLock`을 사용해 여러 서버에서 동시에 실행되지 않도록 막습니다.

- `MaeilMailIssueStartupResumeListener`
  - 서버가 다시 뜬 뒤, 오늘 미완료 발행 job이 있는지 확인하는 진입점입니다.
  - 재개에 실패해도 서버 기동은 실패시키지 않고 로그만 남깁니다.

- `MaeilMailIssueStartupResumeExecutor`
  - 실제 자동 재개 실행을 담당합니다.
  - 스케줄러와 같은 `maeil_mail_issue` lock을 사용합니다.

#### 발행 job 관리

- `MaeilMailIssueService`
  - 매일메일 발행 전체 흐름을 조율합니다.
  - 정기 발행에서는 오늘 job을 만들거나 기존 job을 이어서 실행합니다.
  - 서버 재시작 재개에서는 오늘 `RUNNING` 또는 `FAILED` job이 있을 때만 이어서 실행합니다.

- `MaeilMailIssueJobManager`
  - `MaeilMailIssueJob`의 상태를 관리합니다.
  - job 생성, 재개, chunk 진행 기록, 완료 처리, 실패 처리를 담당합니다.

#### chunk 처리

- `MaeilMailIssueChunkProcessor`
  - 하나의 chunk를 처리합니다.
  - 발행 대상 track을 조회하고, 데이터 로딩, entry 준비, 발행, job cursor 갱신을 순서대로 실행합니다.
  - chunk 단위로 독립 트랜잭션을 사용합니다.

- `MaeilMailIssueDataLoader`
  - chunk 처리에 필요한 데이터를 한 번에 모읍니다.
  - topic, content, sent content, issue history, newsletterId 등을 조회합니다.

- `MaeilMailIssueEntryPreparer`
  - 실제 발행할 entry를 만듭니다.
  - 같은 member/topic 중복을 하나로 합치고, 이미 오늘 발행된 member/topic은 제외합니다.
  - 오늘 보낼 content를 선택합니다.

- `MaeilMailIssueContentAssigner`
  - 특정 member/topic에게 보낼 content를 고릅니다.
  - 이미 보낸 content는 제외합니다.
  - 모든 content를 보냈다면 sent content를 초기화하고 다시 선택합니다.

#### 발행 결과 저장

- `MaeilMailIssuePublisher`
  - 준비된 entry를 실제 발행 결과로 저장합니다.
  - `Article`을 생성하고, `sent_content`, `issue_history`, track 상태를 갱신합니다.
  - 마지막으로 `ArticleArrivedEvent(MAEIL_MAIL_ISSUED)`를 발행합니다.

</details>

### 서비스 흐름
<details>
<summary>서비스 흐름</summary>

```mermaid
flowchart TD
    A["평일 오전 7시 스케줄러"] --> B["ShedLock 획득: maeil_mail_issue"]
    R["서버 재시작 ApplicationReadyEvent"] --> S["ShedLock 획득: maeil_mail_issue"]

    B --> C["issue()"]
    C --> D{"주말인가?"}
    D -- "예" --> E["발행 스킵"]
    D -- "아니오" --> F["오늘 job 조회 또는 생성"]

    S --> G["resumeIncompleteTodayJob()"]
    G --> H{"오늘 RUNNING/FAILED job 존재?"}
    H -- "없음" --> I["재개 안 함"]
    H -- "있음" --> J["기존 job 재개"]

    F --> K["runIssueJob()"]
    J --> K

    K --> L{"job COMPLETED?"}
    L -- "예" --> M["종료"]
    L -- "아니오" --> N["lastProcessedTrackId 이후 chunk 조회"]

    N --> O{"발행 대상 track 있음?"}
    O -- "없음" --> P["job COMPLETED 저장"]
    O -- "있음" --> Q["발행 데이터 로딩"]

    Q --> R1["발행 entry 준비"]
    R1 --> R2["member/topic 중복 제거"]
    R2 --> R3["오늘 이미 발행된 member/topic 제외"]
    R3 --> R4["content 선택"]

    R4 --> T["Article 저장"]
    T --> U["sent_content 저장"]
    U --> V["issue_history 저장"]
    V --> W["track lastIssuedDate 갱신"]
    W --> X["ArticleArrivedEvent 발행"]
    X --> Y["job cursor/count 갱신"]
    Y --> N

```
</details>

### 고민한 내용

<details>
<summary>대량 발행 고민</summary>


이전 매일메일 구독자 수가 1만 명을 넘었던 것을 생각하면, 지금 당장은 구독자 수가 많지 않더라도 가까운 미래의 규모는 어느 정도 고려해야 한다고 봤습니다. 그래서 1차 목표는 이전 구독자 수의 약 10%인 1천 명 정도를 안정적으로 처리하는 것이었습니다.

1천 명에게 한 번에 발행한다고 생각해보면 몇 가지 문제가 있습니다. 모든 구독자를 한 번에 조회하면 메모리 부담이 생길 수 있고, 발행 도중 서버가 꺼지면 어디까지 처리됐는지 알기 어렵습니다. 또 다시 실행했을 때 이미 발행된 사용자에게 중복으로 발행될 수도 있고, 서버가 여러 대라면 스케줄러가 동시에 실행될 가능성도 있습니다.

처음 떠오른 건 Spring Batch였습니다. 하지만 이번에는 도입하지 않았습니다. 현재 규모에서 JobRepository, Step, Reader/Processor/Writer 구조까지 가져가는 것은 과하다고 봤고, 서버 메모리를 아껴 써야 하는 상황에서 큰 의존성을 추가하는 것도 부담이 있었습니다. 지금 필요한 것은 Spring Batch 전체 기능이 아니라, 대량 데이터를 chunk 단위로 나누어 처리하고, 중간에 실패하더라도 다시 이어서 실행할 수 있고, 중복 발행을 막는 정도라고 판단했습니다.

그래서 Spring Batch 대신 발행 job 개념만 가볍게 구현했습니다. `MaeilMailIssueService`가 전체 발행 흐름을 시작하고, `MaeilMailIssueChunkProcessor`가 발행 대상을 chunk 단위로 나누어 처리합니다. 기본 chunk size는 200으로 두었고, 구독자가 1천 명이면 대략 5번의 chunk로 나누어 처리됩니다. (일단 초기값을 200으로 잡았고 모니터링을 통해서 조정할 생각입니다) 

각 chunk는 독립 트랜잭션으로 처리됩니다. 그리고 chunk가 성공하면 `MaeilMailIssueJob`에 `lastProcessedTrackId`를 저장합니다. 그래서 발행 도중 서버가 종료되더라도 이미 커밋된 chunk의 결과와 cursor는 유지됩니다. 이후 다시 job이 실행되면 저장된 `lastProcessedTrackId` 이후부터 이어서 처리할 수 있습니다. 즉, 단순히 처음부터 다시 훑는 방식이 아니라 job cursor를 기준으로 중단된 지점부터 재개할 수 있는 구조를 만들었습니다.

재실행 시 중복 발행을 막기 위해서는 두 가지 기준을 두었습니다.

첫 번째는 track의 `lastIssuedDate`입니다. 오늘 이미 발행된 track은 다시 발행 대상에서 제외합니다. 이 값이 있기 때문에 서버가 중간에 종료된 뒤 다시 실행되어도 이미 처리된 track은 다시 article을 만들지 않습니다.

두 번째는 `MaeilMailIssueHistory`입니다. 같은 날 같은 member/topic 조합이 이미 발행되었다면 다시 article을 만들지 않습니다. 이 기준이 필요한 이유는 같은 사용자와 topic으로 여러 track이 수렴할 수 있기 때문입니다. 단순히 track 단위로만 막으면, 다른 track이지만 같은 member/topic인 경우 중복 발행이 생길 수 있습니다. 그래서 track의 `lastIssuedDate`로 1차 중복을 막고, issue history로 member/topic 기준의 2차 중복을 막았습니다.

스케줄러 중복 실행도 고려했습니다. 운영 환경에서는 서버가 여러 대일 수 있기 때문에 같은 시간에 발행 job이 여러 번 실행되면 안 됩니다. 그래서 ShedLock을 사용해 같은 시간에는 하나의 서버만 매일메일 발행 job을 실행할 수 있도록 했습니다.

정리하면, 이번 발행 로직은 한 번에 전체 대상을 처리하지 않고 chunk 단위로 나누어 메모리 부담을 줄였습니다. 또한 chunk별 독립 트랜잭션과 job cursor를 사용해 중간 실패 시에도 중단된 지점부터 이어서 실행할 수 있도록 했고, `lastIssuedDate`와 `MaeilMailIssueHistory`를 기준으로 중복 발행을 막았습니다.

</details>

### 발행 대상 선정 및 content 선택 로직 설명

<details>
<summary>설명</summary>

**발행 대상 선정**

- 평일에만 발행합니다.
- 발행 대상은 다음 조건을 만족해야 합니다.
  - Subscribe: `SUBSCRIBED`
  - Newsletter source: `MAEIL_MAIL`
  - Newsletter status: `ACTIVE`
  - Track `lastIssuedDate`가 오늘이 아님
- chunk 단위로 처리합니다.
- 기본 chunk size는 `200`이고 설정으로 변경 가능합니다.
  - `maeil-mail.issue.chunk-size`

**content 선택 로직**

- track의 `curriculumIndex % topics.size()`로 다음 topic을 고릅니다.
- 같은 `(memberId, topicId)`가 한 chunk 안에 여러 번 등장하면 Article은 하나만 생성하고, 관련 track들은 함께 진행 처리합니다.
- 이미 보낸 content는 제외합니다.
- 해당 topic의 모든 content를 이미 보냈다면 `sent_content`를 삭제하고 다시 처음부터 순환합니다.
- 선택된 content가 실제 조회되지 않으면 silent skip하지 않고 예외를 던져 chunk를 실패시킵니다.

</details>

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
1. 서비스 코드가 너무 많아져서 아래처럼 폴더를 통해 분리를 해보았는데 어떤가요? 혹시 더 좋은 방법이 있을까요?
<img width="279" height="178" alt="image" src="https://github.com/user-attachments/assets/11cbf2ce-122f-4b33-b0bc-4bfc6cc41bad" />
같은 레벨에 두기에는 너무 복잡해지고 폴더로 분리하면 그나마 직관적으로 보았을 때 가독성이 더 좋은 것 같아서 시도해보았습니다. 
전부 MaeilMailIssueService의 하위 객체들입니다.      

2. 스키마 PR - https://github.com/woowacourse-teams/2025-bom-bom/pull/740



## 가이드 라인
현재 코드가 거의 4천줄에 육박합니다.
"저도 메일만 넣어주면 끝아냐?" 했지만 
고려할게 너무 많고 운영서버가 아니다보니 추가해 줘야 할 게 많아 이렇게 되었습니다.
현실적으로 코드를 전체보기는 어렵다고 생각합니다. 
해서 중요한 부분을 알려드리겠습니다.  
일단 `MaeilMailIssueService`가 핵심입니다. 모든 로직이 여기서 부터 시작됩니다.(스케줄링이 이넘을 호출)
해당 서비스 기준으로 public 메서드만 쭉 한 번 흐름을 먼저 보세요. 
그리고 더 궁금한 로직이 생기면 그때 부터 파보시면됩니다. 

`MaeilMailIssueService` 바로 하위인 `chunkProcessor` 에서는 issueData, preparedEntries, issuePublisher 정보만 보셔도 좋습니다.
