### PR TITLE
[BOM-1113] fix: 매일메일 답변 API를 아티클 기준으로 변경

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/controller/MaeilMailController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/controller/MaeilMailController.java
@@ -40,22 +40,22 @@ public class MaeilMailController implements MaeilMailControllerApi {
 
     @Override
     @ResponseStatus(HttpStatus.CREATED)
-    @PostMapping("/{contentId}/answer/me")
+    @PostMapping("/articles/{articleId}/answers/me")
     public void submitAnswer(
             @LoginMember Member member,
-            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long contentId,
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long articleId,
             @RequestBody @Valid MaeilMailSubmitAnswerRequest request
     ) {
-        maeilMailService.submitAnswer(member, contentId, request);
+        maeilMailService.submitAnswer(member, articleId, request);
     }
 
     @Override
-    @GetMapping("/{contentId}/answer/me")
+    @GetMapping("/articles/{articleId}/answers/me")
     public MaeilMailSubmittedAnswerResponse getSubmittedAnswer(
             @LoginMember Member member,
-            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long contentId
+            @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long articleId
     ) {
-        return maeilMailService.getSubmittedAnswer(member, contentId);
+        return maeilMailService.getSubmittedAnswer(member, articleId);
     }
 
     @Override

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/controller/MaeilMailControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/controller/MaeilMailControllerApi.java
@@ -39,7 +39,7 @@ public interface MaeilMailControllerApi {
     })
     void submitAnswer(
             @Parameter(hidden = true) Member member,
-            @Parameter(description = "매일메일 컨텐츠 id") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long contentId,
+            @Parameter(description = "매일메일 아티클 id") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long articleId,
             @RequestBody @Valid MaeilMailSubmitAnswerRequest request
     );
 
