### PR TITLE
[BOM-1121] feat: 구독 취소 url 파싱 패턴 외부 관리

### DIFF
--- a/backend/mail-server/gradle/wrapper/gradle-wrapper.properties
+++ b/backend/mail-server/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/backend/mail-server/src/main/java/news/bombomemail/article/service/ArticleService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/service/ArticleService.java
@@ -41,6 +41,7 @@ public class ArticleService {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final NewsletterVerificationRepository newsletterVerificationRepository;
     private final HtmlTagCleaner htmlTagCleaner;
+    private final UnsubscribeUrlExtractor unsubscribeUrlExtractor;
 
     @Transactional
     public boolean save(MimeMessage message, String contents) throws MessagingException, DataAccessException {
@@ -56,7 +57,7 @@ public class ArticleService {
 
         String contentsText = htmlTagCleaner.clean(contents);
         Article article = articleRepository.save(buildArticle(message, contents, contentsText, member, newsletter));
-        String unsubscribeUrl = UnsubscribeUrlExtractor.extract(article.getContents());
+        String unsubscribeUrl = unsubscribeUrlExtractor.extract(article.getContents());
 
         applicationEventPublisher.publishEvent(ArticleArrivedEvent.of(
                         newsletter.getId(),

--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -1,41 +1,36 @@
 package news.bombomemail.article.util;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class UnsubscribeUrlExtractor {
+@Component
+public class UnsubscribeUrlExtractor {
 
-    // 1단계: href URL 자체에 "unsubscribe"가 포함된 경우
-    private static final Pattern UNSUBSCRIBE_URL_PATTERN = Pattern.compile(
-            "href=\"([^\"]*unsubscribe[^\"]*)\"",
-            Pattern.CASE_INSENSITIVE
-    );
-
-    // 2단계: <a href="...">...</a> 블록 전체를 추출 (href와 내부 HTML을 함께 캡처)
     private static final Pattern ANCHOR_PATTERN = Pattern.compile(
             "<a\\s[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
-    // 앵커 내부의 <span> 등 중첩 태그를 제거해 순수 텍스트만 남기기 위한 패턴
     private static final Pattern INNER_TAG_PATTERN = Pattern.compile("<[^>]+>");
 
-    // 앵커 텍스트가 수신거부 키워드로 시작하는지 확인. 앞에 '[', '(' 등 브라켓이 있어도 허용 (예: "[수신거부]")
-    private static final Pattern UNSUBSCRIBE_TEXT_PATTERN = Pattern.compile(
-            "^[\\[(\\s]*(unsubscribe|unsubscription|수신\\s*거부|구독\\s*취소|구독\\s*해지)",
-            Pattern.CASE_INSENSITIVE
-    );
+    private final AtomicReference<Pattern> urlPattern = new AtomicReference<>();
+    private final AtomicReference<Pattern> textPattern = new AtomicReference<>();
 
-    public static String extract(String articleContents) {
+    public void reload(String urlKeyword, List<String> textKeywords) {
+        urlPattern.set(Pattern.compile(buildUrlRegex(urlKeyword), Pattern.CASE_INSENSITIVE));
+        textPattern.set(Pattern.compile(buildTextRegex(textKeywords), Pattern.CASE_INSENSITIVE));
+    }
+
+    public String extract(String articleContents) {
         if (!StringUtils.hasText(articleContents)) {
             return null;
         }
 
-        Matcher urlMatcher = UNSUBSCRIBE_URL_PATTERN.matcher(articleContents);
+        Matcher urlMatcher = urlPattern.get().matcher(articleContents);
         if (urlMatcher.find()) {
             return urlMatcher.group(1);
         }
@@ -48,11 +43,19 @@ public final class UnsubscribeUrlExtractor {
                 continue;
             }
             String text = INNER_TAG_PATTERN.matcher(anchorBody).replaceAll("").strip();
-            if (UNSUBSCRIBE_TEXT_PATTERN.matcher(text).find()) {
+            if (textPattern.get().matcher(text).find()) {
                 return href;
             }
         }
 
         return null;
+    }
+
+    private static String buildUrlRegex(String urlKeyword) {
+        return "href=\"([^\"]*" + Pattern.quote(urlKeyword) + "[^\"]*)\"";
+    }
+
+    private static String buildTextRegex(List<String> textKeywords) {
+        return "^[\\[(\\s]*(" + String.join("|", textKeywords) + ")";
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -1,6 +1,7 @@
 package news.bombomemail.common;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -17,6 +18,7 @@ import org.springframework.web.client.RestClient;
 public class DiscordWebhookNotifier {
 
     private static final int COLOR_RED = 0xE74C3C;
+    private static final int MAX_DISPLAY_COUNT = 50;
 
     private final RestClient restClient;
 
@@ -28,25 +30,35 @@ public class DiscordWebhookNotifier {
     }
 
     public void sendUnsubscribeUrlMissingAlert(List<UnsubscribeUrlFailure> failures) {
-        try {
-            restClient.post()
-                    .uri(webhookUrl)
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .body(buildBody(failures))
-                    .retrieve()
-                    .toBodilessEntity();
-        } catch (Exception e) {
-            log.warn("Discord Webhook 전송 실패: {}", e.getMessage(), e);
+        for (List<UnsubscribeUrlFailure> chunk : partition(failures)) {
+            try {
+                restClient.post()
+                        .uri(webhookUrl)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body(buildBody(failures.size(), chunk))
+                        .retrieve()
+                        .toBodilessEntity();
+            } catch (Exception e) {
+                log.warn("구독 취소 url 파싱 실패 알림 전송 실패: {}", e.getMessage(), e);
+            }
         }
     }
 
-    private Map<String, Object> buildBody(List<UnsubscribeUrlFailure> failures) {
-        String description = failures.stream()
+    private List<List<UnsubscribeUrlFailure>> partition(List<UnsubscribeUrlFailure> failures) {
+        List<List<UnsubscribeUrlFailure>> chunks = new ArrayList<>();
+        for (int i = 0; i < failures.size(); i += MAX_DISPLAY_COUNT) {
+            chunks.add(failures.subList(i, Math.min(i + MAX_DISPLAY_COUNT, failures.size())));
+        }
+        return chunks;
+    }
+
+    private Map<String, Object> buildBody(int totalCount, List<UnsubscribeUrlFailure> unsubscribeUrlFailures) {
+        String description = unsubscribeUrlFailures.stream()
                 .map(f -> "📰 **%s**\n└ %s".formatted(f.newsletterName(), f.articleTitle()))
                 .collect(Collectors.joining("\n\n"));
 
         Map<String, Object> embed = Map.of(
-                "title", "🚨 unsubscribeUrl 파싱 실패 (%d건)".formatted(failures.size()),
+                "title", "🚨 unsubscribeUrl 파싱 실패 (%d건)".formatted(totalCount),
                 "description", description,
                 "color", COLOR_RED,
                 "footer", Map.of("text", "매일 오후 1시 집계"),

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -1,40 +1,58 @@
 package news.bombomemail.common;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 public class DiscordWebhookNotifier {
+
+    private static final int COLOR_RED = 0xE74C3C;
 
     private final RestClient restClient;
 
     @Value("${discord.webhook.unsubscribe-alert.url}")
     private String webhookUrl;
 
-    public DiscordWebhookNotifier(RestClient.Builder builder) {
-        this.restClient = builder.build();
+    public DiscordWebhookNotifier(@Qualifier("discordRestClient") RestClient restClient) {
+        this.restClient = restClient;
     }
 
     public void sendUnsubscribeUrlMissingAlert(List<UnsubscribeUrlFailure> failures) {
-        restClient.post()
-                .uri(webhookUrl)
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(Map.of("content", formatMessage(failures)))
-                .retrieve()
-                .toBodilessEntity();
+        try {
+            restClient.post()
+                    .uri(webhookUrl)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(buildBody(failures))
+                    .retrieve()
+                    .toBodilessEntity();
+        } catch (Exception e) {
+            log.warn("[WARN] Discord Webhook 전송 실패: {}", e.getMessage(), e);
+        }
     }
 
-    private String formatMessage(List<UnsubscribeUrlFailure> failures) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("⚠️ **unsubscribeUrl 파싱 실패 (%d건)**\n".formatted(failures.size()));
-        failures.forEach(f ->
-                sb.append("• %s | %s\n".formatted(f.newsletterName(), f.articleTitle()))
+    private Map<String, Object> buildBody(List<UnsubscribeUrlFailure> failures) {
+        String description = failures.stream()
+                .map(f -> "📰 **%s**\n└ %s".formatted(f.newsletterName(), f.articleTitle()))
+                .collect(Collectors.joining("\n\n"));
+
+        Map<String, Object> embed = Map.of(
+                "title", "🚨 unsubscribeUrl 파싱 실패 (%d건)".formatted(failures.size()),
+                "description", description,
+                "color", COLOR_RED,
+                "footer", Map.of("text", "매일 오후 1시 집계"),
+                "timestamp", Instant.now().toString()
         );
-        return sb.toString();
+
+        return Map.of("embeds", List.of(embed));
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -1,4 +1,4 @@
-package news.bombomemail.common.discord;
+package news.bombomemail.common;
 
 import java.util.List;
 import java.util.Map;
@@ -9,14 +9,14 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 @Component
-public class DiscordWebhookSender {
+public class DiscordWebhookNotifier {
 
     private final RestClient restClient;
 
     @Value("${discord.webhook.unsubscribe-alert.url}")
     private String webhookUrl;
 
-    public DiscordWebhookSender(RestClient.Builder builder) {
+    public DiscordWebhookNotifier(RestClient.Builder builder) {
         this.restClient = builder.build();
     }
 

--- a/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/DiscordWebhookNotifier.java
@@ -36,7 +36,7 @@ public class DiscordWebhookNotifier {
                     .retrieve()
                     .toBodilessEntity();
         } catch (Exception e) {
-            log.warn("[WARN] Discord Webhook 전송 실패: {}", e.getMessage(), e);
+            log.warn("Discord Webhook 전송 실패: {}", e.getMessage(), e);
         }
     }
 

--- a/backend/mail-server/src/main/java/news/bombomemail/common/config/RandomConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/config/RandomConfig.java
@@ -1,4 +1,4 @@
-package news.bombomemail.common;
+package news.bombomemail.common.config;
 
 import java.util.Random;
 import org.springframework.context.annotation.Bean;

--- a/backend/mail-server/src/main/java/news/bombomemail/common/config/RestClientConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/config/RestClientConfig.java
@@ -1,0 +1,21 @@
+package news.bombomemail.common.config;
+
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(5);
+
+    @Bean
+    public RestClient discordRestClient(RestClient.Builder builder) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(REQUEST_TIMEOUT);
+        factory.setReadTimeout(REQUEST_TIMEOUT);
+        return builder.requestFactory(factory).build();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/common/config/SchedulingConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/config/SchedulingConfig.java
@@ -1,4 +1,4 @@
-package news.bombomemail.common;
+package news.bombomemail.common.config;
 
 import javax.sql.DataSource;
 import net.javacrumbs.shedlock.core.LockProvider;

--- a/backend/mail-server/src/main/java/news/bombomemail/common/config/TimeConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/config/TimeConfig.java
@@ -1,4 +1,4 @@
-package news.bombomemail.common;
+package news.bombomemail.common.config;
 
 import java.time.Clock;
 import java.time.ZoneId;

--- a/backend/mail-server/src/main/java/news/bombomemail/common/discord/DiscordWebhookSender.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/discord/DiscordWebhookSender.java
@@ -33,7 +33,7 @@ public class DiscordWebhookSender {
         StringBuilder sb = new StringBuilder();
         sb.append("⚠️ **unsubscribeUrl 파싱 실패 (%d건)**\n".formatted(failures.size()));
         failures.forEach(f ->
-                sb.append("• %s | %s | memberId: %d\n".formatted(f.newsletterName(), f.articleTitle(), f.memberId()))
+                sb.append("• %s | %s\n".formatted(f.newsletterName(), f.articleTitle()))
         );
         return sb.toString();
     }

--- a/backend/mail-server/src/main/java/news/bombomemail/common/discord/DiscordWebhookSender.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/discord/DiscordWebhookSender.java
@@ -1,0 +1,40 @@
+package news.bombomemail.common.discord;
+
+import java.util.List;
+import java.util.Map;
+import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class DiscordWebhookSender {
+
+    private final RestClient restClient;
+
+    @Value("${discord.webhook.unsubscribe-alert.url}")
+    private String webhookUrl;
+
+    public DiscordWebhookSender(RestClient.Builder builder) {
+        this.restClient = builder.build();
+    }
+
+    public void sendUnsubscribeUrlMissingAlert(List<UnsubscribeUrlFailure> failures) {
+        restClient.post()
+                .uri(webhookUrl)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(Map.of("content", formatMessage(failures)))
+                .retrieve()
+                .toBodilessEntity();
+    }
+
+    private String formatMessage(List<UnsubscribeUrlFailure> failures) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("⚠️ **unsubscribeUrl 파싱 실패 (%d건)**\n".formatted(failures.size()));
+        failures.forEach(f ->
+                sb.append("• %s | %s | memberId: %d\n".formatted(f.newsletterName(), f.articleTitle(), f.memberId()))
+        );
+        return sb.toString();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
@@ -1,0 +1,22 @@
+package news.bombomemail.subscribe.alert;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+
+public class PendingUnsubscribeFailures {
+
+    private final Map<Long, UnsubscribeUrlFailure> failures = new ConcurrentHashMap<>();
+
+    void record(UnsubscribeUrlMissingEvent event) {
+        failures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
+    }
+
+    List<UnsubscribeUrlFailure> collectForAlert() {
+        List<UnsubscribeUrlFailure> result = new ArrayList<>(failures.values());
+        failures.clear();
+        return result;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailures.java
@@ -4,19 +4,19 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 
 public class PendingUnsubscribeFailures {
 
-    private final Map<Long, UnsubscribeUrlFailure> failures = new ConcurrentHashMap<>();
+    private final AtomicReference<Map<Long, UnsubscribeUrlFailure>> failures = new AtomicReference<>(new ConcurrentHashMap<>());
 
     void record(UnsubscribeUrlMissingEvent event) {
-        failures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
+        failures.get().putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
     }
 
     List<UnsubscribeUrlFailure> collectForAlert() {
-        List<UnsubscribeUrlFailure> result = new ArrayList<>(failures.values());
-        failures.clear();
-        return result;
+        Map<Long, UnsubscribeUrlFailure> snapshot = failures.getAndSet(new ConcurrentHashMap<>());
+        return new ArrayList<>(snapshot.values());
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertManager.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertManager.java
@@ -1,0 +1,30 @@
+package news.bombomemail.subscribe.alert;
+
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UnsubscribeUrlAlertManager {
+
+    private static final String TIME_ZONE = "Asia/Seoul";
+    private static final String DAILY_CRON = "0 0 13 * * *"; // 오후 1시
+
+    private final UnsubscribeUrlAlertService unsubscribeUrlAlertService;
+
+    @TransactionalEventListener
+    public void on(UnsubscribeUrlMissingEvent event) {
+        unsubscribeUrlAlertService.record(event);
+    }
+
+    @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
+    @SchedulerLock(name = "unsubscribe_url_alert", lockAtMostFor = "PT5M")
+    public void sendAlert() {
+        unsubscribeUrlAlertService.drainAndSend();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
@@ -2,7 +2,6 @@ package news.bombomemail.subscribe.alert;
 
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
-import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
@@ -18,6 +18,6 @@ public class UnsubscribeUrlAlertScheduler {
     @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
     @SchedulerLock(name = "unsubscribe_url_alert", lockAtMostFor = "PT5M")
     public void sendAlert() {
-        unsubscribeUrlAlertService.drainAndSend();
+        unsubscribeUrlAlertService.sendPendingAlerts();
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertScheduler.java
@@ -3,24 +3,17 @@ package news.bombomemail.subscribe.alert;
 import lombok.RequiredArgsConstructor;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
-import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 @Component
 @RequiredArgsConstructor
-public class UnsubscribeUrlAlertManager {
+public class UnsubscribeUrlAlertScheduler {
 
     private static final String TIME_ZONE = "Asia/Seoul";
     private static final String DAILY_CRON = "0 0 13 * * *"; // 오후 1시
 
     private final UnsubscribeUrlAlertService unsubscribeUrlAlertService;
-
-    @TransactionalEventListener
-    public void on(UnsubscribeUrlMissingEvent event) {
-        unsubscribeUrlAlertService.record(event);
-    }
 
     @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
     @SchedulerLock(name = "unsubscribe_url_alert", lockAtMostFor = "PT5M")

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
@@ -20,8 +20,9 @@ public class UnsubscribeUrlAlertService {
     public void sendPendingAlerts() {
         List<UnsubscribeUrlFailure> failures = pendingFailures.collectForAlert();
 
-        if (!failures.isEmpty()) {
-            discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);
+        if (failures.isEmpty()) {
+            return;
         }
+        discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertService.java
@@ -1,12 +1,8 @@
-package news.bombomemail.subscribe.alert.service;
+package news.bombomemail.subscribe.alert;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import news.bombomemail.common.DiscordWebhookNotifier;
-import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import org.springframework.stereotype.Service;
 
@@ -14,16 +10,15 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UnsubscribeUrlAlertService {
 
-    private final Map<Long, UnsubscribeUrlFailure> pendingFailures = new ConcurrentHashMap<>();
+    private final PendingUnsubscribeFailures pendingFailures = new PendingUnsubscribeFailures();
     private final DiscordWebhookNotifier discordWebhookNotifier;
 
     public void record(UnsubscribeUrlMissingEvent event) {
-        pendingFailures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
+        pendingFailures.record(event);
     }
 
     public void sendPendingAlerts() {
-        List<UnsubscribeUrlFailure> failures = new ArrayList<>(pendingFailures.values());
-        pendingFailures.clear();
+        List<UnsubscribeUrlFailure> failures = pendingFailures.collectForAlert();
 
         if (!failures.isEmpty()) {
             discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
@@ -5,10 +5,9 @@ import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 public record UnsubscribeUrlFailure(
 
         String newsletterName,
-        String articleTitle,
-        Long memberId
+        String articleTitle
 ) {
     public static UnsubscribeUrlFailure from(UnsubscribeUrlMissingEvent event) {
-        return new UnsubscribeUrlFailure(event.newsletterName(), event.articleTitle(), event.memberId());
+        return new UnsubscribeUrlFailure(event.newsletterName(), event.articleTitle());
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlFailure.java
@@ -1,0 +1,14 @@
+package news.bombomemail.subscribe.alert;
+
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+
+public record UnsubscribeUrlFailure(
+
+        String newsletterName,
+        String articleTitle,
+        Long memberId
+) {
+    public static UnsubscribeUrlFailure from(UnsubscribeUrlMissingEvent event) {
+        return new UnsubscribeUrlFailure(event.newsletterName(), event.articleTitle(), event.memberId());
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlMissingEventListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlMissingEventListener.java
@@ -1,7 +1,6 @@
 package news.bombomemail.subscribe.alert;
 
 import lombok.RequiredArgsConstructor;
-import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.event.TransactionalEventListener;

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlMissingEventListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/UnsubscribeUrlMissingEventListener.java
@@ -1,0 +1,19 @@
+package news.bombomemail.subscribe.alert;
+
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.subscribe.alert.service.UnsubscribeUrlAlertService;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class UnsubscribeUrlMissingEventListener {
+
+    private final UnsubscribeUrlAlertService unsubscribeUrlAlertService;
+
+    @TransactionalEventListener
+    public void on(UnsubscribeUrlMissingEvent event) {
+        unsubscribeUrlAlertService.record(event);
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
-import news.bombomemail.common.discord.DiscordWebhookSender;
+import news.bombomemail.common.DiscordWebhookNotifier;
 import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
 import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import org.springframework.stereotype.Service;
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Service;
 public class UnsubscribeUrlAlertService {
 
     private final Map<Long, UnsubscribeUrlFailure> pendingFailures = new ConcurrentHashMap<>();
-    private final DiscordWebhookSender discordWebhookSender;
+    private final DiscordWebhookNotifier discordWebhookNotifier;
 
     public void record(UnsubscribeUrlMissingEvent event) {
         pendingFailures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
@@ -26,7 +26,7 @@ public class UnsubscribeUrlAlertService {
         pendingFailures.clear();
 
         if (!failures.isEmpty()) {
-            discordWebhookSender.sendUnsubscribeUrlMissingAlert(failures);
+            discordWebhookNotifier.sendUnsubscribeUrlMissingAlert(failures);
         }
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
@@ -2,10 +2,8 @@ package news.bombomemail.subscribe.alert.service;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Queue;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import lombok.RequiredArgsConstructor;
 import news.bombomemail.common.discord.DiscordWebhookSender;
 import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
@@ -16,23 +14,17 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UnsubscribeUrlAlertService {
 
-    private final Set<Long> failedNewsletterIds = ConcurrentHashMap.newKeySet();
-    private final Queue<UnsubscribeUrlFailure> pendingAlerts = new ConcurrentLinkedQueue<>();
+    private final Map<Long, UnsubscribeUrlFailure> pendingFailures = new ConcurrentHashMap<>();
     private final DiscordWebhookSender discordWebhookSender;
 
     public void record(UnsubscribeUrlMissingEvent event) {
-        boolean isNew = failedNewsletterIds.add(event.newsletterId());
-        if (isNew) {
-            pendingAlerts.offer(UnsubscribeUrlFailure.from(event));
-        }
+        pendingFailures.putIfAbsent(event.newsletterId(), UnsubscribeUrlFailure.from(event));
     }
 
-    public void drainAndSend() {
-        List<UnsubscribeUrlFailure> failures = new ArrayList<>();
-        UnsubscribeUrlFailure failure;
-        while ((failure = pendingAlerts.poll()) != null) {
-            failures.add(failure);
-        }
+    public void sendPendingAlerts() {
+        List<UnsubscribeUrlFailure> failures = new ArrayList<>(pendingFailures.values());
+        pendingFailures.clear();
+
         if (!failures.isEmpty()) {
             discordWebhookSender.sendUnsubscribeUrlMissingAlert(failures);
         }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/alert/service/UnsubscribeUrlAlertService.java
@@ -1,0 +1,40 @@
+package news.bombomemail.subscribe.alert.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.common.discord.DiscordWebhookSender;
+import news.bombomemail.subscribe.alert.UnsubscribeUrlFailure;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UnsubscribeUrlAlertService {
+
+    private final Set<Long> failedNewsletterIds = ConcurrentHashMap.newKeySet();
+    private final Queue<UnsubscribeUrlFailure> pendingAlerts = new ConcurrentLinkedQueue<>();
+    private final DiscordWebhookSender discordWebhookSender;
+
+    public void record(UnsubscribeUrlMissingEvent event) {
+        boolean isNew = failedNewsletterIds.add(event.newsletterId());
+        if (isNew) {
+            pendingAlerts.offer(UnsubscribeUrlFailure.from(event));
+        }
+    }
+
+    public void drainAndSend() {
+        List<UnsubscribeUrlFailure> failures = new ArrayList<>();
+        UnsubscribeUrlFailure failure;
+        while ((failure = pendingAlerts.poll()) != null) {
+            failures.add(failure);
+        }
+        if (!failures.isEmpty()) {
+            discordWebhookSender.sendUnsubscribeUrlMissingAlert(failures);
+        }
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/Subscribe.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/Subscribe.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import news.bombomemail.common.BaseEntity;
+import org.springframework.util.StringUtils;
 
 @Entity
 @Getter
@@ -39,8 +40,12 @@ public class Subscribe extends BaseEntity {
     @Column(nullable = false, length = 20)
     private SubscribeStatus status = SubscribeStatus.SUBSCRIBED;
 
+    public boolean isUnsubscribeUrlMissing() {
+        return !StringUtils.hasText(unsubscribeUrl);
+    }
+
     public void updateUnsubscribeUrl(String unsubscribeUrl) {
-        if (unsubscribeUrl == null) {
+        if (!StringUtils.hasText(unsubscribeUrl)) {
             return;
         }
         this.unsubscribeUrl = unsubscribeUrl;

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import news.bombomemail.common.BaseEntity;
@@ -26,4 +27,10 @@ public class UnsubscribePattern extends BaseEntity {
     @Lob
     @Column(nullable = false, columnDefinition = "TEXT")
     private String patternValue;
+
+    @Builder
+    public UnsubscribePattern(String patternKey, String patternValue) {
+        this.patternKey = patternKey;
+        this.patternValue = patternValue;
+    }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
@@ -1,0 +1,29 @@
+package news.bombomemail.subscribe.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import news.bombomemail.common.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UnsubscribePattern extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String patternKey;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String patternValue;
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListener.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListener.java
@@ -22,7 +22,13 @@ public class SubscribeArticleArrivedListener {
         }
 
         try {
-            subscribeService.upsertSubscribe(event.newsletterId(), event.memberId(), event.unsubscribeUrl());
+            subscribeService.upsertSubscribe(
+                    event.newsletterId(),
+                    event.memberId(),
+                    event.unsubscribeUrl(),
+                    event.newsletterName(),
+                    event.articleTitle()
+            );
         } catch (Exception e) {
             // FIXME :: 로깅 시스템 구축후 추가될 예정
             log.error("구독 리스트 저장 실패");

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/UnsubscribeUrlMissingEvent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/UnsubscribeUrlMissingEvent.java
@@ -4,6 +4,5 @@ public record UnsubscribeUrlMissingEvent(
 
         Long newsletterId,
         String newsletterName,
-        String articleTitle,
-        Long memberId
+        String articleTitle
 ) {}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/UnsubscribeUrlMissingEvent.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/event/UnsubscribeUrlMissingEvent.java
@@ -1,0 +1,9 @@
+package news.bombomemail.subscribe.event;
+
+public record UnsubscribeUrlMissingEvent(
+
+        Long newsletterId,
+        String newsletterName,
+        String articleTitle,
+        Long memberId
+) {}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/repository/UnsubscribePatternRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/repository/UnsubscribePatternRepository.java
@@ -1,0 +1,7 @@
+package news.bombomemail.subscribe.repository;
+
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UnsubscribePatternRepository extends JpaRepository<UnsubscribePattern, Long> {
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/SubscribeService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/SubscribeService.java
@@ -35,8 +35,7 @@ public class SubscribeService {
                     new UnsubscribeUrlMissingEvent(
                             newsletterId,
                             newsletterName,
-                            articleTitle,
-                            memberId
+                            articleTitle
                     )
             );
         }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/SubscribeService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/SubscribeService.java
@@ -3,6 +3,7 @@ package news.bombomemail.subscribe.service;
 import lombok.RequiredArgsConstructor;
 import news.bombomemail.subscribe.domain.Subscribe;
 import news.bombomemail.subscribe.event.NewsletterSubscribedEvent;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
 import news.bombomemail.subscribe.repository.SubscribeRepository;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
@@ -18,24 +19,39 @@ public class SubscribeService {
     private final ApplicationEventPublisher applicationEventPublisher;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public void upsertSubscribe(Long newsletterId, Long memberId, String unsubscribeUrl) {
-        subscribeRepository.findByMemberIdAndNewsletterId(memberId, newsletterId)
-                .ifPresentOrElse(
-                        subscribe -> subscribe.updateUnsubscribeUrl(unsubscribeUrl),
-                        () -> registerSubscribe(newsletterId, memberId, unsubscribeUrl)
-                );
+    public void upsertSubscribe(
+            Long newsletterId,
+            Long memberId,
+            String unsubscribeUrl,
+            String newsletterName,
+            String articleTitle
+    ) {
+        Subscribe subscribe = subscribeRepository.findByMemberIdAndNewsletterId(memberId, newsletterId)
+                .orElseGet(() -> registerSubscribe(newsletterId, memberId, unsubscribeUrl));
+        subscribe.updateUnsubscribeUrl(unsubscribeUrl);
+
+        if (subscribe.isUnsubscribeUrlMissing()) {
+            applicationEventPublisher.publishEvent(
+                    new UnsubscribeUrlMissingEvent(
+                            newsletterId,
+                            newsletterName,
+                            articleTitle,
+                            memberId
+                    )
+            );
+        }
     }
 
-    private void registerSubscribe(Long newsletterId, Long memberId, String unsubscribeUrl) {
+    private Subscribe registerSubscribe(Long newsletterId, Long memberId, String unsubscribeUrl) {
         Subscribe newSubscribe = Subscribe.builder()
                 .newsletterId(newsletterId)
                 .memberId(memberId)
                 .unsubscribeUrl(unsubscribeUrl)
                 .build();
-        subscribeRepository.save(newSubscribe);
 
         applicationEventPublisher.publishEvent(
                 NewsletterSubscribedEvent.of(newsletterId, memberId)
         );
+        return subscribeRepository.save(newSubscribe);
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloader.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloader.java
@@ -1,0 +1,65 @@
+package news.bombomemail.subscribe.service;
+
+import jakarta.annotation.PostConstruct;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import news.bombomemail.subscribe.repository.UnsubscribePatternRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UnsubscribePatternReloader {
+
+    private static final String URL_KEY = "parse.url-keyword";
+    private static final String TEXT_KEY = "parse.text-keywords";
+
+    private static final String DEFAULT_URL_KEYWORD = "unsubscribe";
+    private static final List<String> DEFAULT_TEXT_KEYWORDS = List.of(
+            "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
+    );
+
+    private final UnsubscribePatternRepository repository;
+    private final UnsubscribeUrlExtractor extractor;
+
+    @PostConstruct
+    public void init() {
+        reload();
+    }
+
+    @Scheduled(fixedDelayString = "PT1H")
+    public void reload() {
+        Map<String, String> patterns = repository.findAll().stream()
+                .collect(Collectors.toMap(UnsubscribePattern::getPatternKey, UnsubscribePattern::getPatternValue));
+
+        String urlKeyword = patterns.get(URL_KEY);
+        List<String> textKeywords = parseTextKeywords(patterns.get(TEXT_KEY));
+
+        if (!StringUtils.hasText(urlKeyword) || textKeywords.isEmpty()) {
+            log.warn("[UnsubscribePattern] DB에 패턴이 없어 기본값을 사용합니다.");
+            extractor.reload(DEFAULT_URL_KEYWORD, DEFAULT_TEXT_KEYWORDS);
+            return;
+        }
+
+        extractor.reload(urlKeyword, textKeywords);
+        log.info("[UnsubscribePattern] 패턴 리로드 완료 - url: {}, text: {}", urlKeyword, textKeywords);
+    }
+
+    private List<String> parseTextKeywords(String value) {
+        if (!StringUtils.hasText(value)) {
+            return List.of();
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
@@ -12,7 +12,9 @@ import news.bombomemail.article.event.ArticleArrivedEvent;
 import news.bombomemail.article.event.ArticleSource;
 import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloader;
 import news.bombomemail.email.extractor.EmailContentExtractor;
 import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
@@ -30,7 +32,7 @@ import org.springframework.test.context.event.RecordApplicationEvents;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({ArticleService.class, HtmlCleanerConfig.class})
+@Import({ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
 @RecordApplicationEvents
 class ArticleServiceTest {
 

--- a/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/service/RecentArticleServiceTest.java
@@ -9,7 +9,7 @@ import java.util.Properties;
 import news.bombomemail.article.domain.RecentArticle;
 import news.bombomemail.article.repository.RecentArticleRepository;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
-import news.bombomemail.common.TimeConfig;
+import news.bombomemail.common.config.TimeConfig;
 import news.bombomemail.email.extractor.EmailContentExtractor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
@@ -2,14 +2,26 @@ package news.bombomemail.article.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class UnsubscribeUrlExtractorTest {
 
+    private UnsubscribeUrlExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        extractor = new UnsubscribeUrlExtractor();
+        extractor.reload("unsubscribe", List.of(
+                "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
+        ));
+    }
+
     @Test
     void URL에_unsubscribe가_있으면_추출한다() {
         String html = "<a href=\"https://example.com/unsubscribe?id=123\">Unsubscribe</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/unsubscribe?id=123");
     }
 
@@ -17,7 +29,7 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_Unsubscribe이면_추출한다() {
         // theSkimm, Korean FE Article
         String html = "<a href=\"https://link.example.com/oc/abc123\">Unsubscribe or Update Your Preferences</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://link.example.com/oc/abc123");
     }
 
@@ -25,7 +37,7 @@ class UnsubscribeUrlExtractorTest {
     void span_내부에_Unsubscribe가_있으면_추출한다() {
         // Substack
         String html = "<a href=\"https://substack.com/redirect/2/eyJl...\"><span>Unsubscribe</span></a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://substack.com/redirect/2/eyJl...");
     }
 
@@ -33,7 +45,7 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_수신거부이면_추출한다() {
         // NHN Cloud, Careet
         String html = "<a href=\"http://mkt.nhncloud.com/u/NDg4...\">수신거부</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("http://mkt.nhncloud.com/u/NDg4...");
     }
 
@@ -41,7 +53,7 @@ class UnsubscribeUrlExtractorTest {
     void 대괄호로_감싼_수신거부도_추출한다() {
         // Careet
         String html = "<a href=\"https://event.stibee.com/v2/click/abc\">[수신거부]</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://event.stibee.com/v2/click/abc");
     }
 
@@ -49,38 +61,38 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_Unsubscription이면_추출한다() {
         // NHN Cloud
         String html = "<a href=\"http://mkt.nhncloud.com/u/NDg4...\">Unsubscription)</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("http://mkt.nhncloud.com/u/NDg4...");
     }
 
     @Test
     void 앵커_텍스트가_구독취소이면_추출한다() {
         String html = "<a href=\"https://example.com/cancel\">구독 취소</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/cancel");
     }
 
     @Test
     void 앵커_텍스트가_구독해지이면_추출한다() {
         String html = "<a href=\"https://example.com/cancel\">구독 해지</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/cancel");
     }
 
     @Test
     void 본문_링크에_unsubscribe가_포함되어도_오탐하지_않는다() {
         String html = "<a href=\"https://blog.example.com/email-tips\">Why unsubscribe rates matter for marketers</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html)).isNull();
+        assertThat(extractor.extract(html)).isNull();
     }
 
     @Test
     void 수신거부_URL이_없으면_null을_반환한다() {
         String html = "<a href=\"https://example.com/subscribe\">Subscribe</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html)).isNull();
+        assertThat(extractor.extract(html)).isNull();
     }
 
     @Test
     void null_입력이면_null을_반환한다() {
-        assertThat(UnsubscribeUrlExtractor.extract(null)).isNull();
+        assertThat(extractor.extract(null)).isNull();
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/common/SchedulingConfigTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/common/SchedulingConfigTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider;
+import news.bombomemail.common.config.SchedulingConfig;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;

--- a/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
@@ -14,8 +14,10 @@ import java.util.List;
 import news.bombomemail.article.domain.Article;
 import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
 import news.bombomemail.email.EmailConfig;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloader;
 import news.bombomemail.email.service.EmailService.BusinessProcessingException;
 import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
@@ -32,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({EmailService.class, EmailConfig.class, ArticleService.class, HtmlCleanerConfig.class})
+@Import({EmailService.class, EmailConfig.class, ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
 class EmailServiceTest {
 
     @Autowired

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailuresTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/PendingUnsubscribeFailuresTest.java
@@ -1,0 +1,62 @@
+package news.bombomemail.subscribe.alert;
+
+import java.util.List;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PendingUnsubscribeFailuresTest {
+
+    private PendingUnsubscribeFailures pendingFailures;
+
+    @BeforeEach
+    void setUp() {
+        pendingFailures = new PendingUnsubscribeFailures();
+    }
+
+    @Test
+    void 같은_뉴스레터는_중복_저장되지_않는다() {
+        // given
+        UnsubscribeUrlMissingEvent event1 = new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1");
+        UnsubscribeUrlMissingEvent event2 = new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 2");
+
+        // when
+        pendingFailures.record(event1);
+        pendingFailures.record(event2);
+
+        // then
+        List<UnsubscribeUrlFailure> result = pendingFailures.collectForAlert();
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).articleTitle()).isEqualTo("아티클 1");
+    }
+
+    @Test
+    void 다른_뉴스레터는_각각_저장된다() {
+        // given
+        UnsubscribeUrlMissingEvent event1 = new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1");
+        UnsubscribeUrlMissingEvent event2 = new UnsubscribeUrlMissingEvent(2L, "뉴스레터B", "아티클 2");
+
+        // when
+        pendingFailures.record(event1);
+        pendingFailures.record(event2);
+
+        // then
+        List<UnsubscribeUrlFailure> result = pendingFailures.collectForAlert();
+        assertThat(result).hasSize(2);
+    }
+
+    @Test
+    void collectForAlert_호출_후_초기화된다() {
+        // given
+        pendingFailures.record(new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1"));
+
+        // when
+        pendingFailures.collectForAlert();
+        List<UnsubscribeUrlFailure> result = pendingFailures.collectForAlert();
+
+        // then
+        assertThat(result).isEmpty();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/alert/UnsubscribeUrlAlertServiceTest.java
@@ -1,0 +1,57 @@
+package news.bombomemail.subscribe.alert;
+
+import news.bombomemail.common.DiscordWebhookNotifier;
+import news.bombomemail.subscribe.event.UnsubscribeUrlMissingEvent;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UnsubscribeUrlAlertServiceTest {
+
+    @Mock
+    private DiscordWebhookNotifier discordWebhookNotifier;
+
+    @InjectMocks
+    private UnsubscribeUrlAlertService unsubscribeUrlAlertService;
+
+    @Test
+    void 실패가_있으면_Discord_알림을_전송한다() {
+        // given
+        unsubscribeUrlAlertService.record(new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1"));
+
+        // when
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // then
+        verify(discordWebhookNotifier).sendUnsubscribeUrlMissingAlert(anyList());
+    }
+
+    @Test
+    void 실패가_없으면_Discord_알림을_전송하지_않는다() {
+        // when
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // then
+        verify(discordWebhookNotifier, never()).sendUnsubscribeUrlMissingAlert(anyList());
+    }
+
+    @Test
+    void 알림_전송_후_다시_전송하면_Discord_알림을_전송하지_않는다() {
+        // given
+        unsubscribeUrlAlertService.record(new UnsubscribeUrlMissingEvent(1L, "뉴스레터A", "아티클 1"));
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // when
+        unsubscribeUrlAlertService.sendPendingAlerts();
+
+        // then
+        verify(discordWebhookNotifier).sendUnsubscribeUrlMissingAlert(anyList()); // 정확히 1번만
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListenerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/event/SubscribeArticleArrivedListenerTest.java
@@ -44,7 +44,7 @@ class SubscribeArticleArrivedListenerTest {
         TestTransaction.end();
 
         // then
-        verify(subscribeService).upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+        verify(subscribeService).upsertSubscribe(newsletterId, memberId, unsubscribeUrl, newsletterName, articleTitle);
     }
 
     @Test

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/SubscribeServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/SubscribeServiceTest.java
@@ -28,7 +28,7 @@ class SubscribeServiceTest {
         String unsubscribeUrl = "unsubscribeUrl";
 
         // when
-        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl, "뉴스레터", "아티클");
 
         // then
         boolean exists = subscribeRepository.existsByNewsletterIdAndMemberId(newsletterId, memberId);
@@ -43,7 +43,7 @@ class SubscribeServiceTest {
         String unsubscribeUrl = "unsubscribeUrl";
 
         // when
-        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl, "뉴스레터", "아티클");
 
         // then
         Subscribe subscribe = subscribeRepository.findByMemberIdAndNewsletterId(memberId, newsletterId)
@@ -59,8 +59,8 @@ class SubscribeServiceTest {
         String unsubscribeUrl = "unsubscribeUrl";
 
         // when
-        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
-        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl, "뉴스레터", "아티클");
+        subscribeService.upsertSubscribe(newsletterId, memberId, unsubscribeUrl, "뉴스레터", "아티클");
 
         // then
         long count = subscribeRepository.findAll().stream()
@@ -76,10 +76,10 @@ class SubscribeServiceTest {
         Long memberId = 2L;
         String oldUrl = "oldUnsubscribeUrl";
         String newUrl = "newUnsubscribeUrl";
-        subscribeService.upsertSubscribe(newsletterId, memberId, oldUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, oldUrl, "뉴스레터", "아티클");
 
         // when
-        subscribeService.upsertSubscribe(newsletterId, memberId, newUrl);
+        subscribeService.upsertSubscribe(newsletterId, memberId, newUrl, "뉴스레터", "아티클");
 
         // then
         subscribeRepository.findByMemberIdAndNewsletterId(newsletterId, memberId)

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
@@ -1,0 +1,69 @@
+package news.bombomemail.subscribe.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import news.bombomemail.subscribe.repository.UnsubscribePatternRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
+class UnsubscribePatternReloaderTest {
+
+    @Autowired
+    UnsubscribePatternRepository repository;
+
+    @Autowired
+    UnsubscribePatternReloader reloader;
+
+    @Autowired
+    UnsubscribeUrlExtractor extractor;
+
+    @Test
+    void DB_패턴으로_reload후에_새_패턴으로_추출한다() {
+        // given
+        repository.save(UnsubscribePattern.builder()
+                .patternKey("parse.url-keyword")
+                .patternValue("cancel")
+                .build());
+        repository.save(UnsubscribePattern.builder()
+                .patternKey("parse.text-keywords")
+                .patternValue("cancel,취소,해지")
+                .build());
+
+        // when
+        reloader.reload();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel?id=123\">cancel</a>"))
+                    .isEqualTo("https://example.com/cancel?id=123");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel\">취소</a>"))
+                    .isEqualTo("https://example.com/cancel");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/unsubscribe\">unsubscribe</a>"))
+                    .isNull();
+        });
+    }
+
+    @Test
+    void DB가_비어있으면_기본값으로_추출한다() {
+        // when
+        reloader.reload();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/unsubscribe?id=123\">Unsubscribe</a>"))
+                    .isEqualTo("https://example.com/unsubscribe?id=123");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel\">수신거부</a>"))
+                    .isEqualTo("https://example.com/cancel");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/page\">cancel</a>"))
+                    .isNull();
+        });
+    }
+}


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
구독 취소 URL 파싱 패턴을 코드에서 DB로 외부화

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기능이 아직 안정화되지 않아 새로운 뉴스레터 패턴 대응 시마다 코드 수정 및 재배포가 필요했음. DB로 관리하면 재배포 없이 패턴을 추가/수정할 수 있음

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- UnsubscribeUrlExtractor를 static 유틸에서 Spring Bean으로 전환, AtomicReference<Pattern>으로 런타임 패턴 교체 지원
- unsubscribe_pattern 테이블의 parse.url-keyword / parse.text-keywords row를 읽어 패턴 빌드
- UnsubscribePatternReloader가 앱 시작 시(`@PostConstruct`) 및 1시간마다(`@Scheduled`) DB에서 패턴을 로드해 extractor에 반영
  - DB가 비어있을 경우 기존 하드코딩 키워드를 기본값으로 사용

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

yml로 관리할까 생각했지만, 결국 재부팅이 필요한 것은 동일합니다. 이메일 서버의 경우는 재부팅을 최대한 피하는게 낫다고 생각해서 DB를 사용하여 런타임에 수정 가능하도록 구현했습니다.
어드민 페이지에서 패턴을 수정해 실패 알림에 빠르게 대응하고, 변경 사항은 1시간 주기 스케줄러로 반영됩니다.
실패 알림은 오후 1시에 집계되고 이메일은 낮 시간대에 거의 수신되지 않으므로, 1시간 주기가 부하와 반영 속도 사이에서 적절하다고 생각했습니다.

이 구현 방식이 적절할까요?