### PR TITLE
[BOM-1123] chore: 스프링 부트 패치 버전 업데이트 및 일부 의존성 불일치 버전 교정

### DIFF
--- a/backend/bom-bom-server/build.gradle.kts
+++ b/backend/bom-bom-server/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
 dependencyManagement {
     imports {
         mavenBom("org.testcontainers:testcontainers-bom:2.0.3")
+        mavenBom("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.26.1-alpha")
     }
 }
 
@@ -87,7 +88,6 @@ dependencies {
     implementation("net.javacrumbs.shedlock:shedlock-provider-jdbc-template:6.9.2")
 
     //otel
-    implementation(platform("io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha:2.26.1-alpha"))
     implementation("io.opentelemetry.instrumentation:opentelemetry-instrumentation-annotations")
     implementation("io.opentelemetry.instrumentation:opentelemetry-logback-appender-1.0")
 

--- a/backend/bom-bom-server/build.gradle.kts
+++ b/backend/bom-bom-server/build.gradle.kts
@@ -61,8 +61,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.testcontainers:testcontainers")
-    testImplementation("org.testcontainers:mysql")
-    testImplementation("org.testcontainers:junit-jupiter")
+    testImplementation("org.testcontainers:testcontainers-mysql")
+    testImplementation("org.testcontainers:testcontainers-junit-jupiter")
     testImplementation("org.springframework.boot:spring-boot-testcontainers")
 
     // db

--- a/backend/bom-bom-server/build.gradle.kts
+++ b/backend/bom-bom-server/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     java
-    id("org.springframework.boot") version "3.5.3"
+    id("org.springframework.boot") version "3.5.14"
     id("io.spring.dependency-management") version "1.1.7"
 }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/support/TestcontainerConfig.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/support/TestcontainerConfig.java
@@ -1,17 +1,17 @@
 package me.bombom.support;
 
 import org.springframework.boot.test.context.TestConfiguration;
-import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.mysql.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @TestConfiguration
 public class TestcontainerConfig {
 
     private static final String MYSQL_IMAGE = "mysql:8.4.5";
-    private static final MySQLContainer<?> MYSQL_CONTAINER;
+    private static final MySQLContainer MYSQL_CONTAINER;
 
     static {
-        MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse(MYSQL_IMAGE));
+        MYSQL_CONTAINER = new MySQLContainer(DockerImageName.parse(MYSQL_IMAGE));
         MYSQL_CONTAINER.start();
 
         System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl());


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- Spring Boot 패치 버전을 `3.5.3`에서 `3.5.14`로 업데이트했습니다.
- Testcontainers `2.0.3` BOM에 맞춰 MySQL/JUnit Jupiter 모듈 좌표를 2.x 방식으로 정렬했습니다.
  - `org.testcontainers:mysql` -> `org.testcontainers:testcontainers-mysql`
  - `org.testcontainers:junit-jupiter` -> `org.testcontainers:testcontainers-junit-jupiter`
  - Testcontainers 2.x API에 맞춰 `MySQLContainer` import와 타입 선언을 변경했습니다.
- OpenTelemetry BOM을 `dependencyManagement.imports`로 옮겨 OTel 계열 런타임 버전이 Spring Boot 관리 버전으로 내려가지 않도록 정렬했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
### 1. Spring Boot 패치 버전 업데이트한 이유
<details>
<summary>Spring Boot 패치 버전 업데이트한 이유</summary>
현재 약 7개월간 패치버전을 업데이트 하지 않았습니다.  
다행히 큰 사고 없이 잘 운영되었습니다. 

Spring Boot 및 Spring Security 보안 패치가 누적되어 있어, 알려진 취약 버전을 계속 유지할 이유가 없기 때문에 패치 버전을 업데이트했습니다.
현재 서버는 Actuator, Spring Security, OAuth2 검증, embedded Tomcat을 실제로 사용하고 있어 단순 버전 최신화가 아니라 인증/관측/HTTP 서버 계층의 보안 패치를 반영하는 의미가 있습니다.

현재 코드와 설정만으로 각 CVE의 exploit 조건이 모두 충족된다고 단정할 수는 없지만, 패치 버전을 장기간 유지하지 않으면 알려진 취약 버전에 머무르게 됩니다. 따라서 운영 안정성과 보안 기준을 맞추기 위해 Spring Boot를 `3.5.14`로 업데이트했습니다.

참고: https://spring.io/security
</details>

### 기타

- Testcontainers는 BOM만 2.x인데 일부 모듈이 1.x 좌표로 남아 있으면 core와 module 버전이 섞일 수 있습니다.
- `opentelemetry-logback-appender-1.0:2.26.1-alpha`가 요구하는 OTel API 라인과 실제 런타임 `opentelemetry-api` 버전이 어긋나는 문제를 방지하기 위함입니다.
  - 쉽게 말해 이전에는 버전이 짬뽕이라 충돌 위험이 존재했음 따라서 이번에 통일 시킴


<details>
<summary>OpenTelemetry 의존성을 별도로 정렬한 이유</summary>

현재 서버는 `opentelemetry-logback-appender-1.0:2.26.1-alpha`를 운영 로그 수집 경로에서 사용하고 있습니다.  
이 appender는 OpenTelemetry `1.60.1` 계열 API를 기준으로 동작하지만, Spring Boot 관리 버전을 그대로 따르면 `opentelemetry-api`가 `1.49.0`으로 내려가 버전 불일치가 발생합니다.

Spring Boot dependency management를 일부 벗어나는 리스크는 있습니다.  
하지만 appender/instrumentation은 `2.26.1-alpha`인데 런타임 OTel API만 낮은 버전을 쓰는 상태가 더 위험하다고 판단했습니다. 이 불일치는 컴파일에서는 드러나지 않더라도 운영 환경에서 `OpenTelemetryAppender` 초기화나 로그 전송 시점의 런타임 오류로 이어질 수 있습니다.

따라서 OTel 관련 의존성은 `opentelemetry-instrumentation-bom-alpha:2.26.1-alpha` 기준으로 정렬했습니다.  
최신 `2.27.0-alpha`로 올리지는 않고, 기존에 사용하던 `2.26.1-alpha` 라인을 유지해 변경 범위를 최소화했습니다.
</details>


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 조로 저번에 Testcontainer 설정할 때 왜 2.x 버전으로 했나요?? 지금 스프링 부트에서 관리하는 테스트 컨테이너 버전은 1.4xx이 최신입니다. 지원하는데 뭔가 문제가 있어서 한건가? 싶어서 일단 2.x버전으로 통일시켜놓았어요. 기존은 혼합된 버전 방식이라 충돌 위험이 있었습니다. 만약 2.x 버전이 필요없다면 스프링 부트가 버전관리하게 하면 좋을 것 같아요