### PR TITLE
[BOM-1117] feat: 구독 취소 url 파싱 실패 알림

### DIFF
--- a/.github/workflows/email-dev-deploy.yml
+++ b/.github/workflows/email-dev-deploy.yml
@@ -59,6 +59,8 @@ jobs:
     runs-on:
       - self-hosted
       - email
+    env:
+      MAIL_SERVER_INTERNAL_API_KEY: ${{ secrets.MAIL_SERVER_INTERNAL_API_KEY }}
     defaults:
       run:
         working-directory: backend/mail-server

--- a/backend/mail-server/docker-compose.yml
+++ b/backend/mail-server/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       INTEGRATION_MAILDIR: /maildir/new
       SPRING_PROFILES_ACTIVE: docker
       LOGGING_FILE_NAME: /logs/bombom-email.log
+      MAIL_SERVER_INTERNAL_API_KEY: ${MAIL_SERVER_INTERNAL_API_KEY:?MAIL_SERVER_INTERNAL_API_KEY is required}
     volumes:
       - /home/ec2-user/Maildir:/maildir
       - /home/ec2-user/bombom-email/logs:/logs 

--- a/backend/mail-server/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/mail-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/backend/mail-server/src/main/java/news/bombomemail/article/service/ArticleService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/service/ArticleService.java
@@ -41,6 +41,7 @@ public class ArticleService {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final NewsletterVerificationRepository newsletterVerificationRepository;
     private final HtmlTagCleaner htmlTagCleaner;
+    private final UnsubscribeUrlExtractor unsubscribeUrlExtractor;
 
     @Transactional
     public boolean save(MimeMessage message, String contents) throws MessagingException, DataAccessException {
@@ -56,7 +57,7 @@ public class ArticleService {
 
         String contentsText = htmlTagCleaner.clean(contents);
         Article article = articleRepository.save(buildArticle(message, contents, contentsText, member, newsletter));
-        String unsubscribeUrl = UnsubscribeUrlExtractor.extract(article.getContents());
+        String unsubscribeUrl = unsubscribeUrlExtractor.extract(article.getContents());
 
         applicationEventPublisher.publishEvent(ArticleArrivedEvent.of(
                         newsletter.getId(),

--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -1,41 +1,36 @@
 package news.bombomemail.article.util;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class UnsubscribeUrlExtractor {
+@Component
+public class UnsubscribeUrlExtractor {
 
-    // 1단계: href URL 자체에 "unsubscribe"가 포함된 경우
-    private static final Pattern UNSUBSCRIBE_URL_PATTERN = Pattern.compile(
-            "href=\"([^\"]*unsubscribe[^\"]*)\"",
-            Pattern.CASE_INSENSITIVE
-    );
-
-    // 2단계: <a href="...">...</a> 블록 전체를 추출 (href와 내부 HTML을 함께 캡처)
     private static final Pattern ANCHOR_PATTERN = Pattern.compile(
             "<a\\s[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
-    // 앵커 내부의 <span> 등 중첩 태그를 제거해 순수 텍스트만 남기기 위한 패턴
     private static final Pattern INNER_TAG_PATTERN = Pattern.compile("<[^>]+>");
 
-    // 앵커 텍스트가 수신거부 키워드로 시작하는지 확인. 앞에 '[', '(' 등 브라켓이 있어도 허용 (예: "[수신거부]")
-    private static final Pattern UNSUBSCRIBE_TEXT_PATTERN = Pattern.compile(
-            "^[\\[(\\s]*(unsubscribe|unsubscription|수신\\s*거부|구독\\s*취소|구독\\s*해지)",
-            Pattern.CASE_INSENSITIVE
-    );
+    private final AtomicReference<Pattern> urlPattern = new AtomicReference<>();
+    private final AtomicReference<Pattern> textPattern = new AtomicReference<>();
 
-    public static String extract(String articleContents) {
+    public void reload(List<String> urlKeywords, List<String> textKeywords) {
+        urlPattern.set(Pattern.compile(buildUrlRegex(urlKeywords), Pattern.CASE_INSENSITIVE));
+        textPattern.set(Pattern.compile(buildTextRegex(textKeywords), Pattern.CASE_INSENSITIVE));
+    }
+
+    public String extract(String articleContents) {
         if (!StringUtils.hasText(articleContents)) {
             return null;
         }
 
-        Matcher urlMatcher = UNSUBSCRIBE_URL_PATTERN.matcher(articleContents);
+        Matcher urlMatcher = urlPattern.get().matcher(articleContents);
         if (urlMatcher.find()) {
             return urlMatcher.group(1);
         }
@@ -48,11 +43,23 @@ public final class UnsubscribeUrlExtractor {
                 continue;
             }
             String text = INNER_TAG_PATTERN.matcher(anchorBody).replaceAll("").strip();
-            if (UNSUBSCRIBE_TEXT_PATTERN.matcher(text).find()) {
+            if (textPattern.get().matcher(text).find()) {
                 return href;
             }
         }
 
         return null;
+    }
+
+    private static String buildUrlRegex(List<String> urlKeywords) {
+        String joinedKeywords = urlKeywords.stream()
+                .map(Pattern::quote)
+                .reduce((left, right) -> left + "|" + right)
+                .orElseThrow();
+        return "href=\"([^\"]*(?:" + joinedKeywords + ")[^\"]*)\"";
+    }
+
+    private static String buildTextRegex(List<String> textKeywords) {
+        return "^[\\[(\\s]*(" + String.join("|", textKeywords) + ")";
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -40,6 +40,7 @@ public class DiscordWebhookNotifier {
                         .toBodilessEntity();
             } catch (Exception e) {
                 log.warn("구독 취소 url 파싱 실패 알림 전송 실패: {}", e.getMessage(), e);
+                throw new IllegalStateException("구독 취소 url 파싱 실패 알림 전송 실패", e);
             }
         }
     }

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -1,6 +1,7 @@
 package news.bombomemail.common;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ import org.springframework.web.client.RestClient;
 public class DiscordWebhookNotifier {
 
     private static final int COLOR_RED = 0xE74C3C;
+    private static final int MAX_DISPLAY_COUNT = 50;
 
     private final RestClient restClient;
 
@@ -28,25 +30,35 @@ public class DiscordWebhookNotifier {
     }
 
     public void sendUnsubscribeUrlMissingAlert(List<UnsubscribeUrlFailure> failures) {
-        try {
-            restClient.post()
-                    .uri(webhookUrl)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(buildBody(failures))
-                    .retrieve()
-                    .toBodilessEntity();
-        } catch (Exception e) {
-            log.warn("Discord Webhook 전송 실패: {}", e.getMessage(), e);
+        for (List<UnsubscribeUrlFailure> chunk : partition(failures)) {
+            try {
+                restClient.post()
+                        .uri(webhookUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(buildBody(failures.size(), chunk))
+                        .retrieve()
+                        .toBodilessEntity();
+            } catch (Exception e) {
+                log.warn("구독 취소 url 파싱 실패 알림 전송 실패: {}", e.getMessage(), e);
+            }
         }
     }
 
-    private Map<String, Object> buildBody(List<UnsubscribeUrlFailure> failures) {
-        String description = failures.stream()
+    private List<List<UnsubscribeUrlFailure>> partition(List<UnsubscribeUrlFailure> failures) {
+        List<List<UnsubscribeUrlFailure>> chunks = new ArrayList<>();
+        for (int i = 0; i < failures.size(); i += MAX_DISPLAY_COUNT) {
+            chunks.add(failures.subList(i, Math.min(i + MAX_DISPLAY_COUNT, failures.size())));
+        }
+        return chunks;
+    }
+
+    private Map<String, Object> buildBody(int totalCount, List<UnsubscribeUrlFailure> unsubscribeUrlFailures) {
+        String description = unsubscribeUrlFailures.stream()
                 .map(f -> "📰 **%s**\n└ %s".formatted(f.newsletterName(), f.articleTitle()))
                 .collect(Collectors.joining("\n\n"));
 
         Map<String, Object> embed = Map.of(
-                "title", "🚨 unsubscribeUrl 파싱 실패 (%d건)".formatted(failures.size()),
+                "title", "🚨 unsubscribeUrl 파싱 실패 (%d건)".formatted(totalCount),
                 "description", description,
                 "color", COLOR_RED,
                 "footer", Map.of("text", "매일 오후 1시 집계"),

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -1,40 +1,58 @@
 package news.bombomemail.common;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 public class DiscordWebhookNotifier {
+
+    private static final int COLOR_RED = 0xE74C3C;
 
     private final RestClient restClient;
 
     @Value("${discord.webhook.unsubscribe-alert.url}")
     private String webhookUrl;
 
-    public DiscordWebhookNotifier(RestClient.Builder builder) {
-        this.restClient = builder.build();
+    public DiscordWebhookNotifier(@Qualifier("discordRestClient") RestClient restClient) {
+        this.restClient = restClient;
     }
 
     public void sendUnsubscribeUrlMissingAlert(List<UnsubscribeUrlFailure> failures) {
-        restClient.post()
-                .uri(webhookUrl)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Map.of("content", formatMessage(failures)))
-                .retrieve()
-                .toBodilessEntity();
+        try {
+            restClient.post()
+                    .uri(webhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(buildBody(failures))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("[WARN] Discord Webhook 전송 실패: {}", e.getMessage(), e);
+        }
     }
 
-    private String formatMessage(List<UnsubscribeUrlFailure> failures) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("⚠️ **unsubscribeUrl 파싱 실패 (%d건)**\n".formatted(failures.size()));
-        failures.forEach(f ->
-                sb.append("• %s | %s\n".formatted(f.newsletterName(), f.articleTitle()))
+    private Map<String, Object> buildBody(List<UnsubscribeUrlFailure> failures) {
+        String description = failures.stream()
+                .map(f -> "📰 **%s**\n└ %s".formatted(f.newsletterName(), f.articleTitle()))
+                .collect(Collectors.joining("\n\n"));
+
+        Map<String, Object> embed = Map.of(
+                "title", "🚨 unsubscribeUrl 파싱 실패 (%d건)".formatted(failures.size()),
+                "description", description,
+                "color", COLOR_RED,
+                "footer", Map.of("text", "매일 오후 1시 집계"),
+                "timestamp", Instant.now().toString()
         );
-        return sb.toString();
+
+        return Map.of("embeds", List.of(embed));
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -1,4 +1,4 @@
-package news.bombomemail.common.discord;
+package news.bombomemail.common;
 
 import java.util.List;
 import java.util.Map;
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
-public class DiscordWebhookSender {
+public class DiscordWebhookNotifier {
 
     private final RestClient restClient;
 
     @Value("${discord.webhook.unsubscribe-alert.url}")
     private String webhookUrl;
 
-    public DiscordWebhookSender(RestClient.Builder builder) {
+    public DiscordWebhookNotifier(RestClient.Builder builder) {
         this.restClient = builder.build();
     }
 

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -36,7 +36,7 @@ public class DiscordWebhookNotifier {
                     .retrieve()
                     .toBodilessEntity();
         } catch (Exception e) {
-            log.warn("[WARN] Discord Webhook 전송 실패: {}", e.getMessage(), e);
+            log.warn("Discord Webhook 전송 실패: {}", e.getMessage(), e);
         }
     }
 

--- a/backend/mail-server/src/main/java/news/bombomemail/common/config/RandomConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/config/RandomConfig.java
@@ -1,4 +1,4 @@
-package news.bombomemail.common;
+package news.bombomemail.common.config;
 
 import java.util.Random;
 import org.springframework.context.annotation.Bean;

--- a/backend/mail-server/src/main/java/news/bombomemail/common/config/RestClientConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/config/RestClientConfig.java
@@ -1,0 +1,21 @@
+package news.bombomemail.common.config;
+
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    @Bean
+    public RestClient discordRestClient(RestClient.Builder builder) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(REQUEST_TIMEOUT);
+        factory.setReadTimeout(REQUEST_TIMEOUT);
+        return builder.requestFactory(factory).build();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/common/config/SchedulingConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/config/SchedulingConfig.java
@@ -1,4 +1,4 @@
-package news.bombomemail.common;
+package news.bombomemail.common.config;
 
 import javax.sql.DataSource;
 import net.javacrumbs.shedlock.core.LockProvider;

--- a/backend/mail-server/src/main/java/news/bombomemail/common/config/TimeConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/config/TimeConfig.java
@@ -1,4 +1,4 @@
-package news.bombomemail.common;
+package news.bombomemail.common.config;
 
 import java.time.Clock;
 import java.time.ZoneId;

--- a/backend/mail-server/src/main/java/news/bombomemail/common/discord/DiscordWebhookSender.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/discord/DiscordWebhookSender.java
@@ -33,7 +33,7 @@ public class DiscordWebhookSender {
         StringBuilder sb = new StringBuilder();
         sb.append("⚠️ **unsubscribeUrl 파싱 실패 (%d건)**\n".formatted(failures.size()));
         failures.forEach(f ->
-                sb.append("• %s | %s | memberId: %d\n".formatted(f.newsletterName(), f.articleTitle(), f.memberId()))
+                sb.append("• %s | %s\n".formatted(f.newsletterName(), f.articleTitle()))
         );
         return sb.toString();
     }

--- a/backend/mail-server/src/main/java/news/bombomemail/common/discord/DiscordWebhookSender.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/discord/DiscordWebhookSender.java
@@ -1,0 +1,40 @@
+package news.bombomemail.common.discord;
+
+import java.util.List;
+import java.util.Map;
+import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class DiscordWebhookSender {
+
+    private final RestClient restClient;
+
+    @Value("${discord.webhook.unsubscribe-alert.url}")
+    private String webhookUrl;
+
+    public DiscordWebhookSender(RestClient.Builder builder) {
+        this.restClient = builder.build();
+    }
+
+    public void sendUnsubscribeUrlMissingAlert(List<UnsubscribeUrlFailure> failures) {
+        restClient.post()
+                .uri(webhookUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("content", formatMessage(failures)))
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    private String formatMessage(List<UnsubscribeUrlFailure> failures) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("⚠️ **unsubscribeUrl 파싱 실패 (%d건)**\n".formatted(failures.size()));
+        failures.forEach(f ->
+                sb.append("• %s | %s | memberId: %d\n".formatted(f.newsletterName(), f.articleTitle(), f.memberId()))
+        );
+        return sb.toString();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiKeyInterceptor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiKeyInterceptor.java
@@ -1,0 +1,40 @@
+package news.bombomemail.common.internal.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+@RequiredArgsConstructor
+public class InternalApiKeyInterceptor implements HandlerInterceptor {
+
+    public static final String INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key";
+
+    @Value("${MAIL_SERVER_INTERNAL_API_KEY:}")
+    private String configuredApiKey;
+
+    @Override
+    public boolean preHandle(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull Object handler
+    ) {
+        if (!StringUtils.hasText(configuredApiKey)) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "내부 API 키가 설정되지 않았습니다.");
+        }
+
+        String requestApiKey = request.getHeader(INTERNAL_API_KEY_HEADER);
+        if (!configuredApiKey.equals(requestApiKey)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "내부 API 키가 올바르지 않습니다.");
+        }
+
+        return true;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiWebConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiWebConfig.java
@@ -1,0 +1,19 @@
+package news.bombomemail.common.internal.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class InternalApiWebConfig implements WebMvcConfigurer {
+
+    private final InternalApiKeyInterceptor internalApiKeyInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(internalApiKeyInterceptor)
+                .addPathPatterns("/internal/**");
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueChunkResult.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueChunkResult.java
@@ -1,6 +1,7 @@
 package news.bombomemail.nativenewsletter.maeilmail.dto;
 
 public record IssueChunkResult(
+
         boolean hasTracks,
         Long lastTrackId,
         int trackCount,

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueData.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueData.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailTopic;
 
 public record IssueData(
+
         Map<Long, MaeilMailTopic> issueTopicsByTrackId,
         Map<Long, List<Long>> contentIdsByTopicId,
         Map<MemberTopicKey, List<Long>> sentContentIdsByMemberTopic,

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueEntry.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/IssueEntry.java
@@ -6,6 +6,7 @@ import news.bombomemail.article.domain.Article;
 import news.bombomemail.nativenewsletter.maeilmail.domain.MaeilMailSentContent;
 
 public record IssueEntry(
+
         Article article,
         List<Long> trackIds,
         MaeilMailSentContent sentContent

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/MemberTopicKey.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/MemberTopicKey.java
@@ -1,4 +1,8 @@
 package news.bombomemail.nativenewsletter.maeilmail.dto;
 
-public record MemberTopicKey(Long memberId, Long topicId) {
+public record MemberTopicKey(
+
+        Long memberId,
+        Long topicId
+) {
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/PreparedIssueEntries.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/PreparedIssueEntries.java
@@ -3,6 +3,7 @@ package news.bombomemail.nativenewsletter.maeilmail.dto;
 import java.util.List;
 
 public record PreparedIssueEntries(
+
         List<IssueEntry> entries,
         List<Long> previouslyIssuedTrackIds
 ) {

--- a/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/TopicContentId.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/nativenewsletter/maeilmail/dto/TopicContentId.java
@@ -1,6 +1,7 @@
 package news.bombomemail.nativenewsletter.maeilmail.dto;
 
 public record TopicContentId(
+
         Long topicId,
         Long contentId
 ) {

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
@@ -1,0 +1,22 @@
+package news.bombomemail.subscribe.alert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+
+public class PendingUnsubscribeFailures {
+
+    private final Map<Long, UnsubscribeUrlFailure> failures = new ConcurrentHashMap<>();
+
+    void record(UnsubscribeUrlMissingEvent event) {
+        failures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
+    }
+
+    List<UnsubscribeUrlFailure> collectForAlert() {
+        List<UnsubscribeUrlFailure> result = new ArrayList<>(failures.values());
+        failures.clear();
+        return result;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
@@ -23,4 +23,10 @@ public class PendingUnsubscribeFailures {
         }
         return collectedFailures;
     }
+
+    void restore(List<UnsubscribeUrlFailure> failuresToRestore) {
+        for (UnsubscribeUrlFailure failure : failuresToRestore) {
+            failures.putIfAbsent(failure.newsletterId(), failure);
+        }
+    }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
@@ -4,19 +4,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 
 public class PendingUnsubscribeFailures {
 
-    private final Map<Long, UnsubscribeUrlFailure> failures = new ConcurrentHashMap<>();
+    private final AtomicReference<Map<Long, UnsubscribeUrlFailure>> failures = new AtomicReference<>(new ConcurrentHashMap<>());
 
     void record(UnsubscribeUrlMissingEvent event) {
-        failures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
+        failures.get().putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
     }
 
     List<UnsubscribeUrlFailure> collectForAlert() {
-        List<UnsubscribeUrlFailure> result = new ArrayList<>(failures.values());
-        failures.clear();
-        return result;
+        Map<Long, UnsubscribeUrlFailure> snapshot = failures.getAndSet(new ConcurrentHashMap<>());
+        return new ArrayList<>(snapshot.values());
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
@@ -2,21 +2,25 @@ package news.bombomemail.subscribe.alert;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 
 public class PendingUnsubscribeFailures {
 
-    private final AtomicReference<Map<Long, UnsubscribeUrlFailure>> failures = new AtomicReference<>(new ConcurrentHashMap<>());
+    private final ConcurrentHashMap<Long, UnsubscribeUrlFailure> failures = new ConcurrentHashMap<>();
 
     void record(UnsubscribeUrlMissingEvent event) {
-        failures.get().putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
+        failures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
     }
 
     List<UnsubscribeUrlFailure> collectForAlert() {
-        Map<Long, UnsubscribeUrlFailure> snapshot = failures.getAndSet(new ConcurrentHashMap<>());
-        return new ArrayList<>(snapshot.values());
+        List<UnsubscribeUrlFailure> collectedFailures = new ArrayList<>();
+
+        for (ConcurrentHashMap.Entry<Long, UnsubscribeUrlFailure> entry : failures.entrySet()) {
+            if (failures.remove(entry.getKey(), entry.getValue())) {
+                collectedFailures.add(entry.getValue());
+            }
+        }
+        return collectedFailures;
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertManager.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertManager.java
@@ -1,0 +1,30 @@
+package news.bombomemail.subscribe.alert;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UnsubscribeUrlAlertManager {
+
+    private static final String TIME_ZONE = "Asia/Seoul";
+    private static final String DAILY_CRON = "0 0 13 * * *"; // 오후 1시
+
+    private final UnsubscribeUrlAlertService unsubscribeUrlAlertService;
+
+    @TransactionalEventListener
+    public void on(UnsubscribeUrlMissingEvent event) {
+        unsubscribeUrlAlertService.record(event);
+    }
+
+    @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
+    @SchedulerLock(name = "unsubscribe_url_alert", lockAtMostFor = "PT5M")
+    public void sendAlert() {
+        unsubscribeUrlAlertService.drainAndSend();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
@@ -2,7 +2,6 @@ package news.bombomemail.subscribe.alert;
 
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
@@ -18,6 +18,6 @@ public class UnsubscribeUrlAlertScheduler {
     @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
     @SchedulerLock(name = "unsubscribe_url_alert", lockAtMostFor = "PT5M")
     public void sendAlert() {
-        unsubscribeUrlAlertService.drainAndSend();
+        unsubscribeUrlAlertService.sendPendingAlerts();
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
@@ -3,24 +3,17 @@ package news.bombomemail.subscribe.alert;
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
-import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-public class UnsubscribeUrlAlertManager {
+public class UnsubscribeUrlAlertScheduler {
 
     private static final String TIME_ZONE = "Asia/Seoul";
     private static final String DAILY_CRON = "0 0 13 * * *"; // 오후 1시
 
     private final UnsubscribeUrlAlertService unsubscribeUrlAlertService;
-
-    @TransactionalEventListener
-    public void on(UnsubscribeUrlMissingEvent event) {
-        unsubscribeUrlAlertService.record(event);
-    }
 
     @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
     @SchedulerLock(name = "unsubscribe_url_alert", lockAtMostFor = "PT5M")

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
@@ -23,6 +23,12 @@ public class UnsubscribeUrlAlertService {
         if (failures.isEmpty()) {
             return;
         }
-        discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);
+
+        try {
+            discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);
+        } catch (Exception e) {
+            pendingFailures.restore(failures);
+            throw e;
+        }
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
@@ -20,8 +20,9 @@ public class UnsubscribeUrlAlertService {
     public void sendPendingAlerts() {
         List<UnsubscribeUrlFailure> failures = pendingFailures.collectForAlert();
 
-        if (!failures.isEmpty()) {
-            discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);
+        if (failures.isEmpty()) {
+            return;
         }
+        discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
@@ -1,12 +1,8 @@
-package news.bombomemail.subscribe.alert.service;
+package news.bombomemail.subscribe.alert;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import news.bombomemail.common.DiscordWebhookNotifier;
-import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import org.springframework.stereotype.Service;
 
@@ -14,16 +10,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UnsubscribeUrlAlertService {
 
-    private final Map<Long, UnsubscribeUrlFailure> pendingFailures = new ConcurrentHashMap<>();
+    private final PendingUnsubscribeFailures pendingFailures = new PendingUnsubscribeFailures();
     private final DiscordWebhookNotifier discordWebhookNotifier;
 
     public void record(UnsubscribeUrlMissingEvent event) {
-        pendingFailures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
+        pendingFailures.record(event);
     }
 
     public void sendPendingAlerts() {
-        List<UnsubscribeUrlFailure> failures = new ArrayList<>(pendingFailures.values());
-        pendingFailures.clear();
+        List<UnsubscribeUrlFailure> failures = pendingFailures.collectForAlert();
 
         if (!failures.isEmpty()) {
             discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
@@ -5,10 +5,9 @@ import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 public record UnsubscribeUrlFailure(
 
         String newsletterName,
-        String articleTitle,
-        Long memberId
+        String articleTitle
 ) {
     public static UnsubscribeUrlFailure from(UnsubscribeUrlMissingEvent event) {
-        return new UnsubscribeUrlFailure(event.newsletterName(), event.articleTitle(), event.memberId());
+        return new UnsubscribeUrlFailure(event.newsletterName(), event.articleTitle());
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
@@ -1,0 +1,14 @@
+package news.bombomemail.subscribe.alert;
+
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+
+public record UnsubscribeUrlFailure(
+
+        String newsletterName,
+        String articleTitle,
+        Long memberId
+) {
+    public static UnsubscribeUrlFailure from(UnsubscribeUrlMissingEvent event) {
+        return new UnsubscribeUrlFailure(event.newsletterName(), event.articleTitle(), event.memberId());
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
@@ -7,6 +7,7 @@ public record UnsubscribeUrlFailure(
         String newsletterName,
         String articleTitle
 ) {
+
     public static UnsubscribeUrlFailure from(UnsubscribeUrlMissingEvent event) {
         return new UnsubscribeUrlFailure(event.newsletterName(), event.articleTitle());
     }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
@@ -4,11 +4,12 @@ import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 
 public record UnsubscribeUrlFailure(
 
+        Long newsletterId,
         String newsletterName,
         String articleTitle
 ) {
 
     public static UnsubscribeUrlFailure from(UnsubscribeUrlMissingEvent event) {
-        return new UnsubscribeUrlFailure(event.newsletterName(), event.articleTitle());
+        return new UnsubscribeUrlFailure(event.newsletterId(), event.newsletterName(), event.articleTitle());
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlMissingEventListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlMissingEventListener.java
@@ -1,7 +1,6 @@
 package news.bombomemail.subscribe.alert;
 
 import lombok.RequiredArgsConstructor;
-import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlMissingEventListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlMissingEventListener.java
@@ -1,0 +1,19 @@
+package news.bombomemail.subscribe.alert;
+
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UnsubscribeUrlMissingEventListener {
+
+    private final UnsubscribeUrlAlertService unsubscribeUrlAlertService;
+
+    @TransactionalEventListener
+    public void on(UnsubscribeUrlMissingEvent event) {
+        unsubscribeUrlAlertService.record(event);
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
-import news.bombomemail.common.discord.DiscordWebhookSender;
+import news.bombomemail.common.DiscordWebhookNotifier;
 import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 public class UnsubscribeUrlAlertService {
 
     private final Map<Long, UnsubscribeUrlFailure> pendingFailures = new ConcurrentHashMap<>();
-    private final DiscordWebhookSender discordWebhookSender;
+    private final DiscordWebhookNotifier discordWebhookNotifier;
 
     public void record(UnsubscribeUrlMissingEvent event) {
         pendingFailures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
@@ -26,7 +26,7 @@ public class UnsubscribeUrlAlertService {
         pendingFailures.clear();
 
         if (!failures.isEmpty()) {
-            discordWebhookSender.sendUnsubscribeUrlMissingAlert(failures);
+            discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);
         }
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
@@ -2,10 +2,8 @@ package news.bombomemail.subscribe.alert.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Queue;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.RequiredArgsConstructor;
 import news.bombomemail.common.discord.DiscordWebhookSender;
 import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
@@ -16,23 +14,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UnsubscribeUrlAlertService {
 
-    private final Set<Long> failedNewsletterIds = ConcurrentHashMap.newKeySet();
-    private final Queue<UnsubscribeUrlFailure> pendingAlerts = new ConcurrentLinkedQueue<>();
+    private final Map<Long, UnsubscribeUrlFailure> pendingFailures = new ConcurrentHashMap<>();
     private final DiscordWebhookSender discordWebhookSender;
 
     public void record(UnsubscribeUrlMissingEvent event) {
-        boolean isNew = failedNewsletterIds.add(event.newsletterId());
-        if (isNew) {
-            pendingAlerts.offer(UnsubscribeUrlFailure.from(event));
-        }
+        pendingFailures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
     }
 
-    public void drainAndSend() {
-        List<UnsubscribeUrlFailure> failures = new ArrayList<>();
-        UnsubscribeUrlFailure failure;
-        while ((failure = pendingAlerts.poll()) != null) {
-            failures.add(failure);
-        }
+    public void sendPendingAlerts() {
+        List<UnsubscribeUrlFailure> failures = new ArrayList<>(pendingFailures.values());
+        pendingFailures.clear();
+
         if (!failures.isEmpty()) {
             discordWebhookSender.sendUnsubscribeUrlMissingAlert(failures);
         }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
@@ -1,0 +1,40 @@
+package news.bombomemail.subscribe.alert.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.common.discord.DiscordWebhookSender;
+import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UnsubscribeUrlAlertService {
+
+    private final Set<Long> failedNewsletterIds = ConcurrentHashMap.newKeySet();
+    private final Queue<UnsubscribeUrlFailure> pendingAlerts = new ConcurrentLinkedQueue<>();
+    private final DiscordWebhookSender discordWebhookSender;
+
+    public void record(UnsubscribeUrlMissingEvent event) {
+        boolean isNew = failedNewsletterIds.add(event.newsletterId());
+        if (isNew) {
+            pendingAlerts.offer(UnsubscribeUrlFailure.from(event));
+        }
+    }
+
+    public void drainAndSend() {
+        List<UnsubscribeUrlFailure> failures = new ArrayList<>();
+        UnsubscribeUrlFailure failure;
+        while ((failure = pendingAlerts.poll()) != null) {
+            failures.add(failure);
+        }
+        if (!failures.isEmpty()) {
+            discordWebhookSender.sendUnsubscribeUrlMissingAlert(failures);
+        }
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadController.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadController.java
@@ -1,0 +1,23 @@
+package news.bombomemail.subscribe.api.internal;
+
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloadService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/unsubscribe-patterns")
+@RequiredArgsConstructor
+public class InternalUnsubscribePatternReloadController {
+
+    private final UnsubscribePatternReloadService unsubscribePatternReloadService;
+
+    @PostMapping("/reload")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void reload() {
+        unsubscribePatternReloadService.reload();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/Subscribe.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/Subscribe.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import news.bombomemail.common.BaseEntity;
+import org.springframework.util.StringUtils;
 
 @Entity
 @Getter
@@ -39,8 +40,12 @@ public class Subscribe extends BaseEntity {
     @Column(nullable = false, length = 20)
     private SubscribeStatus status = SubscribeStatus.SUBSCRIBED;
 
+    public boolean isUnsubscribeUrlMissing() {
+        return !StringUtils.hasText(unsubscribeUrl);
+    }
+
     public void updateUnsubscribeUrl(String unsubscribeUrl) {
-        if (unsubscribeUrl == null) {
+        if (!StringUtils.hasText(unsubscribeUrl)) {
             return;
         }
         this.unsubscribeUrl = unsubscribeUrl;

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
@@ -1,0 +1,39 @@
+package news.bombomemail.subscribe.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import news.bombomemail.common.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = "pattern_key"))
+public class UnsubscribePattern extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 30)
+    private String patternKey;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String patternValue;
+
+    @Builder
+    public UnsubscribePattern(String patternKey, String patternValue) {
+        this.patternKey = patternKey;
+        this.patternValue = patternValue;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/NewsletterSubscribedEvent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/NewsletterSubscribedEvent.java
@@ -1,6 +1,10 @@
 package news.bombomemail.subscribe.event;
 
-public record NewsletterSubscribedEvent(Long newsletterId, Long memberId) {
+public record NewsletterSubscribedEvent(
+
+        Long newsletterId,
+        Long memberId
+) {
 
     public static NewsletterSubscribedEvent of(Long newsletterId, Long memberId) {
         return new NewsletterSubscribedEvent(newsletterId, memberId);

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListener.java
@@ -22,7 +22,13 @@ public class SubscribeArticleArrivedListener {
         }
 
         try {
-            subscribeService.upsertSubscribe(event.newsletterId(), event.memberId(), event.unsubscribeUrl());
+            subscribeService.upsertSubscribe(
+                    event.newsletterId(),
+                    event.memberId(),
+                    event.unsubscribeUrl(),
+                    event.newsletterName(),
+                    event.articleTitle()
+            );
         } catch (Exception e) {
             // FIXME :: 로깅 시스템 구축후 추가될 예정
             log.error("구독 리스트 저장 실패");

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/UnsubscribeUrlMissingEvent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/UnsubscribeUrlMissingEvent.java
@@ -4,6 +4,5 @@ public record UnsubscribeUrlMissingEvent(
 
         Long newsletterId,
         String newsletterName,
-        String articleTitle,
-        Long memberId
+        String articleTitle
 ) {}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/UnsubscribeUrlMissingEvent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/UnsubscribeUrlMissingEvent.java
@@ -1,0 +1,9 @@
+package news.bombomemail.subscribe.event;
+
+public record UnsubscribeUrlMissingEvent(
+
+        Long newsletterId,
+        String newsletterName,
+        String articleTitle,
+        Long memberId
+) {}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/repository/UnsubscribePatternRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/repository/UnsubscribePatternRepository.java
@@ -1,0 +1,7 @@
+package news.bombomemail.subscribe.repository;
+
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UnsubscribePatternRepository extends JpaRepository<UnsubscribePattern, Long> {
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/SubscribeService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/SubscribeService.java
@@ -35,8 +35,7 @@ public class SubscribeService {
                     new UnsubscribeUrlMissingEvent(
                             newsletterId,
                             newsletterName,
-                            articleTitle,
-                            memberId
+                            articleTitle
                     )
             );
         }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/SubscribeService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/SubscribeService.java
@@ -3,6 +3,7 @@ package news.bombomemail.subscribe.service;
 import lombok.RequiredArgsConstructor;
 import news.bombomemail.subscribe.domain.Subscribe;
 import news.bombomemail.subscribe.event.NewsletterSubscribedEvent;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import news.bombomemail.subscribe.repository.SubscribeRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -18,24 +19,39 @@ public class SubscribeService {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void upsertSubscribe(Long newsletterId, Long memberId, String unsubscribeUrl) {
-        subscribeRepository.findByMemberIdAndNewsletterId(memberId, newsletterId)
-                .ifPresentOrElse(
-                        subscribe -> subscribe.updateUnsubscribeUrl(unsubscribeUrl),
-                        () -> registerSubscribe(newsletterId, memberId, unsubscribeUrl)
-                );
+    public void upsertSubscribe(
+            Long newsletterId,
+            Long memberId,
+            String unsubscribeUrl,
+            String newsletterName,
+            String articleTitle
+    ) {
+        Subscribe subscribe = subscribeRepository.findByMemberIdAndNewsletterId(memberId, newsletterId)
+                .orElseGet(() -> registerSubscribe(newsletterId, memberId, unsubscribeUrl));
+        subscribe.updateUnsubscribeUrl(unsubscribeUrl);
+
+        if (subscribe.isUnsubscribeUrlMissing()) {
+            applicationEventPublisher.publishEvent(
+                    new UnsubscribeUrlMissingEvent(
+                            newsletterId,
+                            newsletterName,
+                            articleTitle,
+                            memberId
+                    )
+            );
+        }
     }
 
-    private void registerSubscribe(Long newsletterId, Long memberId, String unsubscribeUrl) {
+    private Subscribe registerSubscribe(Long newsletterId, Long memberId, String unsubscribeUrl) {
         Subscribe newSubscribe = Subscribe.builder()
                 .newsletterId(newsletterId)
                 .memberId(memberId)
                 .unsubscribeUrl(unsubscribeUrl)
                 .build();
-        subscribeRepository.save(newSubscribe);
 
         applicationEventPublisher.publishEvent(
                 NewsletterSubscribedEvent.of(newsletterId, memberId)
         );
+        return subscribeRepository.save(newSubscribe);
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadScheduler.java
@@ -1,0 +1,20 @@
+package news.bombomemail.subscribe.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UnsubscribePatternReloadScheduler {
+
+    private static final String TIME_ZONE = "Asia/Seoul";
+    private static final String DAILY_4AM_CRON = "0 0 4 * * *";
+
+    private final UnsubscribePatternReloadService unsubscribePatternReloadService;
+
+    @Scheduled(cron = DAILY_4AM_CRON, zone = TIME_ZONE)
+    public void reload() {
+        unsubscribePatternReloadService.reload();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadService.java
@@ -1,0 +1,64 @@
+package news.bombomemail.subscribe.service;
+
+import jakarta.annotation.PostConstruct;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import news.bombomemail.subscribe.repository.UnsubscribePatternRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UnsubscribePatternReloadService {
+
+    private static final String URL_KEYS = "parse.url-keywords";
+    private static final String TEXT_KEY = "parse.text-keywords";
+
+    private static final String PATTERN_REGEX = ",";
+    private static final List<String> DEFAULT_URL_KEYWORDS = List.of("unsubscribe");
+    private static final List<String> DEFAULT_TEXT_KEYWORDS = List.of(
+            "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
+    );
+
+    private final UnsubscribePatternRepository unsubscribePatternRepository;
+    private final UnsubscribeUrlExtractor unsubscribeUrlExtractor;
+
+    @PostConstruct
+    public void init() {
+        reload();
+    }
+
+    public void reload() {
+        Map<String, String> patterns = unsubscribePatternRepository.findAll().stream()
+                .collect(Collectors.toMap(UnsubscribePattern::getPatternKey, UnsubscribePattern::getPatternValue));
+
+        List<String> urlKeywords = parseKeywords(patterns.get(URL_KEYS));
+        List<String> textKeywords = parseKeywords(patterns.get(TEXT_KEY));
+
+        if (urlKeywords.isEmpty() || textKeywords.isEmpty()) {
+            log.warn("[UnsubscribePattern] DB에 패턴이 없어 기본값을 사용합니다.");
+            unsubscribeUrlExtractor.reload(DEFAULT_URL_KEYWORDS, DEFAULT_TEXT_KEYWORDS);
+            return;
+        }
+
+        unsubscribeUrlExtractor.reload(urlKeywords, textKeywords);
+        log.info("[UnsubscribePattern] 패턴 리로드 완료 - url: {}, text: {}", urlKeywords, textKeywords);
+    }
+
+    private List<String> parseKeywords(String value) {
+        if (!StringUtils.hasText(value)) {
+            return List.of();
+        }
+        return Arrays.stream(value.split(PATTERN_REGEX))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
@@ -12,7 +12,9 @@ import news.bombomemail.article.event.ArticleArrivedEvent;
 import news.bombomemail.article.event.ArticleSource;
 import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloadService;
 import news.bombomemail.email.extractor.EmailContentExtractor;
 import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
@@ -30,7 +32,7 @@ import org.springframework.test.context.event.RecordApplicationEvents;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({ArticleService.class, HtmlCleanerConfig.class})
+@Import({ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloadService.class})
 @RecordApplicationEvents
 class ArticleServiceTest {
 

--- a/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
@@ -9,7 +9,7 @@ import java.util.Properties;
 import news.bombomemail.article.domain.RecentArticle;
 import news.bombomemail.article.repository.RecentArticleRepository;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
-import news.bombomemail.common.TimeConfig;
+import news.bombomemail.common.config.TimeConfig;
 import news.bombomemail.email.extractor.EmailContentExtractor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
@@ -2,14 +2,37 @@ package news.bombomemail.article.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class UnsubscribeUrlExtractorTest {
 
+    private UnsubscribeUrlExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        extractor = new UnsubscribeUrlExtractor();
+        extractor.reload(List.of("unsubscribe"), List.of(
+                "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
+        ));
+    }
+
+    @Test
+    void URL에_여러_키워드중_하나가_있으면_추출한다() {
+        extractor.reload(List.of("unsubscribe", "cancel", "optout"), List.of(
+                "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
+        ));
+
+        String html = "<a href=\"https://example.com/cancel?id=123\">Manage</a>";
+        assertThat(extractor.extract(html))
+                .isEqualTo("https://example.com/cancel?id=123");
+    }
+
     @Test
     void URL에_unsubscribe가_있으면_추출한다() {
         String html = "<a href=\"https://example.com/unsubscribe?id=123\">Unsubscribe</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/unsubscribe?id=123");
     }
 
@@ -17,7 +40,7 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_Unsubscribe이면_추출한다() {
         // theSkimm, Korean FE Article
         String html = "<a href=\"https://link.example.com/oc/abc123\">Unsubscribe or Update Your Preferences</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://link.example.com/oc/abc123");
     }
 
@@ -25,7 +48,7 @@ class UnsubscribeUrlExtractorTest {
     void span_내부에_Unsubscribe가_있으면_추출한다() {
         // Substack
         String html = "<a href=\"https://substack.com/redirect/2/eyJl...\"><span>Unsubscribe</span></a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://substack.com/redirect/2/eyJl...");
     }
 
@@ -33,7 +56,7 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_수신거부이면_추출한다() {
         // NHN Cloud, Careet
         String html = "<a href=\"http://mkt.nhncloud.com/u/NDg4...\">수신거부</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("http://mkt.nhncloud.com/u/NDg4...");
     }
 
@@ -41,7 +64,7 @@ class UnsubscribeUrlExtractorTest {
     void 대괄호로_감싼_수신거부도_추출한다() {
         // Careet
         String html = "<a href=\"https://event.stibee.com/v2/click/abc\">[수신거부]</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://event.stibee.com/v2/click/abc");
     }
 
@@ -49,38 +72,38 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_Unsubscription이면_추출한다() {
         // NHN Cloud
         String html = "<a href=\"http://mkt.nhncloud.com/u/NDg4...\">Unsubscription)</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("http://mkt.nhncloud.com/u/NDg4...");
     }
 
     @Test
     void 앵커_텍스트가_구독취소이면_추출한다() {
         String html = "<a href=\"https://example.com/cancel\">구독 취소</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/cancel");
     }
 
     @Test
     void 앵커_텍스트가_구독해지이면_추출한다() {
         String html = "<a href=\"https://example.com/cancel\">구독 해지</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/cancel");
     }
 
     @Test
     void 본문_링크에_unsubscribe가_포함되어도_오탐하지_않는다() {
         String html = "<a href=\"https://blog.example.com/email-tips\">Why unsubscribe rates matter for marketers</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html)).isNull();
+        assertThat(extractor.extract(html)).isNull();
     }
 
     @Test
     void 수신거부_URL이_없으면_null을_반환한다() {
         String html = "<a href=\"https://example.com/subscribe\">Subscribe</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html)).isNull();
+        assertThat(extractor.extract(html)).isNull();
     }
 
     @Test
     void null_입력이면_null을_반환한다() {
-        assertThat(UnsubscribeUrlExtractor.extract(null)).isNull();
+        assertThat(extractor.extract(null)).isNull();
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/common/SchedulingConfigTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/common/SchedulingConfigTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import news.bombomemail.common.config.SchedulingConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
@@ -14,8 +14,10 @@ import java.util.List;
 import news.bombomemail.article.domain.Article;
 import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
 import news.bombomemail.email.EmailConfig;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloadService;
 import news.bombomemail.email.service.EmailService.BusinessProcessingException;
 import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
@@ -32,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({EmailService.class, EmailConfig.class, ArticleService.class, HtmlCleanerConfig.class})
+@Import({EmailService.class, EmailConfig.class, ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloadService.class})
 class EmailServiceTest {
 
     @Autowired

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailuresTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailuresTest.java
@@ -1,0 +1,62 @@
+package news.bombomemail.subscribe.alert;
+
+import java.util.List;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PendingUnsubscribeFailuresTest {
+
+    private PendingUnsubscribeFailures pendingFailures;
+
+    @BeforeEach
+    void setUp() {
+        pendingFailures = new PendingUnsubscribeFailures();
+    }
+
+    @Test
+    void 같은_뉴스레터는_중복_저장되지_않는다() {
+        // given
+        UnsubscribeUrlMissingEvent event1 = new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1");
+        UnsubscribeUrlMissingEvent event2 = new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 2");
+
+        // when
+        pendingFailures.record(event1);
+        pendingFailures.record(event2);
+
+        // then
+        List<UnsubscribeUrlFailure> result = pendingFailures.collectForAlert();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).articleTitle()).isEqualTo("아티클 1");
+    }
+
+    @Test
+    void 다른_뉴스레터는_각각_저장된다() {
+        // given
+        UnsubscribeUrlMissingEvent event1 = new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1");
+        UnsubscribeUrlMissingEvent event2 = new UnsubscribeUrlMissingEvent(2L, "뉴스레터B", "아티클 2");
+
+        // when
+        pendingFailures.record(event1);
+        pendingFailures.record(event2);
+
+        // then
+        List<UnsubscribeUrlFailure> result = pendingFailures.collectForAlert();
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void collectForAlert_호출_후_초기화된다() {
+        // given
+        pendingFailures.record(new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1"));
+
+        // when
+        pendingFailures.collectForAlert();
+        List<UnsubscribeUrlFailure> result = pendingFailures.collectForAlert();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertServiceTest.java
@@ -8,8 +8,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,5 +56,24 @@ class UnsubscribeUrlAlertServiceTest {
 
         // then
         verify(discordWebhookNotifier).sendUnsubscribeUrlMissingAlert(anyList()); // 정확히 1번만
+    }
+
+    @Test
+    void 알림_전송에_실패하면_다음_전송에서_재시도할_수_있다() {
+        // given
+        unsubscribeUrlAlertService.record(new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1"));
+        doThrow(new IllegalStateException("discord send failed"))
+                .doNothing()
+                .when(discordWebhookNotifier)
+                .sendUnsubscribeUrlMissingAlert(anyList());
+
+        // when
+        assertThatThrownBy(() -> unsubscribeUrlAlertService.sendPendingAlerts())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("discord send failed");
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // then
+        verify(discordWebhookNotifier, times(2)).sendUnsubscribeUrlMissingAlert(anyList());
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertServiceTest.java
@@ -1,0 +1,57 @@
+package news.bombomemail.subscribe.alert;
+
+import news.bombomemail.common.DiscordWebhookNotifier;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UnsubscribeUrlAlertServiceTest {
+
+    @Mock
+    private DiscordWebhookNotifier discordWebhookNotifier;
+
+    @InjectMocks
+    private UnsubscribeUrlAlertService unsubscribeUrlAlertService;
+
+    @Test
+    void 실패가_있으면_Discord_알림을_전송한다() {
+        // given
+        unsubscribeUrlAlertService.record(new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1"));
+
+        // when
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // then
+        verify(discordWebhookNotifier).sendUnsubscribeUrlMissingAlert(anyList());
+    }
+
+    @Test
+    void 실패가_없으면_Discord_알림을_전송하지_않는다() {
+        // when
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // then
+        verify(discordWebhookNotifier, never()).sendUnsubscribeUrlMissingAlert(anyList());
+    }
+
+    @Test
+    void 알림_전송_후_다시_전송하면_Discord_알림을_전송하지_않는다() {
+        // given
+        unsubscribeUrlAlertService.record(new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1"));
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // when
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // then
+        verify(discordWebhookNotifier).sendUnsubscribeUrlMissingAlert(anyList()); // 정확히 1번만
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadControllerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadControllerTest.java
@@ -1,0 +1,61 @@
+package news.bombomemail.subscribe.api.internal;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import news.bombomemail.common.internal.api.InternalApiKeyInterceptor;
+import news.bombomemail.common.internal.api.InternalApiWebConfig;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloadService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = InternalUnsubscribePatternReloadController.class)
+@ContextConfiguration(classes = InternalUnsubscribePatternReloadControllerTest.TestApplication.class)
+@Import({InternalApiWebConfig.class, InternalApiKeyInterceptor.class})
+@TestPropertySource(properties = "MAIL_SERVER_INTERNAL_API_KEY=test-secret")
+class InternalUnsubscribePatternReloadControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UnsubscribePatternReloadService unsubscribePatternReloadService;
+
+    @Test
+    void 올바른_internal_api_key로_리로드를_호출한다() throws Exception {
+        mockMvc.perform(post("/internal/v1/unsubscribe-patterns/reload")
+                        .header(InternalApiKeyInterceptor.INTERNAL_API_KEY_HEADER, "test-secret"))
+                .andExpect(status().isNoContent());
+
+        verify(unsubscribePatternReloadService).reload();
+    }
+
+    @Test
+    void internal_api_key가_없으면_unauthorized를_반환한다() throws Exception {
+        mockMvc.perform(post("/internal/v1/unsubscribe-patterns/reload"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 잘못된_internal_api_key면_unauthorized를_반환한다() throws Exception {
+        mockMvc.perform(post("/internal/v1/unsubscribe-patterns/reload")
+                        .header(InternalApiKeyInterceptor.INTERNAL_API_KEY_HEADER, "wrong-key"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @ComponentScan(basePackageClasses = InternalUnsubscribePatternReloadController.class)
+    static class TestApplication {
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListenerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListenerTest.java
@@ -44,7 +44,7 @@ class SubscribeArticleArrivedListenerTest {
         TestTransaction.end();
 
         // then
-        verify(subscribeService).upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+        verify(subscribeService).upsertSubscribe(newsletterId, memberId, unsubscribeUrl, newsletterName, articleTitle);
     }
 
     @Test

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/SubscribeServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/SubscribeServiceTest.java
@@ -28,7 +28,7 @@ class SubscribeServiceTest {
         String unsubscribeUrl = "unsubscribeUrl";
 
         // when
-        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl, "뉴스레터", "아티클");
 
         // then
         boolean exists = subscribeRepository.existsByNewsletterIdAndMemberId(newsletterId, memberId);
@@ -43,7 +43,7 @@ class SubscribeServiceTest {
         String unsubscribeUrl = "unsubscribeUrl";
 
         // when
-        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl, "뉴스레터", "아티클");
 
         // then
         Subscribe subscribe = subscribeRepository.findByMemberIdAndNewsletterId(memberId, newsletterId)
@@ -59,8 +59,8 @@ class SubscribeServiceTest {
         String unsubscribeUrl = "unsubscribeUrl";
 
         // when
-        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
-        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl, "뉴스레터", "아티클");
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl, "뉴스레터", "아티클");
 
         // then
         long count = subscribeRepository.findAll().stream()
@@ -76,10 +76,10 @@ class SubscribeServiceTest {
         Long memberId = 2L;
         String oldUrl = "oldUnsubscribeUrl";
         String newUrl = "newUnsubscribeUrl";
-        subscribeService.upsertSubscribe(newsletterId, memberId, oldUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, oldUrl, "뉴스레터", "아티클");
 
         // when
-        subscribeService.upsertSubscribe(newsletterId, memberId, newUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, newUrl, "뉴스레터", "아티클");
 
         // then
         subscribeRepository.findByMemberIdAndNewsletterId(newsletterId, memberId)

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
@@ -1,0 +1,71 @@
+package news.bombomemail.subscribe.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import news.bombomemail.subscribe.repository.UnsubscribePatternRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({UnsubscribeUrlExtractor.class, UnsubscribePatternReloadService.class})
+class UnsubscribePatternReloaderTest {
+
+    @Autowired
+    UnsubscribePatternRepository repository;
+
+    @Autowired
+    UnsubscribePatternReloadService reloadService;
+
+    @Autowired
+    UnsubscribeUrlExtractor extractor;
+
+    @Test
+    void DB_패턴으로_reload후에_새_패턴으로_추출한다() {
+        // given
+        repository.save(UnsubscribePattern.builder()
+                .patternKey("parse.url-keywords")
+                .patternValue("cancel,optout")
+                .build());
+        repository.save(UnsubscribePattern.builder()
+                .patternKey("parse.text-keywords")
+                .patternValue("cancel,취소,해지")
+                .build());
+
+        // when
+        reloadService.reload();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel?id=123\">cancel</a>"))
+                    .isEqualTo("https://example.com/cancel?id=123");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/optout?id=123\">manage</a>"))
+                    .isEqualTo("https://example.com/optout?id=123");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel\">취소</a>"))
+                    .isEqualTo("https://example.com/cancel");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/unsubscribe\">unsubscribe</a>"))
+                    .isNull();
+        });
+    }
+
+    @Test
+    void DB가_비어있으면_기본값으로_추출한다() {
+        // when
+        reloadService.reload();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/unsubscribe?id=123\">Unsubscribe</a>"))
+                    .isEqualTo("https://example.com/unsubscribe?id=123");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel\">수신거부</a>"))
+                    .isEqualTo("https://example.com/cancel");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/page\">cancel</a>"))
+                    .isNull();
+        });
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
구독 취소 URL(`unsubscribeUrl`) 파싱에 실패한 경우를 별도로 수집하고, 하루 1회 Discord 알림으로 전달하는 기능을 추가했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존에는 구독 취소 URL 파싱 실패를 운영자가 즉시 인지하기 어려웠고, 모든 뉴스레터를 직접 구독한 계정을 통해 수동으로 확인해야 했습니다.
이 방식은 누락 가능성이 높고, 어떤 뉴스레터에서 파싱이 깨졌는지 빠르게 파악하기 어렵다는 문제가 있었습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
뉴스레터 수신 후 구독 정보를 저장하는 흐름에서 unsubscribeUrl이 비어 있는 경우 UnsubscribeUrlMissingEvent를 발행하도록 구현했습니다. (기존 파싱 흐름과 분리를 위해)
이 이벤트는 알림 전용 리스너가 받아 메모리 기반의 대기 저장소에 적재합니다.

 **메모리 기반으로 구현한 이유**
구독 취소 URL 파싱 실패는 메일 수신 시점에 함께 발생하는 부가적인 운영 알림성 데이터이기 때문에, 이를 별도 DB에 즉시 적재하면 아티클 저장 흐름과 같은 타이밍에 추가적인 DB 쓰기와 커넥션 점유가 발생합니다. 아티클 저장을 위한 DB 커넥션 획득에 방해가 되지 않고자 했습니다. 서버 재시작 시 일부 대기 데이터가 유실될 수는 있지만, 동일 이슈가 지속되면 이후 아티클 수신에서 다시 드러나기 때문에 감수 가능한 수준으로 봤습니다.

대기 저장소는 newsletterId를 key로 갖는 `ConcurrentHashMap`을 사용해 관리했습니다.
**같은 뉴스레터에서 파싱 실패가 여러 번 발생하더라도 putIfAbsent로 최초 1건만 유지**하도록 해, **동일한 뉴스레터에 대한 중복 알림이 계속 쌓이지 않도록** 했습니다.

알림 전송 시점에는 AtomicReference로 관리하는 현재 맵을 새로운 ConcurrentHashMap으로 교체하고, 교체 직전 스냅샷의 값들만 꺼내 전송합니다.
이 방식으로 이벤트 적재와 알림 전송이 동시에 일어나더라도 락 없이 안전하게 수집할 수 있고, 전송 이후에는 대기 목록이 자연스럽게 초기화됩니다.

수집된 실패 내역은 매일 오후 1시에 스케줄러가 모아서 Discord 웹훅으로 전송합니다.
알림에는 아래와 같이 파싱에 실패한 뉴스레터명과 아티클 제목을 포함해 어떤 케이스에서 문제가 발생했는지 바로 확인할 수 있도록 했습니다.
<img width="238" height="201" alt="image" src="https://github.com/user-attachments/assets/689cf869-a5f2-4c03-85f0-9fad6221c3d8" />

**구현 구조 입니다.**
  - `SubscribeService`
      - 구독 저장 후 unsubscribeUrl 누락 여부를 판단하고 이벤트 발행
  - `UnsubscribeUrlMissingEventListener`
      - 파싱 실패 이벤트 수신
  - `PendingUnsubscribeFailures`
      - 알림 대기 목록 관리
  - `UnsubscribeUrlAlertScheduler`
      - 매일 1회 알림 전송 트리거
  - `DiscordWebhookNotifier`
      - Discord 웹훅 전송 담당

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 알림 전송을 오후 1시로 정했는데 적절할까요?
  - 이 시간이 이메일이 거의 도착하지 않는 여유로운 시간이고 저희가 알림 확인하기에도 적절한 시간이라 보았습니다.
- `ConcurrentHashMap`과 `AtomicReference` 기반이 적절한지 검토 부탁드립니다.
- 디스코드 알림 포맷도 검토 부탁드립니다.

**파싱 실패 알림 수신 후 빠른 대응을 위해 yml로 패턴 파일을 분리하는 작업은 다른 pr에서 진행하겠습니다.**