### PR TITLE
[BOM-1147] hotfix: 리뷰와 코멘트 동시 참여 처리 안되는 문제 해결

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListener.java
@@ -34,13 +34,16 @@ public class CreateChallengeCommentListener {
         log.info("챌린지 코멘트 작성 후 출석 처리 시작");
 
         LocalDate today = LocalDate.now(clock);
-        if(challengeTodoService.isCompletedToday(event.participantId(), today)){
+        ChallengeParticipant participant = challengeParticipantService.getParticipant(event.participantId());
+        boolean alreadyCompleted = challengeTodoService.isCompletedToday(event.participantId(), today);
+        insertCommentDone(participant, today);
+
+        if (alreadyCompleted) {
             log.info("이미 출석 처리 완료된 참여자입니다. participantId:{}", event.participantId());
             return;
         }
 
-        ChallengeParticipant participant = challengeParticipantService.getParticipant(event.participantId());
-        completeDailyTodoWithComment(participant, today);
+        challengeTodoService.completeDailyTodo(participant.getId(), today);
 
         ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
         challengeTeamService.updateTeamProgress(challengeTeam);
@@ -48,10 +51,9 @@ public class CreateChallengeCommentListener {
         log.info("챌린지 코멘트 작성 후 출석 처리 완료");
     }
 
-    private void completeDailyTodoWithComment(ChallengeParticipant participant, LocalDate today) {
+    private void insertCommentDone(ChallengeParticipant participant, LocalDate today) {
         try {
             challengeTodoService.insertCommentDone(participant, today);
-            challengeTodoService.completeDailyTodo(participant.getId(), today);
         } catch (DataIntegrityViolationException e) {
             String violated = extractConstraintName(e);
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeReviewListener.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/challenge/event/CreateChallengeReviewListener.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.challenge.event;
 
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
@@ -7,6 +8,8 @@ import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.service.ChallengeParticipantService;
 import me.bombom.api.v1.challenge.service.ChallengeTeamService;
 import me.bombom.api.v1.challenge.service.ChallengeTodoService;
+import org.hibernate.exception.ConstraintViolationException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Recover;
 import org.springframework.retry.annotation.Retryable;
@@ -19,6 +22,8 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 public class CreateChallengeReviewListener {
+
+    private static final String UK_DAILY_TODO = "uk_challenge_daily_todo";
 
     private final ChallengeTodoService challengeTodoService;
     private final ChallengeParticipantService challengeParticipantService;
@@ -35,19 +40,46 @@ public class CreateChallengeReviewListener {
         log.info("챌린지 리뷰 작성 후 출석 처리 시작 participantId={}, reviewDate={}",
                 event.participantId(), event.reviewDate());
 
-        if (challengeTodoService.isCompletedToday(event.participantId(), event.reviewDate())) {
+        ChallengeParticipant participant = challengeParticipantService.getParticipant(event.participantId());
+        boolean alreadyCompleted = challengeTodoService.isCompletedToday(event.participantId(), event.reviewDate());
+        insertReviewDone(participant, event.reviewDate());
+
+        if (alreadyCompleted) {
             log.info("이미 출석 처리 완료된 참여자입니다. participantId:{}", event.participantId());
             return;
         }
 
-        ChallengeParticipant participant = challengeParticipantService.getParticipant(event.participantId());
-        challengeTodoService.insertReviewDone(participant, event.reviewDate());
         challengeTodoService.completeDailyTodo(event.participantId(), event.reviewDate());
 
         ChallengeTeam challengeTeam = challengeTeamService.getByParticipant(participant);
         challengeTeamService.updateTeamProgress(challengeTeam);
 
         log.info("챌린지 리뷰 작성 후 출석 처리 완료 participantId={}", event.participantId());
+    }
+
+    private void insertReviewDone(ChallengeParticipant participant, LocalDate reviewDate) {
+        try {
+            challengeTodoService.insertReviewDone(participant, reviewDate);
+        } catch (DataIntegrityViolationException e) {
+            String violated = extractConstraintName(e);
+
+            if (UK_DAILY_TODO.equalsIgnoreCase(violated)) {
+                log.warn("challenge TODO가 이미 존재합니다. -> skip. participantId={}, constraint={}", participant.getId(), violated);
+                return;
+            }
+            throw e;
+        }
+    }
+
+    private String extractConstraintName(Throwable e) {
+        Throwable cur = e;
+        while (cur != null) {
+            if (cur instanceof ConstraintViolationException cve) {
+                return cve.getConstraintName();
+            }
+            cur = cur.getCause();
+        }
+        return null;
     }
 
     @Recover

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/event/CreateChallengeCommentListenerTest.java
@@ -6,6 +6,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.domain.ChallengeTodo;
@@ -167,6 +168,34 @@ class CreateChallengeCommentListenerTest {
             )).isTrue();
             softly.assertThat(updated.getCompletedDays()).isEqualTo(completedDays);
             softly.assertThat(updatedTeam.getProgress()).isEqualTo(50); // 두 번째 호출은 early return → 첫 번째 결과(50) 유지
+        });
+    }
+
+    @Test
+    void 이미_출석한_날이어도_COMMENT_일일_TODO는_저장한다() {
+        // given
+        LocalDate today = LocalDate.now(clock);
+        challengeDailyResultRepository.save(TestFixture.createChallengeDailyResult(
+                participant.getId(),
+                today,
+                ChallengeDailyStatus.COMPLETE
+        ));
+
+        // when
+        listener.on(new CreateChallengeCommentEvent(participant.getId()));
+
+        // then
+        ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        ChallengeTeam updatedTeam = challengeTeamRepository.findById(participant.getChallengeTeamId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                    participant.getId(),
+                    today,
+                    commentTodo.getId()
+            )).isTrue();
+            softly.assertThat(challengeDailyResultRepository.count()).isEqualTo(1);
+            softly.assertThat(updated.getCompletedDays()).isZero();
+            softly.assertThat(updatedTeam.getProgress()).isZero();
         });
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/event/CreateChallengeReviewListenerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/challenge/event/CreateChallengeReviewListenerTest.java
@@ -6,6 +6,7 @@ import java.time.Clock;
 import java.time.LocalDate;
 import me.bombom.api.v1.TestFixture;
 import me.bombom.api.v1.challenge.domain.Challenge;
+import me.bombom.api.v1.challenge.domain.ChallengeDailyStatus;
 import me.bombom.api.v1.challenge.domain.ChallengeParticipant;
 import me.bombom.api.v1.challenge.domain.ChallengeTeam;
 import me.bombom.api.v1.challenge.domain.ChallengeTodo;
@@ -167,6 +168,34 @@ class CreateChallengeReviewListenerTest {
             )).isTrue();
             softly.assertThat(updated.getCompletedDays()).isEqualTo(completedDays);
             softly.assertThat(updatedTeam.getProgress()).isEqualTo(50); // 두 번째 호출은 early return → 첫 번째 결과(50) 유지