@@ -51,7 +51,7 @@ public interface MaeilMailControllerApi {
     })
     MaeilMailSubmittedAnswerResponse getSubmittedAnswer(
             @Parameter(hidden = true) Member member,
-            @Parameter(description = "매일메일 컨텐츠 id") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long contentId
+            @Parameter(description = "매일메일 아티클 id") @PathVariable @Positive(message = "id는 1 이상의 값이어야 합니다.") Long articleId
     );
 
     @Operation(summary = "매일메일 정보 조회", description = "아티클 id로 매일메일 컨텐츠 정보를 조회합니다.")

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/repository/MaeilMailIssueHistoryRepository.java
@@ -8,6 +8,4 @@ import java.util.Optional;
 public interface MaeilMailIssueHistoryRepository extends JpaRepository<MaeilMailIssueHistory, Long> {
 
     Optional<MaeilMailIssueHistory> findByArticleId(Long articleId);
-
-    Optional<MaeilMailIssueHistory> findByContentId(Long contentId);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/service/MaeilMailService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/nativenewsletter/maeilmail/service/MaeilMailService.java
@@ -39,10 +39,10 @@ public class MaeilMailService {
     @Transactional
     public void submitAnswer(
             Member member,
-            Long contentId,
+            Long articleId,
             MaeilMailSubmitAnswerRequest request
     ) {
-        MaeilMailIssueHistory issueHistory = getIssueHistoryByContentId(contentId);
+        MaeilMailIssueHistory issueHistory = getIssueHistoryByArticleId(articleId);
 
         MaeilMailUserAnswer userAnswer = MaeilMailUserAnswer.builder()
                 .issueHistoryId(issueHistory.getId())
@@ -52,11 +52,11 @@ public class MaeilMailService {
         userAnswerRepository.save(userAnswer);
     }
 
-    public MaeilMailSubmittedAnswerResponse getSubmittedAnswer(Member member, Long contentId) {
+    public MaeilMailSubmittedAnswerResponse getSubmittedAnswer(Member member, Long articleId) {
         // TODO: List<MaeilMailIssueHistory> | List<Integer> 로 반환
-        MaeilMailIssueHistory issueHistory = getIssueHistoryByContentId(contentId);
+        MaeilMailIssueHistory issueHistory = getIssueHistoryByArticleId(articleId);
         // TODO: List<MaeilMailUserAnswer> 로 반환
-        MaeilMailUserAnswer userAnswer = getUserAnswer(member, contentId, issueHistory);
+        MaeilMailUserAnswer userAnswer = getUserAnswer(member, articleId, issueHistory);
         return new MaeilMailSubmittedAnswerResponse(userAnswer.getAnswer());
     }
 
@@ -89,20 +89,12 @@ public class MaeilMailService {
                         .addContext(ErrorContextKeys.ARTICLE_ID, articleId));
     }
 
-    private MaeilMailIssueHistory getIssueHistoryByContentId(Long contentId) {
-        return issueHistoryRepository.findByContentId(contentId)
-                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
-                        .addContext(ErrorContextKeys.ENTITY_TYPE, "MaeilMailIssueHistory")
-                        .addContext(ErrorContextKeys.OPERATION, "findByContentId")
-                        .addContext(ErrorContextKeys.CONTENT_ID, contentId));
-    }
-
-    private MaeilMailUserAnswer getUserAnswer(Member member, Long contentId, MaeilMailIssueHistory issueHistory) {
+    private MaeilMailUserAnswer getUserAnswer(Member member, Long articleId, MaeilMailIssueHistory issueHistory) {
         return userAnswerRepository.findByMemberIdAndIssueHistoryId(member.getId(), issueHistory.getId())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "MaeilMailUserAnswer")
                         .addContext(ErrorContextKeys.OPERATION, "findByMemberIdAndIssueHistoryId")
                         .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
-                        .addContext(ErrorContextKeys.ARTICLE_ID, contentId));
+                        .addContext(ErrorContextKeys.ARTICLE_ID, articleId));
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/nativenewsletter/maeilmail/controller/MaeilMailControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/nativenewsletter/maeilmail/controller/MaeilMailControllerTest.java
@@ -44,6 +44,7 @@ import org.springframework.test.web.servlet.MvcResult;
 class MaeilMailControllerTest {
 
     private static final Long ARTICLE_ID = 10_001L;
+    private static final Long SECOND_ARTICLE_ID = 10_002L;
     private static final Long UNKNOWN_ARTICLE_ID = 99_999L;
 
     @Autowired
@@ -130,14 +131,14 @@ class MaeilMailControllerTest {
     }
 
     @Test
-    @DisplayName("컨텐츠 id로 사용자 답변을 제출하고 다시 조회한다")
+    @DisplayName("아티클 id로 사용자 답변을 제출하고 다시 조회한다")
     void submitAnswerAndGetSubmittedAnswer_success() throws Exception {
         // given
-        Long contentId = issueHistory.getContentId();
+        Long articleId = issueHistory.getArticleId();
         String answer = "GC Root에서 도달할 수 없는 객체를 수거한다.";
 
         // when
-        mockMvc.perform(post("/api/v1/maeil-mail/{contentId}/answer/me", contentId)
+        mockMvc.perform(post("/api/v1/maeil-mail/articles/{articleId}/answers/me", articleId)
                         .with(authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(Map.of("answer", answer))))
@@ -151,7 +152,7 @@ class MaeilMailControllerTest {
             softly.assertThat(savedAnswer.getAnswer()).isEqualTo(answer);
         });
 
-        MvcResult result = mockMvc.perform(get("/api/v1/maeil-mail/{contentId}/answer/me", contentId)
+        MvcResult result = mockMvc.perform(get("/api/v1/maeil-mail/articles/{articleId}/answers/me", articleId)
                         .with(authentication(authToken)))
                 .andExpect(status().isOk())
                 .andReturn();
@@ -161,13 +162,89 @@ class MaeilMailControllerTest {
     }
 
     @Test
+    @DisplayName("같은 컨텐츠라도 발행 아티클이 다르면 각각 답변을 제출하고 조회한다")
+    void submitAnswer_sameContentDifferentArticles_success() throws Exception {
+        // given
+        MaeilMailIssueHistory secondIssueHistory = issueHistoryRepository.save(
+                createIssueHistory(SECOND_ARTICLE_ID, content.getId())
+        );
+        String firstAnswer = "첫 번째 발행 아티클에 대한 답변";
+        String secondAnswer = "두 번째 발행 아티클에 대한 답변";
+
+        // when
+        mockMvc.perform(post("/api/v1/maeil-mail/articles/{articleId}/answers/me", issueHistory.getArticleId())
+                        .with(authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("answer", firstAnswer))))
+                .andExpect(status().isCreated());
+
+        mockMvc.perform(post("/api/v1/maeil-mail/articles/{articleId}/answers/me", secondIssueHistory.getArticleId())
+                        .with(authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("answer", secondAnswer))))
+                .andExpect(status().isCreated());
+
+        MvcResult firstResult = mockMvc.perform(get("/api/v1/maeil-mail/articles/{articleId}/answers/me",
+                        issueHistory.getArticleId())
+                        .with(authentication(authToken)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        MvcResult secondResult = mockMvc.perform(get("/api/v1/maeil-mail/articles/{articleId}/answers/me",
+                        secondIssueHistory.getArticleId())
+                        .with(authentication(authToken)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // then
+        MaeilMailSubmittedAnswerResponse firstResponse = readResponse(firstResult, MaeilMailSubmittedAnswerResponse.class);
+        MaeilMailSubmittedAnswerResponse secondResponse = readResponse(secondResult, MaeilMailSubmittedAnswerResponse.class);
+        MaeilMailUserAnswer savedFirstAnswer = userAnswerRepository
+                .findByMemberIdAndIssueHistoryId(member.getId(), issueHistory.getId())
+                .orElseThrow();
+        MaeilMailUserAnswer savedSecondAnswer = userAnswerRepository
+                .findByMemberIdAndIssueHistoryId(member.getId(), secondIssueHistory.getId())
+                .orElseThrow();
+
+        assertSoftly(softly -> {
+            softly.assertThat(firstResponse.answer()).isEqualTo(firstAnswer);
+            softly.assertThat(secondResponse.answer()).isEqualTo(secondAnswer);
+            softly.assertThat(savedFirstAnswer.getAnswer()).isEqualTo(firstAnswer);
+            softly.assertThat(savedSecondAnswer.getAnswer()).isEqualTo(secondAnswer);
+            softly.assertThat(userAnswerRepository.findAll()).hasSize(2);
+        });
+    }
+
+    @Test
+    @DisplayName("답변이 1500자면 제출할 수 있다")
+    void submitAnswer_answerMaxLength_success() throws Exception {
+        // given
+        Long articleId = issueHistory.getArticleId();
+        String answer = "가".repeat(1_500);
+
+        // when
+        mockMvc.perform(post("/api/v1/maeil-mail/articles/{articleId}/answers/me", articleId)
+                        .with(authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("answer", answer))))
+                .andExpect(status().isCreated());
+
+        // then
+        MaeilMailUserAnswer savedAnswer = userAnswerRepository.findAll().getFirst();
+        assertSoftly(softly -> {
+            softly.assertThat(savedAnswer.getIssueHistoryId()).isEqualTo(issueHistory.getId());
+            softly.assertThat(savedAnswer.getAnswer()).isEqualTo(answer);
+        });
+    }
+
+    @Test
     @DisplayName("존재하지 않는 아티클에 답변을 제출하면 404를 반환한다")
     void submitAnswer_articleNotFound() throws Exception {
         // given
         String answer = "존재하지 않는 아티클에는 저장되지 않는다.";
 
         // when & then
-        MvcResult result = mockMvc.perform(post("/api/v1/maeil-mail/{articleId}/answer/me", UNKNOWN_ARTICLE_ID)
+        MvcResult result = mockMvc.perform(post("/api/v1/maeil-mail/articles/{articleId}/answers/me", UNKNOWN_ARTICLE_ID)
                         .with(authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(Map.of("answer", answer))))
@@ -180,13 +257,30 @@ class MaeilMailControllerTest {
     }
 
     @Test
+    @DisplayName("기존 컨텐츠 id 기반 답변 제출 URL은 더 이상 사용하지 않는다")
+    void submitAnswer_legacyContentIdPathNotFound() throws Exception {
+        // given
+        Long contentId = issueHistory.getContentId();
+        String answer = "기존 URL로는 저장되지 않는다.";
+
+        // when & then
+        mockMvc.perform(post("/api/v1/maeil-mail/{contentId}/answer/me", contentId)
+                        .with(authentication(authToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(toJson(Map.of("answer", answer))))
+                .andExpect(status().isNotFound());
+
+        assertThat(userAnswerRepository.findAll()).isEmpty();
+    }
+
+    @Test
     @DisplayName("답변이 공백이면 제출할 수 없다")
     void submitAnswer_blankAnswer() throws Exception {
         // given
-        Long contentId = issueHistory.getContentId();
+        Long articleId = issueHistory.getArticleId();
 
         // when & then
-        MvcResult result = mockMvc.perform(post("/api/v1/maeil-mail/{contentId}/answer/me", contentId)
+        MvcResult result = mockMvc.perform(post("/api/v1/maeil-mail/articles/{articleId}/answers/me", articleId)
                         .with(authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(Map.of("answer", " "))))
@@ -199,14 +293,14 @@ class MaeilMailControllerTest {
     }
 
     @Test
-    @DisplayName("답변이 16000자를 초과하면 제출할 수 없다")
+    @DisplayName("답변이 1500자를 초과하면 제출할 수 없다")
     void submitAnswer_answerTooLong() throws Exception {
         // given
-        Long contentId = issueHistory.getContentId();
-        String answer = "가".repeat(16_001);
+        Long articleId = issueHistory.getArticleId();
+        String answer = "가".repeat(1_501);
 
         // when & then
-        MvcResult result = mockMvc.perform(post("/api/v1/maeil-mail/{contentId}/answer/me", contentId)
+        MvcResult result = mockMvc.perform(post("/api/v1/maeil-mail/articles/{articleId}/answers/me", articleId)
                         .with(authentication(authToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(toJson(Map.of("answer", answer))))
@@ -222,10 +316,24 @@ class MaeilMailControllerTest {
     @DisplayName("아직 제출하지 않은 답변을 조회하면 404를 반환한다")
     void getSubmittedAnswer_notFound() throws Exception {
         // given
-        Long contentId = issueHistory.getContentId();
+        Long articleId = issueHistory.getArticleId();
 
         // when & then
-        MvcResult result = mockMvc.perform(get("/api/v1/maeil-mail/{contentId}/answer/me", contentId)
+        MvcResult result = mockMvc.perform(get("/api/v1/maeil-mail/articles/{articleId}/answers/me", articleId)
+                        .with(authentication(authToken)))
+                .andExpect(status().isNotFound())
+                .andReturn();
+
+        ErrorResponse response = readResponse(result, ErrorResponse.class);
+        assertThat(response.code()).isEqualTo(ErrorDetail.ENTITY_NOT_FOUND.getCode());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 아티클의 제출 답변을 조회하면 404를 반환한다")
+    void getSubmittedAnswer_articleNotFound() throws Exception {
+        // when & then
+        MvcResult result = mockMvc.perform(get("/api/v1/maeil-mail/articles/{articleId}/answers/me",
+                        UNKNOWN_ARTICLE_ID)
                         .with(authentication(authToken)))
                 .andExpect(status().isNotFound())
                 .andReturn();

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/nativenewsletter/maeilmail/service/MaeilMailServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/nativenewsletter/maeilmail/service/MaeilMailServiceTest.java
@@ -23,7 +23,6 @@ import me.bombom.api.v1.nativenewsletter.maeilmail.repository.MaeilMailIssueHist
 import me.bombom.api.v1.nativenewsletter.maeilmail.repository.MaeilMailUserAnswerRepository;
 import me.bombom.support.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -42,6 +41,7 @@ class MaeilMailServiceTest {
     private static final int EXPECTED_READ_TIME = 3;
     private static final String IDEAL_ANSWER = "<p>GC는 더 이상 참조되지 않는 객체를 정리합니다.</p>";
     private static final String USER_ANSWER = "GC Root에서 도달할 수 없는 객체를 수거한다.";
+    private static final String SECOND_USER_ANSWER = "GC 대상 여부는 참조 가능성으로 판단한다.";
 
     @Autowired
     private MaeilMailService maeilMailService;
@@ -107,14 +107,14 @@ class MaeilMailServiceTest {
     }
 
     @Test
-    void 컨텐츠_id로_사용자_답변을_제출하고_조회한다() {
+    void 아티클_id로_사용자_답변을_제출하고_조회한다() {
         // given
-        Long contentId = issueHistory.getContentId();
+        Long articleId = issueHistory.getArticleId();
         MaeilMailSubmitAnswerRequest request = new MaeilMailSubmitAnswerRequest(USER_ANSWER);
 
         // when
-        maeilMailService.submitAnswer(member, contentId, request);
-        MaeilMailSubmittedAnswerResponse response = maeilMailService.getSubmittedAnswer(member, contentId);
+        maeilMailService.submitAnswer(member, articleId, request);
+        MaeilMailSubmittedAnswerResponse response = maeilMailService.getSubmittedAnswer(member, articleId);
 
         // then
         MaeilMailUserAnswer savedAnswer = userAnswerRepository.findAll().getFirst();
@@ -126,8 +126,6 @@ class MaeilMailServiceTest {
         });
     }
 
-    // TODO: 명세 변경 후 활성화 가능
-    @Disabled
     @Test
     void 같은_컨텐츠라도_발행_이력이_다르면_사용자가_다시_답변할_수_있다() {
         // given
@@ -136,16 +134,64 @@ class MaeilMailServiceTest {
         );
 
         // when
-        maeilMailService.submitAnswer(member, issueHistory.getContentId(), new MaeilMailSubmitAnswerRequest(USER_ANSWER));
-        maeilMailService.submitAnswer(member, secondIssueHistory.getContentId(), new MaeilMailSubmitAnswerRequest(USER_ANSWER));
+        maeilMailService.submitAnswer(member, issueHistory.getArticleId(), new MaeilMailSubmitAnswerRequest(USER_ANSWER));
+        maeilMailService.submitAnswer(
+                member,
+                secondIssueHistory.getArticleId(),
+                new MaeilMailSubmitAnswerRequest(SECOND_USER_ANSWER)
+        );
+        MaeilMailSubmittedAnswerResponse firstResponse = maeilMailService.getSubmittedAnswer(
+                member,
+                issueHistory.getArticleId()
+        );
+        MaeilMailSubmittedAnswerResponse secondResponse = maeilMailService.getSubmittedAnswer(
+                member,
+                secondIssueHistory.getArticleId()
+        );
 
         // then
+        MaeilMailUserAnswer firstAnswer = userAnswerRepository
+                .findByMemberIdAndIssueHistoryId(member.getId(), issueHistory.getId())
+                .orElseThrow();
+        MaeilMailUserAnswer secondAnswer = userAnswerRepository
+                .findByMemberIdAndIssueHistoryId(member.getId(), secondIssueHistory.getId())
+                .orElseThrow();
+
         assertSoftly(softly -> {
+            softly.assertThat(firstResponse.answer()).isEqualTo(USER_ANSWER);
+            softly.assertThat(secondResponse.answer()).isEqualTo(SECOND_USER_ANSWER);
             softly.assertThat(userAnswerRepository.findAll()).hasSize(2);
-            softly.assertThat(userAnswerRepository.findByMemberIdAndIssueHistoryId(member.getId(), issueHistory.getId()))
-                    .isPresent();
-            softly.assertThat(userAnswerRepository.findByMemberIdAndIssueHistoryId(member.getId(), secondIssueHistory.getId()))
-                    .isPresent();
+            softly.assertThat(firstAnswer.getAnswer()).isEqualTo(USER_ANSWER);
+            softly.assertThat(secondAnswer.getAnswer()).isEqualTo(SECOND_USER_ANSWER);
+        });
+    }
+
+    @Test
+    void 같은_아티클이라도_회원이_다르면_각자_답변할_수_있다() {
+        // given
+        Member secondMember = memberRepository.save(TestFixture.createMemberWithRole("second", "secondProvider", 1L));
+        Long articleId = issueHistory.getArticleId();
+
+        // when
+        maeilMailService.submitAnswer(member, articleId, new MaeilMailSubmitAnswerRequest(USER_ANSWER));
+        maeilMailService.submitAnswer(secondMember, articleId, new MaeilMailSubmitAnswerRequest(SECOND_USER_ANSWER));
+        MaeilMailSubmittedAnswerResponse firstResponse = maeilMailService.getSubmittedAnswer(member, articleId);
+        MaeilMailSubmittedAnswerResponse secondResponse = maeilMailService.getSubmittedAnswer(secondMember, articleId);
+
+        // then
+        MaeilMailUserAnswer firstAnswer = userAnswerRepository
+                .findByMemberIdAndIssueHistoryId(member.getId(), issueHistory.getId())
+                .orElseThrow();
+        MaeilMailUserAnswer secondAnswer = userAnswerRepository
+                .findByMemberIdAndIssueHistoryId(secondMember.getId(), issueHistory.getId())
+                .orElseThrow();
+
+        assertSoftly(softly -> {
+            softly.assertThat(firstResponse.answer()).isEqualTo(USER_ANSWER);
+            softly.assertThat(secondResponse.answer()).isEqualTo(SECOND_USER_ANSWER);
+            softly.assertThat(firstAnswer.getAnswer()).isEqualTo(USER_ANSWER);
+            softly.assertThat(secondAnswer.getAnswer()).isEqualTo(SECOND_USER_ANSWER);
+            softly.assertThat(userAnswerRepository.findAll()).hasSize(2);
         });
     }
 
@@ -179,7 +225,7 @@ class MaeilMailServiceTest {
         MaeilMailSubmitAnswerRequest request = new MaeilMailSubmitAnswerRequest(USER_ANSWER);
 
         // when & then
-        assertThatThrownBy(() -> maeilMailService.submitAnswer(member, content.getId() + 1, request))
+        assertThatThrownBy(() -> maeilMailService.submitAnswer(member, UNKNOWN_ARTICLE_ID, request))
                 .isInstanceOfSatisfying(CIllegalArgumentException.class, exception ->
                         assertThat(exception.getErrorDetail()).isSameAs(ErrorDetail.ENTITY_NOT_FOUND)
                 );
@@ -190,12 +236,12 @@ class MaeilMailServiceTest {
     @Test
     void 같은_발행_이력에_중복으로_답변을_제출하면_예외가_발생하고_답변은_하나만_유지된다() {
         // given
-        Long contentId = issueHistory.getContentId();
+        Long articleId = issueHistory.getArticleId();
         MaeilMailSubmitAnswerRequest request = new MaeilMailSubmitAnswerRequest(USER_ANSWER);
-        maeilMailService.submitAnswer(member, contentId, request);
+        maeilMailService.submitAnswer(member, articleId, request);
 
         // when & then
-        assertThatThrownBy(() -> maeilMailService.submitAnswer(member, contentId, request))
+        assertThatThrownBy(() -> maeilMailService.submitAnswer(member, articleId, request))
                 .isInstanceOf(DataIntegrityViolationException.class);
 
         assertThat(userAnswerRepository.findAll()).hasSize(1);
@@ -204,10 +250,19 @@ class MaeilMailServiceTest {
     @Test
     void 제출하지_않은_답변을_조회하면_예외가_발생한다() {
         // given
-        Long contentId = issueHistory.getContentId();
+        Long articleId = issueHistory.getArticleId();
 
         // when & then
-        assertThatThrownBy(() -> maeilMailService.getSubmittedAnswer(member, contentId))
+        assertThatThrownBy(() -> maeilMailService.getSubmittedAnswer(member, articleId))
+                .isInstanceOfSatisfying(CIllegalArgumentException.class, exception ->
+                        assertThat(exception.getErrorDetail()).isSameAs(ErrorDetail.ENTITY_NOT_FOUND)
+                );
+    }
+
+    @Test
+    void 존재하지_않는_아티클의_제출_답변을_조회하면_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> maeilMailService.getSubmittedAnswer(member, UNKNOWN_ARTICLE_ID))
                 .isInstanceOfSatisfying(CIllegalArgumentException.class, exception ->
                         assertThat(exception.getErrorDetail()).isSameAs(ErrorDetail.ENTITY_NOT_FOUND)
                 );


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

- 매일메일 답변 제출/조회 API를 `contentId` 기준에서 `articleId` 기준으로 변경했습니다.
  - `POST /api/v1/maeil-mail/articles/{articleId}/answers/me`
  - `GET /api/v1/maeil-mail/articles/{articleId}/answers/me`
- 답변 저장/조회 시 `articleId -> MaeilMailIssueHistory -> issueHistoryId` 흐름을 사용하도록 수정했습니다.
- 더 이상 사용하지 않는 `MaeilMailIssueHistoryRepository.findByContentId()`를 제거했습니다.
- 현재 로직을 기준으로 테스트를 보강했습니다.
## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
사용자 답변은 `MaeilMailUserAnswer.issueHistoryId` 기준으로 저장됩니다.

기존처럼 `contentId`만 받으면 같은 매일메일 컨텐츠가 여러 아티클로 다시 발행됐을 때 어떤 발행 이력에 대한 답변인지 구분할 수 없습니다.

그래서 외부 API도 실제 발행 단위인 `articleId`를 받도록 변경했습니다.
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 컨트롤러와 Swagger API 인터페이스의 답변 제출/조회 path를 `articleId` 기준으로 변경했습니다.
- 서비스에서 `getIssueHistoryByArticleId(articleId)`로 발행 이력을 찾고, 해당 `issueHistoryId`로 답변을 저장/조회하도록 수정했습니다.
- 테스트에서 다음 케이스를 검증했습니다.
  - `articleId` 기준 답변 제출/조회
  - 같은 `contentId`라도 다른 `articleId`면 각각 답변 가능
  - 같은 `articleId`라도 회원이 다르면 각각 답변 가능
  - 답변 길이 1,500자 경계값
  - 기존 `contentId` 기반 URL 404
  - 존재하지 않는 `articleId` 요청 404
 
## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 현재 백엔드가 밤샘 근무로 없고 바로 수정사항을 반영해야해서 AI로 리뷰를 받고 진행하도록 하겠습니다.  