### PR TITLE
[BOM-1137] docs: 챌린지 리뷰 Mock API 명세 변경

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeReviewController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeReviewController.java
@@ -2,17 +2,21 @@ package me.bombom.api.v1.challenge.controller;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.challenge.controller.mock.ChallengeReviewMockStore;
+import me.bombom.api.v1.challenge.controller.mock.ChallengeReviewMockStore.MockReview;
 import me.bombom.api.v1.challenge.dto.request.CreateChallengeReviewRequest;
 import me.bombom.api.v1.challenge.dto.request.UpdateChallengeReviewRequest;
 import me.bombom.api.v1.challenge.dto.response.ChallengeReviewResponse;
+import me.bombom.api.v1.challenge.dto.response.MyChallengeReviewResponse;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,24 +39,27 @@ public class ChallengeReviewController implements ChallengeReviewControllerApi {
 
     @Override
     @GetMapping
-    public List<ChallengeReviewResponse> getReviews(
+    public Page<ChallengeReviewResponse> getReviews(
             @PathVariable @Positive(message = "challengeId는 1 이상의 값이어야 합니다.") Long challengeId,
-            @LoginMember Member member
+            @LoginMember Member member,
+            @PageableDefault(size = 20) Pageable pageable
     ) {
-        return mockStore.findAll();
+        return mockStore.findAllAsPage(pageable)
+                .map(mock -> ChallengeReviewMockStore.toResponse(mock, member.getNickname()));
     }
 
     // TODO: Service 도입 시 challengeId + memberId 기준 조회로 보강
     @Override
     @GetMapping("/me")
-    public ChallengeReviewResponse getMyReview(
+    public MyChallengeReviewResponse getMyReview(
             @PathVariable @Positive(message = "challengeId는 1 이상의 값이어야 합니다.") Long challengeId,
             @LoginMember Member member
     ) {
-        return mockStore.findByNickname(member.getNickname())
+        MockReview mine = mockStore.findByNickname(member.getNickname())
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeReview")
                         .addContext(ErrorContextKeys.OPERATION, "getMyReview"));
+        return ChallengeReviewMockStore.toMyResponse(mine);
     }
 
     // TODO: Service 도입 시 challengeId + memberId 기준 중복 검사로 보강
@@ -81,7 +88,7 @@ public class ChallengeReviewController implements ChallengeReviewControllerApi {
             @Valid @RequestBody UpdateChallengeReviewRequest request,
             @LoginMember Member member
     ) {
-        ChallengeReviewResponse existing = mockStore.findById(reviewId)
+        MockReview existing = mockStore.findById(reviewId)
                 .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                         .addContext(ErrorContextKeys.ENTITY_TYPE, "challengeReview")
                         .addContext(ErrorContextKeys.OPERATION, "updateReview"));

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeReviewControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/ChallengeReviewControllerApi.java
@@ -8,12 +8,14 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
-import java.util.List;
 import me.bombom.api.v1.challenge.dto.request.CreateChallengeReviewRequest;
 import me.bombom.api.v1.challenge.dto.request.UpdateChallengeReviewRequest;
 import me.bombom.api.v1.challenge.dto.response.ChallengeReviewResponse;
+import me.bombom.api.v1.challenge.dto.response.MyChallengeReviewResponse;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -22,16 +24,21 @@ public interface ChallengeReviewControllerApi {
 
     @Operation(
             summary = "열람 가능한 리뷰 목록 조회",
-            description = "로그인한 사용자가 직접 작성한 리뷰(비공개 포함)와 다른 사용자가 작성한 공개 리뷰 목록을 함께 조회합니다."
+            description = "로그인한 사용자가 직접 작성한 리뷰(비공개 포함)와 다른 사용자가 작성한 공개 리뷰 목록을 함께 조회합니다. "
+                    + "응답은 `Page<ChallengeReviewResponse>` 형식이며, 정렬은 항상 최신순으로 서버가 강제합니다. "
+                    + "`page`, `size` 쿼리 파라미터만 사용 가능하며, `sort` 파라미터는 무시됩니다. "
+                    + "각 항목의 `isMyReview` 필드로 로그인 회원 본인 작성 여부를 분기 처리할 수 있습니다. "
+                    + "(v2: 응답에 `isMyReview` 추가, 페이징 적용)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "리뷰 목록 조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
             @ApiResponse(responseCode = "404", description = "챌린지를 찾을 수 없음", content = @Content)
     })
-    List<ChallengeReviewResponse> getReviews(
+    Page<ChallengeReviewResponse> getReviews(
             @PathVariable @Positive(message = "challengeId는 1 이상의 값이어야 합니다.") Long challengeId,
-            @Parameter(hidden = true) @LoginMember Member member
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(description = "페이징 요청 (예: ?page=0&size=20). 정렬은 항상 최신순으로 서버 강제이며 sort 파라미터는 무시됩니다.") Pageable pageable
     );
 
     @Operation(
@@ -45,7 +52,7 @@ public interface ChallengeReviewControllerApi {
             @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)", content = @Content),
             @ApiResponse(responseCode = "404", description = "해당 챌린지에 작성한 리뷰가 없음", content = @Content)
     })
-    ChallengeReviewResponse getMyReview(
+    MyChallengeReviewResponse getMyReview(
             @PathVariable @Positive(message = "challengeId는 1 이상의 값이어야 합니다.") Long challengeId,
             @Parameter(hidden = true) @LoginMember Member member
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/mock/ChallengeReviewMockStore.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/controller/mock/ChallengeReviewMockStore.java
@@ -1,17 +1,24 @@
 package me.bombom.api.v1.challenge.controller.mock;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import me.bombom.api.v1.challenge.dto.response.ChallengeReviewResponse;
+import me.bombom.api.v1.challenge.dto.response.MyChallengeReviewResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 // TODO: Service 계층 도입 시 본 빈 삭제 — 실제 Repository/Service 로 대체
+// 본 Store는 viewer-independent 데이터(MockReview)만 보관하며,
+// viewer-dependent 필드(isMyReview) 변환은 호출자(Controller) 책임.
 @Component
 public class ChallengeReviewMockStore {
 
-    private final CopyOnWriteArrayList<ChallengeReviewResponse> reviews = new CopyOnWriteArrayList<>();
+    private final CopyOnWriteArrayList<MockReview> reviews = new CopyOnWriteArrayList<>();
     private final AtomicLong idSequence = new AtomicLong(0);
 
     public ChallengeReviewMockStore() {
@@ -20,12 +27,23 @@ public class ChallengeReviewMockStore {
 //        seed("밍곰", "다음에도 또 참여하고 싶어요.", false);
     }
 
-    public List<ChallengeReviewResponse> findAll() {
-        return List.copyOf(reviews);
+    // 최신순(reviewId DESC) 페이징 — Mock 한계로 createdAt 대용
+    // TODO: 실 구현 단계에서 createdAt DESC 로 전환
+    public Page<MockReview> findAllAsPage(Pageable pageable) {
+        List<MockReview> sorted = reviews.stream()
+                .sorted(Comparator.comparing(MockReview::reviewId).reversed())
+                .toList();
+
+        int total = sorted.size();
+        int from = (int) Math.min((long) pageable.getPageNumber() * pageable.getPageSize(), total);
+        int to = (int) Math.min((long) from + pageable.getPageSize(), total);
+        List<MockReview> slice = sorted.subList(from, to);
+
+        return new PageImpl<>(slice, pageable, total);
     }
 
-    public ChallengeReviewResponse save(String nickname, String comment, boolean isPrivate) {
-        ChallengeReviewResponse saved = new ChallengeReviewResponse(
+    public MockReview save(String nickname, String comment, boolean isPrivate) {
+        MockReview saved = new MockReview(
                 idSequence.incrementAndGet(),
                 nickname,
                 comment,
@@ -36,13 +54,13 @@ public class ChallengeReviewMockStore {
     }
 
     // TODO: Service 계층 도입 시 challengeId + memberId 복합 조건 조회로 대체
-    public Optional<ChallengeReviewResponse> findByNickname(String nickname) {
+    public Optional<MockReview> findByNickname(String nickname) {
         return reviews.stream()
                 .filter(review -> review.nickname().equals(nickname))
                 .findFirst();
     }
 
-    public Optional<ChallengeReviewResponse> findById(Long reviewId) {
+    public Optional<MockReview> findById(Long reviewId) {
         return reviews.stream()
                 .filter(review -> review.reviewId().equals(reviewId))
                 .findFirst();
@@ -50,9 +68,9 @@ public class ChallengeReviewMockStore {
 
     public boolean updateById(Long reviewId, String comment, boolean isPrivate) {
         for (int i = 0; i < reviews.size(); i++) {
-            ChallengeReviewResponse current = reviews.get(i);
+            MockReview current = reviews.get(i);
             if (current.reviewId().equals(reviewId)) {
-                reviews.set(i, new ChallengeReviewResponse(
+                reviews.set(i, new MockReview(
                         current.reviewId(),
                         current.nickname(),
                         comment,
@@ -64,7 +82,33 @@ public class ChallengeReviewMockStore {
         return false;
     }
 
+    // viewer-dependent 변환 — isMyReview 는 호출자가 전달한 viewerNickname 기준으로 산출
+    // TODO: 실 구현 단계에서 memberId 기준으로 정확화 (동명이인 오판 방지)
+    public static ChallengeReviewResponse toResponse(MockReview review, String viewerNickname) {
+        return new ChallengeReviewResponse(
+                review.reviewId(),
+                review.nickname(),
+                review.comment(),
+                review.isPrivate(),
+                review.nickname().equals(viewerNickname)
+        );
+    }
+
+    // 내 리뷰 단건용 — isMyReview 필드 없음 (항상 본인 리뷰이므로 의미 없음)
+    public static MyChallengeReviewResponse toMyResponse(MockReview review) {
+        return new MyChallengeReviewResponse(
+                review.reviewId(),
+                review.nickname(),
+                review.comment(),
+                review.isPrivate()
+        );
+    }
+
     private void seed(String nickname, String comment, boolean isPrivate) {
         save(nickname, comment, isPrivate);
+    }
+
+    // Mock 전용 viewer-independent 저장 표현 — 실 Service 도입 시 삭제
+    public record MockReview(Long reviewId, String nickname, String comment, boolean isPrivate) {
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MyChallengeReviewResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/dto/response/MyChallengeReviewResponse.java
@@ -4,7 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import jakarta.validation.constraints.NotNull;
 
-public record ChallengeReviewResponse(
+public record MyChallengeReviewResponse(
 
         @NotNull
         @Schema(description = "리뷰 코멘트 식별자", example = "1")
@@ -23,13 +23,6 @@ public record ChallengeReviewResponse(
                 description = "비밀글 여부 (자신이 쓴 글이 비공개인지 표시할 때 사용)",
                 example = "false"
         )
-        boolean isPrivate,
-
-        @Schema(
-                requiredMode = RequiredMode.REQUIRED,
-                description = "로그인 회원 본인이 작성한 리뷰인지 여부 (클라이언트 분기용)",
-                example = "true"
-        )
-        boolean isMyReview
+        boolean isPrivate
 ) {
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

API 명세 번경

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

회의 과정 중 명세 변경 발생

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

- 전체 리뷰 조회 API `isMyReview` 필드 추가 _(클라이언트의 본인 리뷰 분기용, 닉네임 비교 의존 제거)_
- 리뷰 목록 조회에 Pageable 적용, 정렬은 서버가 최신순으로 강제 (sort 파라미터 무시)
- 내 리뷰 단건 응답은 `isMyReview` 가 항상 true 이므로 `MyChallengeReviewResponse` 로 분리

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->

없음 (단순 API 스펙 변경 건으로 리뷰 생략)
