### PR TITLE
[BOM-1138] feat: 구독 취소 url 파싱 앵커 직전 키워드 처리

### DIFF
--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -19,10 +19,18 @@ public class UnsubscribeUrlExtractor {
 
     private final AtomicReference<Pattern> urlPattern = new AtomicReference<>();
     private final AtomicReference<Pattern> textPattern = new AtomicReference<>();
+    private final AtomicReference<Pattern> adjacentTextPattern = new AtomicReference<>();
 
     public void reload(List<String> urlKeywords, List<String> textKeywords) {
         urlPattern.set(Pattern.compile(buildUrlRegex(urlKeywords), Pattern.CASE_INSENSITIVE));
-        textPattern.set(Pattern.compile(buildTextRegex(textKeywords), Pattern.CASE_INSENSITIVE));
+        String textKeywordGroup = String.join("|", textKeywords);
+        textPattern.set(Pattern.compile("^[\\[(\\s]*(" + textKeywordGroup + ")", Pattern.CASE_INSENSITIVE));
+        adjacentTextPattern.set(
+                Pattern.compile(
+                        "(?:" + textKeywordGroup + ")\\s{0,3}<a\\s[^>]*href=\"([^\"]+)\"",
+                        Pattern.CASE_INSENSITIVE
+                )
+        );
     }
 
     public String extract(String articleContents) {
@@ -48,6 +56,11 @@ public class UnsubscribeUrlExtractor {
             }
         }
 
+        Matcher adjacentMatcher = adjacentTextPattern.get().matcher(articleContents);
+        if (adjacentMatcher.find()) {
+            return adjacentMatcher.group(1);
+        }
+
         return null;
     }
 
@@ -59,7 +72,4 @@ public class UnsubscribeUrlExtractor {
         return "href=\"([^\"]*(?:" + joinedKeywords + ")[^\"]*)\"";
     }
 
-    private static String buildTextRegex(List<String> textKeywords) {
-        return "^[\\[(\\s]*(" + String.join("|", textKeywords) + ")";
-    }
 }

--- a/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
@@ -91,6 +91,27 @@ class UnsubscribeUrlExtractorTest {
     }
 
     @Test
+    void 앵커_직전_텍스트에_unsubscribe_키워드가_있으면_추출한다() {
+        // beehiiv: "Update your email preferences or unsubscribe <a href="...">here</a>"
+        String html = "<p>Update your email preferences or unsubscribe <a href=\"https://link.mail.beehiiv.com/v1/c/abc\">here</a></p>";
+        assertThat(extractor.extract(html))
+                .isEqualTo("https://link.mail.beehiiv.com/v1/c/abc");
+    }
+
+    @Test
+    void 앵커_직전_텍스트에_수신거부_키워드가_있으면_추출한다() {
+        String html = "<p>수신거부 <a href=\"https://example.com/u/abc\">여기</a></p>";
+        assertThat(extractor.extract(html))
+                .isEqualTo("https://example.com/u/abc");
+    }
+
+    @Test
+    void 앵커_직전에_unsubscribe가_있어도_단어_사이라면_추출하지_않는다() {
+        String html = "<p>unsubscribe rates matter</p><a href=\"https://blog.example.com/tips\">read more</a>";
+        assertThat(extractor.extract(html)).isNull();
+    }
+
+    @Test
     void 본문_링크에_unsubscribe가_포함되어도_오탐하지_않는다() {
         String html = "<a href=\"https://blog.example.com/email-tips\">Why unsubscribe rates matter for marketers</a>";
         assertThat(extractor.extract(html)).isNull();

--- a/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
@@ -99,6 +99,18 @@ class UnsubscribeUrlExtractorTest {
     }
 
     @Test
+    void AI_Breakfast_실제_HTML에서_unsubscribe_url을_추출한다() {
+        String html = "<tbody><tr><td align=\"center\" valign=\"top\">"
+                + "<p style=\"font-family:'Arial',Helvetica,sans-serif;color:#222222!important;\">"
+                + " Update your email preferences or unsubscribe "
+                + "<a class=\"link\" href=\"https://link.mail.beehiiv.com/v1/c/fake%2Ftoken%0Aabc%3D%3D%0A/00000000\" "
+                + "style=\"text-decoration:underline;text-decoration-color:#222222!important;color:#222222!important;\">"
+                + "here</a></p></td></tr></tbody>";
+        assertThat(extractor.extract(html))
+                .isEqualTo("https://link.mail.beehiiv.com/v1/c/fake%2Ftoken%0Aabc%3D%3D%0A/00000000");
+    }
+
+    @Test
     void 앵커_직전_텍스트에_수신거부_키워드가_있으면_추출한다() {
         String html = "<p>수신거부 <a href=\"https://example.com/u/abc\">여기</a></p>";
         assertThat(extractor.extract(html))


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
구독 취소 url 파싱 시, 앵커 본문이 아닌 앵커 직전 텍스트에 키워드가 있는 경우도 처리

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

`AI Breakfast`는 아래처럼 unsubscribe 키워드를 앵커 본문이 아닌 앵커 직전 텍스트에 두고 앵커 본문은 "here" 같은 일반 단어를 사용합니다.
```html
<p>Update your email preferences or unsubscribe 
<a href="https://link.mail.beehiiv.com/...">here</a></p>
```

이와 같은 경우는 기존에 고려되지 않았기 때문에 수정이 필요했습니다.

<img width="504" height="252" alt="image" src="https://github.com/user-attachments/assets/834d706b-daa6-4f1c-9cb8-a60e15be79f5" />

<img width="533" height="132" alt="image" src="https://github.com/user-attachments/assets/421357d2-5922-49ac-ab83-61eb8fb46b21" />

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- `UnsubscribeUrlExtractor`에 fallback 패턴 `adjacentTextPattern` 추가
  - `(키워드)\s{0,3}<a\s[^>]*href="([^"]+)"` 형태로 키워드 바로 뒤에 인접한 anchor의 href를 캡처
  - `\s{0,3}`으로 공백만 허용 → "unsubscribe rates matter ... <a>" 처럼 다른 단어가 끼는 케이스는 매치되지 않아 오탐 방지
- 기존 `textPattern`과 `adjacentTextPattern`이 같은 DB 키워드(textKeywords) 를 공유하도록 textKeywordGroup join 문자열을 한 번만 만들어 재사용
- **추출 순서: ① url 키워드 매치 → ② 앵커 본문 키워드 매치 → ③ 앵커 직전 키워드 매치 (신규)**

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
