### PR TITLE
[BOM-1127] chore: Lambda 클라이언트 인증을 IAM Role 방식으로 변경

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/LambdaClientConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/LambdaClientConfig.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.common.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.InstanceProfileCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 
@@ -16,6 +17,7 @@ public class LambdaClientConfig {
     public LambdaClient lambdaClient() {
         return LambdaClient.builder()
                 .region(Region.of(region))
+                .credentialsProvider(InstanceProfileCredentialsProvider.create())
                 .build();
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/LambdaClientConfig.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/common/config/LambdaClientConfig.java
@@ -3,8 +3,6 @@ package me.bombom.api.v1.common.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.lambda.LambdaClient;
 
@@ -14,17 +12,10 @@ public class LambdaClientConfig {
     @Value("${aws.lambda.playwright.region}")
     private String region;
 
-    @Value("${aws.lambda.playwright.access-key}")
-    private String accessKey;
-
-    @Value("${aws.lambda.playwright.secret-key}")
-    private String secretKey;
-
     @Bean(destroyMethod = "close")
     public LambdaClient lambdaClient() {
         return LambdaClient.builder()
                 .region(Region.of(region))
-                .credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
Lambda 호출 시 사용하던 정적 AWS Access Key / Secret Key 기반 인증 방식을 제거하고, EC2 Instance Profile 기반 인증 방식을 사용하도록 변경했습니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
Spring 서버가 EC2 환경에서 `playwright-unsubscribe` Lambda를 호출해야 하는데, 기존 방식은 Access Key를 설정 파일에 직접 관리해야 했습니다.

장기 자격 증명을 서버 설정에 보관하는 방식은 키 노출 및 운영 관리 측면에서 위험이 있어, EC2 Instance Profile에 연결된 IAM Role의 임시 자격 증명을 사용하는 방식으로 전환하기 위해 변경했습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- `LambdaClientConfig`에서 `access-key`, `secret-key` 설정 주입을 제거했습니다.
- `StaticCredentialsProvider`와 `AwsBasicCredentials` 사용을 제거했습니다.
- `InstanceProfileCredentialsProvider`를 명시하여 EC2 Instance Metadata Service를 통해 제공되는 임시 자격 증명만 사용하도록 변경했습니다.
- `application-prod.yml`에서 Lambda 호출용 Access Key / Secret Key 설정을 제거했습니다.

EC2 인스턴스에 `lambda:InvokeFunction` 권한이 있는 IAM Role이 연결되어 있으면, AWS SDK가 Instance Metadata Service를 통해 임시 자격 증명을 자동으로 조회하여 Lambda를 호출합니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