+        });
+    }
+
+    @Test
+    void 이미_출석한_날이어도_REVIEW_일일_TODO는_저장한다() {
+        // given
+        LocalDate today = LocalDate.now(clock);
+        challengeDailyResultRepository.save(TestFixture.createChallengeDailyResult(
+                participant.getId(),
+                today,
+                ChallengeDailyStatus.COMPLETE
+        ));
+
+        // when
+        listener.on(new CreateChallengeReviewEvent(participant.getId(), today));
+
+        // then
+        ChallengeParticipant updated = challengeParticipantRepository.findById(participant.getId()).orElseThrow();
+        ChallengeTeam updatedTeam = challengeTeamRepository.findById(participant.getChallengeTeamId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(challengeDailyTodoRepository.existsByParticipantIdAndTodoDateAndChallengeTodoId(
+                    participant.getId(),
+                    today,
+                    reviewTodo.getId()
+            )).isTrue();
+            softly.assertThat(challengeDailyResultRepository.count()).isEqualTo(1);
+            softly.assertThat(updated.getCompletedDays()).isZero();
+            softly.assertThat(updatedTeam.getProgress()).isZero();
         });
     }
 


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
리뷰와 코멘트 동시 참여 처리 안되는 문제 해결

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
리뷰와 코멘트 둘다 참여 했음에도 둘 중 늦게 참여한 하나는 incomplete로 저장되는 문제가 있었음
## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
기능상 문제 되도록 안 생기게 올렸는데, 추후에 리팩토링 필요할 것 같습니다.