### PR TITLE
[BOM-1121] feat: 구독 취소 url 파싱 패턴 외부 관리

### DIFF
--- a/.github/workflows/email-dev-deploy.yml
+++ b/.github/workflows/email-dev-deploy.yml
@@ -59,6 +59,8 @@ jobs:
     runs-on:
       - self-hosted
       - email
+    env:
+      MAIL_SERVER_INTERNAL_API_KEY: ${{ secrets.MAIL_SERVER_INTERNAL_API_KEY }}
     defaults:
       run:
         working-directory: backend/mail-server

--- a/backend/mail-server/docker-compose.yml
+++ b/backend/mail-server/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       INTEGRATION_MAILDIR: /maildir/new
       SPRING_PROFILES_ACTIVE: docker
       LOGGING_FILE_NAME: /logs/bombom-email.log
+      MAIL_SERVER_INTERNAL_API_KEY: ${MAIL_SERVER_INTERNAL_API_KEY:?MAIL_SERVER_INTERNAL_API_KEY is required}
     volumes:
       - /home/ec2-user/Maildir:/maildir
       - /home/ec2-user/bombom-email/logs:/logs 

--- a/backend/mail-server/src/main/java/news/bombomemail/article/service/ArticleService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/service/ArticleService.java
@@ -41,6 +41,7 @@ public class ArticleService {
     private final ApplicationEventPublisher applicationEventPublisher;
     private final NewsletterVerificationRepository newsletterVerificationRepository;
     private final HtmlTagCleaner htmlTagCleaner;
+    private final UnsubscribeUrlExtractor unsubscribeUrlExtractor;
 
     @Transactional
     public boolean save(MimeMessage message, String contents) throws MessagingException, DataAccessException {
@@ -56,7 +57,7 @@ public class ArticleService {
 
         String contentsText = htmlTagCleaner.clean(contents);
         Article article = articleRepository.save(buildArticle(message, contents, contentsText, member, newsletter));
-        String unsubscribeUrl = UnsubscribeUrlExtractor.extract(article.getContents());
+        String unsubscribeUrl = unsubscribeUrlExtractor.extract(article.getContents());
 
         applicationEventPublisher.publishEvent(ArticleArrivedEvent.of(
                         newsletter.getId(),

--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -1,41 +1,36 @@
 package news.bombomemail.article.util;
 
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class UnsubscribeUrlExtractor {
+@Component
+public class UnsubscribeUrlExtractor {
 
-    // 1단계: href URL 자체에 "unsubscribe"가 포함된 경우
-    private static final Pattern UNSUBSCRIBE_URL_PATTERN = Pattern.compile(
-            "href=\"([^\"]*unsubscribe[^\"]*)\"",
-            Pattern.CASE_INSENSITIVE
-    );
-
-    // 2단계: <a href="...">...</a> 블록 전체를 추출 (href와 내부 HTML을 함께 캡처)
     private static final Pattern ANCHOR_PATTERN = Pattern.compile(
             "<a\\s[^>]*href=\"([^\"]+)\"[^>]*>(.*?)</a>",
             Pattern.CASE_INSENSITIVE | Pattern.DOTALL
     );
 
-    // 앵커 내부의 <span> 등 중첩 태그를 제거해 순수 텍스트만 남기기 위한 패턴
     private static final Pattern INNER_TAG_PATTERN = Pattern.compile("<[^>]+>");
 
-    // 앵커 텍스트가 수신거부 키워드로 시작하는지 확인. 앞에 '[', '(' 등 브라켓이 있어도 허용 (예: "[수신거부]")
-    private static final Pattern UNSUBSCRIBE_TEXT_PATTERN = Pattern.compile(
-            "^[\\[(\\s]*(unsubscribe|unsubscription|수신\\s*거부|구독\\s*취소|구독\\s*해지)",
-            Pattern.CASE_INSENSITIVE
-    );
+    private final AtomicReference<Pattern> urlPattern = new AtomicReference<>();
+    private final AtomicReference<Pattern> textPattern = new AtomicReference<>();
 
-    public static String extract(String articleContents) {
+    public void reload(String urlKeyword, List<String> textKeywords) {
+        urlPattern.set(Pattern.compile(buildUrlRegex(urlKeyword), Pattern.CASE_INSENSITIVE));
+        textPattern.set(Pattern.compile(buildTextRegex(textKeywords), Pattern.CASE_INSENSITIVE));
+    }
+
+    public String extract(String articleContents) {
         if (!StringUtils.hasText(articleContents)) {
             return null;
         }
 
-        Matcher urlMatcher = UNSUBSCRIBE_URL_PATTERN.matcher(articleContents);
+        Matcher urlMatcher = urlPattern.get().matcher(articleContents);
         if (urlMatcher.find()) {
             return urlMatcher.group(1);
         }
@@ -48,11 +43,19 @@ public final class UnsubscribeUrlExtractor {
                 continue;
             }
             String text = INNER_TAG_PATTERN.matcher(anchorBody).replaceAll("").strip();
-            if (UNSUBSCRIBE_TEXT_PATTERN.matcher(text).find()) {
+            if (textPattern.get().matcher(text).find()) {
                 return href;
             }
         }
 
         return null;
+    }
+
+    private static String buildUrlRegex(String urlKeyword) {
+        return "href=\"([^\"]*" + Pattern.quote(urlKeyword) + "[^\"]*)\"";
+    }
+
+    private static String buildTextRegex(List<String> textKeywords) {
+        return "^[\\[(\\s]*(" + String.join("|", textKeywords) + ")";
     }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -20,8 +20,8 @@ public class UnsubscribeUrlExtractor {
     private final AtomicReference<Pattern> urlPattern = new AtomicReference<>();
     private final AtomicReference<Pattern> textPattern = new AtomicReference<>();
 
-    public void reload(String urlKeyword, List<String> textKeywords) {
-        urlPattern.set(Pattern.compile(buildUrlRegex(urlKeyword), Pattern.CASE_INSENSITIVE));
+    public void reload(List<String> urlKeywords, List<String> textKeywords) {
+        urlPattern.set(Pattern.compile(buildUrlRegex(urlKeywords), Pattern.CASE_INSENSITIVE));
         textPattern.set(Pattern.compile(buildTextRegex(textKeywords), Pattern.CASE_INSENSITIVE));
     }
 
@@ -51,8 +51,12 @@ public class UnsubscribeUrlExtractor {
         return null;
     }
 
-    private static String buildUrlRegex(String urlKeyword) {
-        return "href=\"([^\"]*" + Pattern.quote(urlKeyword) + "[^\"]*)\"";
+    private static String buildUrlRegex(List<String> urlKeywords) {
+        String joinedKeywords = urlKeywords.stream()
+                .map(Pattern::quote)
+                .reduce((left, right) -> left + "|" + right)
+                .orElseThrow();
+        return "href=\"([^\"]*(?:" + joinedKeywords + ")[^\"]*)\"";
     }
 
     private static String buildTextRegex(List<String> textKeywords) {

--- a/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiKeyInterceptor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiKeyInterceptor.java
@@ -1,0 +1,40 @@
+package news.bombomemail.common.internal.api;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.server.ResponseStatusException;
+
+@Component
+@RequiredArgsConstructor
+public class InternalApiKeyInterceptor implements HandlerInterceptor {
+
+    public static final String INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key";
+
+    @Value("${internal.api.key:}")
+    private String configuredApiKey;
+
+    @Override
+    public boolean preHandle(
+            @NonNull HttpServletRequest request,
+            @NonNull HttpServletResponse response,
+            @NonNull Object handler
+    ) {
+        if (!StringUtils.hasText(configuredApiKey)) {
+            throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE, "내부 API 키가 설정되지 않았습니다.");
+        }
+
+        String requestApiKey = request.getHeader(INTERNAL_API_KEY_HEADER);
+        if (!configuredApiKey.equals(requestApiKey)) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "내부 API 키가 올바르지 않습니다.");
+        }
+
+        return true;
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiKeyInterceptor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiKeyInterceptor.java
@@ -17,7 +17,7 @@ public class InternalApiKeyInterceptor implements HandlerInterceptor {
 
     public static final String INTERNAL_API_KEY_HEADER = "X-Internal-Api-Key";
 
-    @Value("${internal.api.key:}")
+    @Value("${MAIL_SERVER_INTERNAL_API_KEY:}")
     private String configuredApiKey;
 
     @Override

--- a/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiWebConfig.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/common/internal/api/InternalApiWebConfig.java
@@ -1,0 +1,19 @@
+package news.bombomemail.common.internal.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class InternalApiWebConfig implements WebMvcConfigurer {
+
+    private final InternalApiKeyInterceptor internalApiKeyInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(internalApiKeyInterceptor)
+                .addPathPatterns("/internal/**");
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadController.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadController.java
@@ -1,0 +1,23 @@
+package news.bombomemail.subscribe.api.internal;
+
+import lombok.RequiredArgsConstructor;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloadService;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/v1/unsubscribe-patterns")
+@RequiredArgsConstructor
+public class InternalUnsubscribePatternReloadController {
+
+    private final UnsubscribePatternReloadService unsubscribePatternReloadService;
+
+    @PostMapping("/reload")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void reload() {
+        unsubscribePatternReloadService.reload();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import news.bombomemail.common.BaseEntity;
@@ -26,4 +27,10 @@ public class UnsubscribePattern extends BaseEntity {
     @Lob
     @Column(nullable = false, columnDefinition = "TEXT")
     private String patternValue;
+
+    @Builder
+    public UnsubscribePattern(String patternKey, String patternValue) {
+        this.patternKey = patternKey;
+        this.patternValue = patternValue;
+    }
 }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
@@ -1,0 +1,29 @@
+package news.bombomemail.subscribe.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import news.bombomemail.common.BaseEntity;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UnsubscribePattern extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String patternKey;
+
+    @Lob
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String patternValue;
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/domain/UnsubscribePattern.java
@@ -6,6 +6,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,13 +17,14 @@ import news.bombomemail.common.BaseEntity;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = "pattern_key"))
 public class UnsubscribePattern extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true, length = 50)
+    @Column(nullable = false, length = 30)
     private String patternKey;
 
     @Lob

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/repository/UnsubscribePatternRepository.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/repository/UnsubscribePatternRepository.java
@@ -1,0 +1,7 @@
+package news.bombomemail.subscribe.repository;
+
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UnsubscribePatternRepository extends JpaRepository<UnsubscribePattern, Long> {
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadScheduler.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadScheduler.java
@@ -1,0 +1,20 @@
+package news.bombomemail.subscribe.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UnsubscribePatternReloadScheduler {
+
+    private static final String TIME_ZONE = "Asia/Seoul";
+    private static final String DAILY_4AM_CRON = "0 0 4 * * *";
+
+    private final UnsubscribePatternReloadService unsubscribePatternReloadService;
+
+    @Scheduled(cron = DAILY_4AM_CRON, zone = TIME_ZONE)
+    public void reload() {
+        unsubscribePatternReloadService.reload();
+    }
+}

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadService.java
@@ -18,11 +18,11 @@ import org.springframework.util.StringUtils;
 @RequiredArgsConstructor
 public class UnsubscribePatternReloadService {
 
-    private static final String URL_KEY = "parse.url-keyword";
+    private static final String URL_KEYS = "parse.url-keywords";
     private static final String TEXT_KEY = "parse.text-keywords";
 
     private static final String PATTERN_REGEX = ",";
-    private static final String DEFAULT_URL_KEYWORD = "unsubscribe";
+    private static final List<String> DEFAULT_URL_KEYWORDS = List.of("unsubscribe");
     private static final List<String> DEFAULT_TEXT_KEYWORDS = List.of(
             "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
     );
@@ -39,20 +39,20 @@ public class UnsubscribePatternReloadService {
         Map<String, String> patterns = unsubscribePatternRepository.findAll().stream()
                 .collect(Collectors.toMap(UnsubscribePattern::getPatternKey, UnsubscribePattern::getPatternValue));
 
-        String urlKeyword = patterns.get(URL_KEY);
-        List<String> textKeywords = parseTextKeywords(patterns.get(TEXT_KEY));
+        List<String> urlKeywords = parseKeywords(patterns.get(URL_KEYS));
+        List<String> textKeywords = parseKeywords(patterns.get(TEXT_KEY));
 
-        if (!StringUtils.hasText(urlKeyword) || textKeywords.isEmpty()) {
+        if (urlKeywords.isEmpty() || textKeywords.isEmpty()) {
             log.warn("[UnsubscribePattern] DB에 패턴이 없어 기본값을 사용합니다.");
-            unsubscribeUrlExtractor.reload(DEFAULT_URL_KEYWORD, DEFAULT_TEXT_KEYWORDS);
+            unsubscribeUrlExtractor.reload(DEFAULT_URL_KEYWORDS, DEFAULT_TEXT_KEYWORDS);
             return;
         }
 
-        unsubscribeUrlExtractor.reload(urlKeyword, textKeywords);
-        log.info("[UnsubscribePattern] 패턴 리로드 완료 - url: {}, text: {}", urlKeyword, textKeywords);
+        unsubscribeUrlExtractor.reload(urlKeywords, textKeywords);
+        log.info("[UnsubscribePattern] 패턴 리로드 완료 - url: {}, text: {}", urlKeywords, textKeywords);
     }
 
-    private List<String> parseTextKeywords(String value) {
+    private List<String> parseKeywords(String value) {
         if (!StringUtils.hasText(value)) {
             return List.of();
         }

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadService.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloadService.java
@@ -10,32 +10,31 @@ import lombok.extern.slf4j.Slf4j;
 import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.subscribe.domain.UnsubscribePattern;
 import news.bombomemail.subscribe.repository.UnsubscribePatternRepository;
-import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 @Slf4j
-@Component
+@Service
 @RequiredArgsConstructor
-public class UnsubscribePatternReloader {
+public class UnsubscribePatternReloadService {
 
     private static final String URL_KEY = "parse.url-keyword";
     private static final String TEXT_KEY = "parse.text-keywords";
 
+    private static final String PATTERN_REGEX = ",";
     private static final String DEFAULT_URL_KEYWORD = "unsubscribe";
     private static final List<String> DEFAULT_TEXT_KEYWORDS = List.of(
             "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
     );
 
     private final UnsubscribePatternRepository unsubscribePatternRepository;
-    private final UnsubscribeUrlExtractor extractor;
+    private final UnsubscribeUrlExtractor unsubscribeUrlExtractor;
 
     @PostConstruct
     public void init() {
         reload();
     }
 
-    @Scheduled(fixedDelayString = "PT1H")
     public void reload() {
         Map<String, String> patterns = unsubscribePatternRepository.findAll().stream()
                 .collect(Collectors.toMap(UnsubscribePattern::getPatternKey, UnsubscribePattern::getPatternValue));
@@ -45,11 +44,11 @@ public class UnsubscribePatternReloader {
 
         if (!StringUtils.hasText(urlKeyword) || textKeywords.isEmpty()) {
             log.warn("[UnsubscribePattern] DB에 패턴이 없어 기본값을 사용합니다.");
-            extractor.reload(DEFAULT_URL_KEYWORD, DEFAULT_TEXT_KEYWORDS);
+            unsubscribeUrlExtractor.reload(DEFAULT_URL_KEYWORD, DEFAULT_TEXT_KEYWORDS);
             return;
         }
 
-        extractor.reload(urlKeyword, textKeywords);
+        unsubscribeUrlExtractor.reload(urlKeyword, textKeywords);
         log.info("[UnsubscribePattern] 패턴 리로드 완료 - url: {}, text: {}", urlKeyword, textKeywords);
     }
 
@@ -57,7 +56,7 @@ public class UnsubscribePatternReloader {
         if (!StringUtils.hasText(value)) {
             return List.of();
         }
-        return Arrays.stream(value.split(","))
+        return Arrays.stream(value.split(PATTERN_REGEX))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .toList();

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloader.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloader.java
@@ -27,7 +27,7 @@ public class UnsubscribePatternReloader {
             "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
     );
 
-    private final UnsubscribePatternRepository repository;
+    private final UnsubscribePatternRepository unsubscribePatternRepository;
     private final UnsubscribeUrlExtractor extractor;
 
     @PostConstruct
@@ -37,7 +37,7 @@ public class UnsubscribePatternReloader {
 
     @Scheduled(fixedDelayString = "PT1H")
     public void reload() {
-        Map<String, String> patterns = repository.findAll().stream()
+        Map<String, String> patterns = unsubscribePatternRepository.findAll().stream()
                 .collect(Collectors.toMap(UnsubscribePattern::getPatternKey, UnsubscribePattern::getPatternValue));
 
         String urlKeyword = patterns.get(URL_KEY);

--- a/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloader.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/subscribe/service/UnsubscribePatternReloader.java
@@ -1,0 +1,65 @@
+package news.bombomemail.subscribe.service;
+
+import jakarta.annotation.PostConstruct;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import news.bombomemail.subscribe.repository.UnsubscribePatternRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UnsubscribePatternReloader {
+
+    private static final String URL_KEY = "parse.url-keyword";
+    private static final String TEXT_KEY = "parse.text-keywords";
+
+    private static final String DEFAULT_URL_KEYWORD = "unsubscribe";
+    private static final List<String> DEFAULT_TEXT_KEYWORDS = List.of(
+            "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
+    );
+
+    private final UnsubscribePatternRepository repository;
+    private final UnsubscribeUrlExtractor extractor;
+
+    @PostConstruct
+    public void init() {
+        reload();
+    }
+
+    @Scheduled(fixedDelayString = "PT1H")
+    public void reload() {
+        Map<String, String> patterns = repository.findAll().stream()
+                .collect(Collectors.toMap(UnsubscribePattern::getPatternKey, UnsubscribePattern::getPatternValue));
+
+        String urlKeyword = patterns.get(URL_KEY);
+        List<String> textKeywords = parseTextKeywords(patterns.get(TEXT_KEY));
+
+        if (!StringUtils.hasText(urlKeyword) || textKeywords.isEmpty()) {
+            log.warn("[UnsubscribePattern] DB에 패턴이 없어 기본값을 사용합니다.");
+            extractor.reload(DEFAULT_URL_KEYWORD, DEFAULT_TEXT_KEYWORDS);
+            return;
+        }
+
+        extractor.reload(urlKeyword, textKeywords);
+        log.info("[UnsubscribePattern] 패턴 리로드 완료 - url: {}, text: {}", urlKeyword, textKeywords);
+    }
+
+    private List<String> parseTextKeywords(String value) {
+        if (!StringUtils.hasText(value)) {
+            return List.of();
+        }
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
@@ -12,7 +12,9 @@ import news.bombomemail.article.event.ArticleArrivedEvent;
 import news.bombomemail.article.event.ArticleSource;
 import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloader;
 import news.bombomemail.email.extractor.EmailContentExtractor;
 import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
@@ -30,7 +32,7 @@ import org.springframework.test.context.event.RecordApplicationEvents;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({ArticleService.class, HtmlCleanerConfig.class})
+@Import({ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
 @RecordApplicationEvents
 class ArticleServiceTest {
 

--- a/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/ArticleServiceTest.java
@@ -14,7 +14,7 @@ import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
 import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
-import news.bombomemail.subscribe.service.UnsubscribePatternReloader;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloadService;
 import news.bombomemail.email.extractor.EmailContentExtractor;
 import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
@@ -32,7 +32,7 @@ import org.springframework.test.context.event.RecordApplicationEvents;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
+@Import({ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloadService.class})
 @RecordApplicationEvents
 class ArticleServiceTest {
 

--- a/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
@@ -2,14 +2,26 @@ package news.bombomemail.article.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class UnsubscribeUrlExtractorTest {
 
+    private UnsubscribeUrlExtractor extractor;
+
+    @BeforeEach
+    void setUp() {
+        extractor = new UnsubscribeUrlExtractor();
+        extractor.reload("unsubscribe", List.of(
+                "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
+        ));
+    }
+
     @Test
     void URL에_unsubscribe가_있으면_추출한다() {
         String html = "<a href=\"https://example.com/unsubscribe?id=123\">Unsubscribe</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/unsubscribe?id=123");
     }
 
@@ -17,7 +29,7 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_Unsubscribe이면_추출한다() {
         // theSkimm, Korean FE Article
         String html = "<a href=\"https://link.example.com/oc/abc123\">Unsubscribe or Update Your Preferences</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://link.example.com/oc/abc123");
     }
 
@@ -25,7 +37,7 @@ class UnsubscribeUrlExtractorTest {
     void span_내부에_Unsubscribe가_있으면_추출한다() {
         // Substack
         String html = "<a href=\"https://substack.com/redirect/2/eyJl...\"><span>Unsubscribe</span></a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://substack.com/redirect/2/eyJl...");
     }
 
@@ -33,7 +45,7 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_수신거부이면_추출한다() {
         // NHN Cloud, Careet
         String html = "<a href=\"http://mkt.nhncloud.com/u/NDg4...\">수신거부</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("http://mkt.nhncloud.com/u/NDg4...");
     }
 
@@ -41,7 +53,7 @@ class UnsubscribeUrlExtractorTest {
     void 대괄호로_감싼_수신거부도_추출한다() {
         // Careet
         String html = "<a href=\"https://event.stibee.com/v2/click/abc\">[수신거부]</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://event.stibee.com/v2/click/abc");
     }
 
@@ -49,38 +61,38 @@ class UnsubscribeUrlExtractorTest {
     void 앵커_텍스트가_Unsubscription이면_추출한다() {
         // NHN Cloud
         String html = "<a href=\"http://mkt.nhncloud.com/u/NDg4...\">Unsubscription)</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("http://mkt.nhncloud.com/u/NDg4...");
     }
 
     @Test
     void 앵커_텍스트가_구독취소이면_추출한다() {
         String html = "<a href=\"https://example.com/cancel\">구독 취소</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/cancel");
     }
 
     @Test
     void 앵커_텍스트가_구독해지이면_추출한다() {
         String html = "<a href=\"https://example.com/cancel\">구독 해지</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html))
+        assertThat(extractor.extract(html))
                 .isEqualTo("https://example.com/cancel");
     }
 
     @Test
     void 본문_링크에_unsubscribe가_포함되어도_오탐하지_않는다() {
         String html = "<a href=\"https://blog.example.com/email-tips\">Why unsubscribe rates matter for marketers</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html)).isNull();
+        assertThat(extractor.extract(html)).isNull();
     }
 
     @Test
     void 수신거부_URL이_없으면_null을_반환한다() {
         String html = "<a href=\"https://example.com/subscribe\">Subscribe</a>";
-        assertThat(UnsubscribeUrlExtractor.extract(html)).isNull();
+        assertThat(extractor.extract(html)).isNull();
     }
 
     @Test
     void null_입력이면_null을_반환한다() {
-        assertThat(UnsubscribeUrlExtractor.extract(null)).isNull();
+        assertThat(extractor.extract(null)).isNull();
     }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
@@ -13,9 +13,20 @@ class UnsubscribeUrlExtractorTest {
     @BeforeEach
     void setUp() {
         extractor = new UnsubscribeUrlExtractor();
-        extractor.reload("unsubscribe", List.of(
+        extractor.reload(List.of("unsubscribe"), List.of(
                 "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
         ));
+    }
+
+    @Test
+    void URL에_여러_키워드중_하나가_있으면_추출한다() {
+        extractor.reload(List.of("unsubscribe", "cancel", "optout"), List.of(
+                "unsubscribe", "unsubscription", "수신\\s*거부", "구독\\s*취소", "구독\\s*해지"
+        ));
+
+        String html = "<a href=\"https://example.com/cancel?id=123\">Manage</a>";
+        assertThat(extractor.extract(html))
+                .isEqualTo("https://example.com/cancel?id=123");
     }
 
     @Test

--- a/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
@@ -17,7 +17,7 @@ import news.bombomemail.article.service.ArticleService;
 import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
 import news.bombomemail.email.EmailConfig;
-import news.bombomemail.subscribe.service.UnsubscribePatternReloader;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloadService;
 import news.bombomemail.email.service.EmailService.BusinessProcessingException;
 import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
@@ -34,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({EmailService.class, EmailConfig.class, ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
+@Import({EmailService.class, EmailConfig.class, ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloadService.class})
 class EmailServiceTest {
 
     @Autowired

--- a/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/email/service/EmailServiceTest.java
@@ -14,8 +14,10 @@ import java.util.List;
 import news.bombomemail.article.domain.Article;
 import news.bombomemail.article.repository.ArticleRepository;
 import news.bombomemail.article.service.ArticleService;
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
 import news.bombomemail.article.util.html.HtmlCleanerConfig;
 import news.bombomemail.email.EmailConfig;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloader;
 import news.bombomemail.email.service.EmailService.BusinessProcessingException;
 import news.bombomemail.member.domain.Gender;
 import news.bombomemail.member.domain.Member;
@@ -32,7 +34,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({EmailService.class, EmailConfig.class, ArticleService.class, HtmlCleanerConfig.class})
+@Import({EmailService.class, EmailConfig.class, ArticleService.class, HtmlCleanerConfig.class, UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
 class EmailServiceTest {
 
     @Autowired

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadControllerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadControllerTest.java
@@ -1,0 +1,61 @@
+package news.bombomemail.subscribe.api.internal;
+
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import news.bombomemail.common.internal.api.InternalApiKeyInterceptor;
+import news.bombomemail.common.internal.api.InternalApiWebConfig;
+import news.bombomemail.subscribe.service.UnsubscribePatternReloadService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = InternalUnsubscribePatternReloadController.class)
+@ContextConfiguration(classes = InternalUnsubscribePatternReloadControllerTest.TestApplication.class)
+@Import({InternalApiWebConfig.class, InternalApiKeyInterceptor.class})
+@TestPropertySource(properties = "internal.api.key=test-secret")
+class InternalUnsubscribePatternReloadControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private UnsubscribePatternReloadService unsubscribePatternReloadService;
+
+    @Test
+    void 올바른_internal_api_key로_리로드를_호출한다() throws Exception {
+        mockMvc.perform(post("/internal/v1/unsubscribe-patterns/reload")
+                        .header(InternalApiKeyInterceptor.INTERNAL_API_KEY_HEADER, "test-secret"))
+                .andExpect(status().isNoContent());
+
+        verify(unsubscribePatternReloadService).reload();
+    }
+
+    @Test
+    void internal_api_key가_없으면_unauthorized를_반환한다() throws Exception {
+        mockMvc.perform(post("/internal/v1/unsubscribe-patterns/reload"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void 잘못된_internal_api_key면_unauthorized를_반환한다() throws Exception {
+        mockMvc.perform(post("/internal/v1/unsubscribe-patterns/reload")
+                        .header(InternalApiKeyInterceptor.INTERNAL_API_KEY_HEADER, "wrong-key"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @SpringBootConfiguration
+    @EnableAutoConfiguration
+    @ComponentScan(basePackageClasses = InternalUnsubscribePatternReloadController.class)
+    static class TestApplication {
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadControllerTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/api/internal/InternalUnsubscribePatternReloadControllerTest.java
@@ -22,7 +22,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(controllers = InternalUnsubscribePatternReloadController.class)
 @ContextConfiguration(classes = InternalUnsubscribePatternReloadControllerTest.TestApplication.class)
 @Import({InternalApiWebConfig.class, InternalApiKeyInterceptor.class})
-@TestPropertySource(properties = "internal.api.key=test-secret")
+@TestPropertySource(properties = "MAIL_SERVER_INTERNAL_API_KEY=test-secret")
 class InternalUnsubscribePatternReloadControllerTest {
 
     @Autowired

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
@@ -1,0 +1,69 @@
+package news.bombomemail.subscribe.service;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import news.bombomemail.article.util.UnsubscribeUrlExtractor;
+import news.bombomemail.subscribe.domain.UnsubscribePattern;
+import news.bombomemail.subscribe.repository.UnsubscribePatternRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
+class UnsubscribePatternReloaderTest {
+
+    @Autowired
+    UnsubscribePatternRepository repository;
+
+    @Autowired
+    UnsubscribePatternReloader reloader;
+
+    @Autowired
+    UnsubscribeUrlExtractor extractor;
+
+    @Test
+    void DB_패턴으로_reload후에_새_패턴으로_추출한다() {
+        // given
+        repository.save(UnsubscribePattern.builder()
+                .patternKey("parse.url-keyword")
+                .patternValue("cancel")
+                .build());
+        repository.save(UnsubscribePattern.builder()
+                .patternKey("parse.text-keywords")
+                .patternValue("cancel,취소,해지")
+                .build());
+
+        // when
+        reloader.reload();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel?id=123\">cancel</a>"))
+                    .isEqualTo("https://example.com/cancel?id=123");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel\">취소</a>"))
+                    .isEqualTo("https://example.com/cancel");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/unsubscribe\">unsubscribe</a>"))
+                    .isNull();
+        });
+    }
+
+    @Test
+    void DB가_비어있으면_기본값으로_추출한다() {
+        // when
+        reloader.reload();
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/unsubscribe?id=123\">Unsubscribe</a>"))
+                    .isEqualTo("https://example.com/unsubscribe?id=123");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel\">수신거부</a>"))
+                    .isEqualTo("https://example.com/cancel");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/page\">cancel</a>"))
+                    .isNull();
+        });
+    }
+}

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
@@ -13,14 +13,14 @@ import org.springframework.test.context.ActiveProfiles;
 
 @DataJpaTest
 @ActiveProfiles("test")
-@Import({UnsubscribeUrlExtractor.class, UnsubscribePatternReloader.class})
+@Import({UnsubscribeUrlExtractor.class, UnsubscribePatternReloadService.class})
 class UnsubscribePatternReloaderTest {
 
     @Autowired
     UnsubscribePatternRepository repository;
 
     @Autowired
-    UnsubscribePatternReloader reloader;
+    UnsubscribePatternReloadService reloadService;
 
     @Autowired
     UnsubscribeUrlExtractor extractor;
@@ -38,7 +38,7 @@ class UnsubscribePatternReloaderTest {
                 .build());
 
         // when
-        reloader.reload();
+        reloadService.reload();
 
         // then
         assertSoftly(softly -> {
@@ -54,7 +54,7 @@ class UnsubscribePatternReloaderTest {
     @Test
     void DB가_비어있으면_기본값으로_추출한다() {
         // when
-        reloader.reload();
+        reloadService.reload();
 
         // then
         assertSoftly(softly -> {

--- a/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/subscribe/service/UnsubscribePatternReloaderTest.java
@@ -29,8 +29,8 @@ class UnsubscribePatternReloaderTest {
     void DB_패턴으로_reload후에_새_패턴으로_추출한다() {
         // given
         repository.save(UnsubscribePattern.builder()
-                .patternKey("parse.url-keyword")
-                .patternValue("cancel")
+                .patternKey("parse.url-keywords")
+                .patternValue("cancel,optout")
                 .build());
         repository.save(UnsubscribePattern.builder()
                 .patternKey("parse.text-keywords")
@@ -44,6 +44,8 @@ class UnsubscribePatternReloaderTest {
         assertSoftly(softly -> {
             softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel?id=123\">cancel</a>"))
                     .isEqualTo("https://example.com/cancel?id=123");
+            softly.assertThat(extractor.extract("<a href=\"https://example.com/optout?id=123\">manage</a>"))
+                    .isEqualTo("https://example.com/optout?id=123");
             softly.assertThat(extractor.extract("<a href=\"https://example.com/cancel\">취소</a>"))
                     .isEqualTo("https://example.com/cancel");
             softly.assertThat(extractor.extract("<a href=\"https://example.com/unsubscribe\">unsubscribe</a>"))


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
구독 취소 URL 파싱 패턴을 코드에서 DB로 외부화

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기능이 아직 안정화되지 않아 새로운 뉴스레터 패턴 대응 시마다 코드 수정 및 재배포가 필요했음. DB로 관리하면 재배포 없이 패턴을 추가/수정할 수 있음

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- UnsubscribeUrlExtractor를 static 유틸에서 Spring Bean으로 전환, AtomicReference<Pattern>으로 런타임 패턴 교체 지원
- unsubscribe_pattern 테이블의 parse.url-keyword / parse.text-keywords row를 읽어 패턴 빌드
- UnsubscribePatternReloader가 앱 시작 시(`@PostConstruct`) 및 1시간마다(`@Scheduled`) DB에서 패턴을 로드해 extractor에 반영
  - DB가 비어있을 경우 기존 하드코딩 키워드를 기본값으로 사용

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

yml로 관리할까 생각했지만, 결국 재부팅이 필요한 것은 동일합니다. 이메일 서버의 경우는 재부팅을 최대한 피하는게 낫다고 생각해서 DB를 사용하여 런타임에 수정 가능하도록 구현했습니다.
어드민 페이지에서 패턴을 수정해 실패 알림에 빠르게 대응하고, 변경 사항은 1시간 주기 스케줄러로 반영됩니다.
실패 알림은 오후 1시에 집계되고 이메일은 낮 시간대에 거의 수신되지 않으므로, 1시간 주기가 부하와 반영 속도 사이에서 적절하다고 생각했습니다.

이 구현 방식이 적절할까요?