### PR TITLE
[BOM-1109] test: 연속 읽기 초기화 테스트 날짜 의존성 제거

### DIFF
--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
@@ -1,6 +1,6 @@
 package me.bombom.api.v1.reading.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -10,25 +10,15 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
-import me.bombom.api.v1.badge.service.BadgeService;
-import me.bombom.api.v1.common.ContinueReadingRankingScheduleProperties;
-import me.bombom.api.v1.common.MonthlyRankingScheduleProperties;
-import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
 import me.bombom.api.v1.reading.domain.TodayReading;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
-import me.bombom.api.v1.reading.repository.ContinueReadingSnapshotRepository;
-import me.bombom.api.v1.reading.repository.MonthlyReadingRealtimeRepository;
-import me.bombom.api.v1.reading.repository.MonthlyReadingSnapshotRepository;
 import me.bombom.api.v1.reading.repository.TodayReadingRepository;
-import me.bombom.api.v1.reading.repository.WeeklyReadingRepository;
-import me.bombom.api.v1.reading.repository.YearlyReadingRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class ReadingServiceResetContinueReadingCountTest {
@@ -39,43 +29,10 @@ class ReadingServiceResetContinueReadingCountTest {
     private ReadingService readingService;
 
     @Mock
-    private ReadingSnapshotMetaService readingSnapshotMetaService;
-
-    @Mock
-    private MemberRepository memberRepository;
-
-    @Mock
     private ContinueReadingRealtimeRepository continueReadingRepository;
 
     @Mock
-    private ContinueReadingSnapshotRepository continueReadingRankingSnapshotRepository;
-
-    @Mock
     private TodayReadingRepository todayReadingRepository;
-
-    @Mock
-    private WeeklyReadingRepository weeklyReadingRepository;
-
-    @Mock
-    private MonthlyReadingSnapshotRepository monthlyReadingSnapshotRepository;
-
-    @Mock
-    private MonthlyReadingRealtimeRepository monthlyReadingRealtimeRepository;
-
-    @Mock
-    private YearlyReadingRepository yearlyReadingRepository;
-
-    @Mock
-    private MonthlyRankingScheduleProperties scheduleProps;
-
-    @Mock
-    private ContinueReadingRankingScheduleProperties continueReadingRankingScheduleProperties;
-
-    @Mock
-    private BadgeService badgeService;
-
-    @Mock
-    private ApplicationEventPublisher applicationEventPublisher;
 
     @Mock
     private Clock clock;
@@ -99,7 +56,7 @@ class ReadingServiceResetContinueReadingCountTest {
     }
 
     @Test
-    void 어제가_평일이면_기존_조건대로_연속_읽기_횟수를_초기화한다() {
+    void 어제가_평일이면_연속_읽기_횟수를_초기화하고_최대_스트릭은_유지한다() {
         fixClockTo(LocalDate.of(2026, 4, 28)); // Tuesday
         TodayReading todayReading = TodayReading.builder()
                 .memberId(1L)
@@ -109,13 +66,17 @@ class ReadingServiceResetContinueReadingCountTest {
         ContinueReadingRealtime continueReading = ContinueReadingRealtime.builder()
                 .memberId(1L)
                 .dayCount(10)
+                .maxDayCount(15)
                 .build();
         given(todayReadingRepository.findTotalNonZeroAndCurrentZero()).willReturn(List.of(todayReading));
         given(continueReadingRepository.findByMemberId(1L)).willReturn(Optional.of(continueReading));
 
         readingService.resetContinueReadingCount();
 
-        assertThat(continueReading.getDayCount()).isZero();
+        assertSoftly(softly -> {
+            softly.assertThat(continueReading.getDayCount()).isZero();
+            softly.assertThat(continueReading.getMaxDayCount()).isEqualTo(15);
+        });
     }
 
     private void fixClockTo(LocalDate date) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -326,22 +326,6 @@ class ReadingServiceTest {
     }
 
     @Test
-    void 연속_읽기_초기화_후에도_최대_스트릭_일수는_유지된다() {
-        ContinueReadingRealtime cr = continueReadingRepository.findByMemberId(member.getId()).get();
-        int initialMaxDayCount = cr.getMaxDayCount();
-        int initialDayCount = cr.getDayCount();
-
-        readingService.resetContinueReadingCount();
-
-        ContinueReadingRealtime updatedContinueReadingRealtime = continueReadingRepository.findByMemberId(member.getId()).get();
-
-        assertSoftly(softly -> {
-            softly.assertThat(updatedContinueReadingRealtime.getDayCount()).isEqualTo(initialDayCount);
-            softly.assertThat(updatedContinueReadingRealtime.getMaxDayCount()).isEqualTo(initialMaxDayCount);
-        });
-    }
-
-    @Test
     void 랭킹_업데이트된_시간을_조회할_수_있다() {
         // given
         LocalDateTime dateTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);;


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
연속 읽기 초기화 테스트가 실행 요일에 따라 실패할 수 있는 문제

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- `resetContinueReadingCount()`는 `LocalDate.now(clock).minusDays(1)` 기준으로 어제가 주말이면 초기화를 스킵합니다.
- 기존 테스트는 실제 현재 날짜에 의존하고 있어, 실행 요일에 따라 `dayCount`가 유지되거나 `0`으로 초기화될 수 있었습니다.
- 이로 인해 테스트 결과가 환경과 실행 날짜에 따라 달라지는 flaky test가 될 수 있었습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
Clock을 사용해서 요일을 고정시켜서 요일에 따라 성공/실패가 나뉘지 않도록 수정

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
