### PR TITLE
[BOM-1145] feat: 공휴일 연속읽기 깨짐 방지

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -15,6 +15,7 @@ import me.bombom.api.v1.common.MonthlyRankingScheduleProperties;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
+import me.bombom.api.v1.common.holiday.repository.HolidayRepository;
 import me.bombom.api.v1.common.util.DateUtils;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
@@ -72,6 +73,7 @@ public class ReadingService {
     private final MonthlyReadingSnapshotRepository monthlyReadingSnapshotRepository;
     private final MonthlyReadingRealtimeRepository monthlyReadingRealtimeRepository;
     private final YearlyReadingRepository yearlyReadingRepository;
+    private final HolidayRepository holidayRepository;
 
     private final MonthlyRankingScheduleProperties scheduleProps;
     private final ContinueReadingRankingScheduleProperties continueReadingRankingScheduleProperties;
@@ -126,7 +128,7 @@ public class ReadingService {
     @Transactional
     public void resetContinueReadingCount() {
         LocalDate targetDate = LocalDate.now(clock).minusDays(1);
-        if (DateUtils.isWeekend(targetDate)) {
+        if (isNonWorkingDay(targetDate)) {
             return;
         }
 
@@ -430,6 +432,10 @@ public class ReadingService {
                 .addContext(ErrorContextKeys.ENTITY_TYPE, "ContinueReadingRealtime")
                 .addContext(ErrorContextKeys.OPERATION, "applyResetContinueReadingCount"));
         continueReading.resetDayCount();
+    }
+
+    private boolean isNonWorkingDay(LocalDate date) {
+        return DateUtils.isWeekend(date) || holidayRepository.existsByDate(date);
     }
 
     private void updateContinueReadingCount(Long memberId) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Optional;
+import me.bombom.api.v1.common.holiday.repository.HolidayRepository;
 import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
 import me.bombom.api.v1.reading.domain.TodayReading;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
@@ -35,6 +36,9 @@ class ReadingServiceResetContinueReadingCountTest {
     private TodayReadingRepository todayReadingRepository;
 
     @Mock
+    private HolidayRepository holidayRepository;
+
+    @Mock
     private Clock clock;
 
     @Test
@@ -56,8 +60,20 @@ class ReadingServiceResetContinueReadingCountTest {
     }
 
     @Test
+    void 어제가_공휴일이면_연속_읽기_횟수를_초기화하지_않는다() {
+        LocalDate holiday = LocalDate.of(2026, 5, 5);
+        fixClockTo(holiday.plusDays(1));
+        given(holidayRepository.existsByDate(holiday)).willReturn(true);
+
+        readingService.resetContinueReadingCount();
+
+        verify(todayReadingRepository, never()).findTotalNonZeroAndReadZero();
+    }
+
+    @Test
     void 어제가_평일이면_연속_읽기_횟수를_초기화하고_최대_스트릭은_유지한다() {
         fixClockTo(LocalDate.of(2026, 4, 28)); // Tuesday
+        given(holidayRepository.existsByDate(LocalDate.of(2026, 4, 27))).willReturn(false);
         TodayReading todayReading = TodayReading.builder()
                 .memberId(1L)
                 .totalCount(3)
@@ -83,6 +99,7 @@ class ReadingServiceResetContinueReadingCountTest {
     @Test
     void 어제가_평일이어도_오늘_읽은_아티클이_있으면_연속_읽기_횟수를_초기화하지_않는다() {
         fixClockTo(LocalDate.of(2026, 4, 28)); // Tuesday
+        given(holidayRepository.existsByDate(LocalDate.of(2026, 4, 27))).willReturn(false);
         given(todayReadingRepository.findTotalNonZeroAndReadZero()).willReturn(List.of());
 
         readingService.resetContinueReadingCount();


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
공휴일에 뉴스레터를 읽지 않아도 연속 읽기 스트릭이 초기화되지 않도록 수정

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존에는 주말만 스트릭 보호 대상이었고, 공휴일에는 읽지 않으면 스트릭이 깨질 수 있었음

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
스트릭 초기화 시 기준일이 주말이거나 공휴일이면 초기화를 건너뛰도록 변경

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
