### PR TITLE
[BOM-1155] feat: 연속 읽기 보호막 기능 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingRealtime.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingRealtime.java
@@ -59,7 +59,7 @@ public class ContinueReadingRealtime extends BaseEntity {
         dayCount = RESET_DAY_COUNT;
     }
 
-    public boolean hasDayCount() {
+    public boolean hasActiveStreak() {
         return dayCount > RESET_DAY_COUNT;
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingRealtime.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingRealtime.java
@@ -59,6 +59,10 @@ public class ContinueReadingRealtime extends BaseEntity {
         dayCount = RESET_DAY_COUNT;
     }
 
+    public boolean hasDayCount() {
+        return dayCount > RESET_DAY_COUNT;
+    }
+
     public void increaseDayCount() {
         dayCount += INCREASE_DAY_COUNT;
         maxDayCount = Math.max(maxDayCount, dayCount);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
@@ -1,0 +1,63 @@
+package me.bombom.api.v1.reading.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(name = "uk_continue_reading_shield_member_id", columnNames = "member_id")
+})
+public class ContinueReadingShield extends BaseEntity {
+
+    private static final int INITIAL_REMAINING_COUNT = 1;
+    private static final int USE_COUNT = 1;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false, columnDefinition = "SMALLINT")
+    private int remainingCount;
+
+    @Builder
+    public ContinueReadingShield(
+            Long id,
+            @NonNull Long memberId,
+            int remainingCount
+    ) {
+        this.id = id;
+        this.memberId = memberId;
+        this.remainingCount = Math.max(remainingCount, 0);
+    }
+
+    public static ContinueReadingShield create(Long memberId) {
+        return ContinueReadingShield.builder()
+                .memberId(memberId)
+                .remainingCount(INITIAL_REMAINING_COUNT)
+                .build();
+    }
+
+    public boolean useIfAvailable() {
+        if (remainingCount <= 0) {
+            return false;
+        }
+        remainingCount -= USE_COUNT;
+        return true;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
@@ -32,7 +32,7 @@ public class ContinueReadingShield extends BaseEntity {
     @Column(nullable = false)
     private Long memberId;
 
-    @Column(nullable = false, columnDefinition = "SMALLINT")
+    @Column(nullable = false, columnDefinition = "TINYINT")
     private int remainingCount;
 
     @Builder

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
@@ -23,7 +23,6 @@ import me.bombom.api.v1.common.BaseEntity;
 public class ContinueReadingShield extends BaseEntity {
 
     private static final int INITIAL_REMAINING_COUNT = 1;
-    private static final int USE_COUNT = 1;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -51,13 +50,5 @@ public class ContinueReadingShield extends BaseEntity {
                 .memberId(memberId)
                 .remainingCount(INITIAL_REMAINING_COUNT)
                 .build();
-    }
-
-    public boolean useIfAvailable() {
-        if (remainingCount <= 0) {
-            return false;
-        }
-        remainingCount -= USE_COUNT;
-        return true;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
@@ -22,7 +22,8 @@ import me.bombom.api.v1.common.BaseEntity;
 })
 public class ContinueReadingShield extends BaseEntity {
 
-    private static final int INITIAL_REMAINING_COUNT = 1;
+    private static final int INITIAL_MONTHLY_REMAINING_COUNT = 1;
+    private static final int INITIAL_REWARD_REMAINING_COUNT = 0;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -32,23 +33,33 @@ public class ContinueReadingShield extends BaseEntity {
     private Long memberId;
 
     @Column(nullable = false, columnDefinition = "TINYINT")
-    private int remainingCount;
+    private int monthlyRemainingCount;
+
+    @Column(nullable = false, columnDefinition = "TINYINT")
+    private int rewardRemainingCount;
 
     @Builder
     public ContinueReadingShield(
             Long id,
             @NonNull Long memberId,
-            int remainingCount
+            int monthlyRemainingCount,
+            int rewardRemainingCount
     ) {
         this.id = id;
         this.memberId = memberId;
-        this.remainingCount = Math.max(remainingCount, 0);
+        this.monthlyRemainingCount = Math.max(monthlyRemainingCount, 0);
+        this.rewardRemainingCount = Math.max(rewardRemainingCount, 0);
     }
 
     public static ContinueReadingShield create(Long memberId) {
         return ContinueReadingShield.builder()
                 .memberId(memberId)
-                .remainingCount(INITIAL_REMAINING_COUNT)
+                .monthlyRemainingCount(INITIAL_MONTHLY_REMAINING_COUNT)
+                .rewardRemainingCount(INITIAL_REWARD_REMAINING_COUNT)
                 .build();
+    }
+
+    public int getRemainingCount() {
+        return monthlyRemainingCount + rewardRemainingCount;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShield.java
@@ -45,10 +45,11 @@ public class ContinueReadingShield extends BaseEntity {
             int monthlyRemainingCount,
             int rewardRemainingCount
     ) {
+        validateRemainingCount(monthlyRemainingCount, rewardRemainingCount);
         this.id = id;
         this.memberId = memberId;
-        this.monthlyRemainingCount = Math.max(monthlyRemainingCount, 0);
-        this.rewardRemainingCount = Math.max(rewardRemainingCount, 0);
+        this.monthlyRemainingCount = monthlyRemainingCount;
+        this.rewardRemainingCount = rewardRemainingCount;
     }
 
     public static ContinueReadingShield create(Long memberId) {
@@ -61,5 +62,11 @@ public class ContinueReadingShield extends BaseEntity {
 
     public int getRemainingCount() {
         return monthlyRemainingCount + rewardRemainingCount;
+    }
+
+    private static void validateRemainingCount(int monthlyRemainingCount, int rewardRemainingCount) {
+        if (monthlyRemainingCount < 0 || rewardRemainingCount < 0) {
+            throw new IllegalArgumentException("보호막 잔여 개수는 음수일 수 없습니다.");
+        }
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistory.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistory.java
@@ -42,7 +42,7 @@ public class ContinueReadingShieldHistory extends BaseEntity {
     @Column(nullable = false)
     private LocalDate eventDate;
 
-    @Column(nullable = false, columnDefinition = "SMALLINT")
+    @Column(nullable = false, columnDefinition = "TINYINT")
     private int quantity;
 
     @Builder

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistory.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistory.java
@@ -22,8 +22,8 @@ import me.bombom.api.v1.common.BaseEntity;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = {
         @UniqueConstraint(
-                name = "uk_continue_reading_shield_history_member_type_date",
-                columnNames = { "member_id", "type", "event_date" }
+                name = "uk_continue_reading_shield_history_member_type_reason_date",
+                columnNames = { "member_id", "type", "reason", "event_date" }
         )
 })
 public class ContinueReadingShieldHistory extends BaseEntity {
@@ -40,6 +40,10 @@ public class ContinueReadingShieldHistory extends BaseEntity {
     private ContinueReadingShieldHistoryType type;
 
     @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContinueReadingShieldHistoryReason reason;
+
+    @Column(nullable = false)
     private LocalDate eventDate;
 
     @Column(nullable = false, columnDefinition = "TINYINT")
@@ -50,29 +54,43 @@ public class ContinueReadingShieldHistory extends BaseEntity {
             Long id,
             @NonNull Long memberId,
             @NonNull ContinueReadingShieldHistoryType type,
+            @NonNull ContinueReadingShieldHistoryReason reason,
             @NonNull LocalDate eventDate,
             int quantity
     ) {
         this.id = id;
         this.memberId = memberId;
         this.type = type;
+        this.reason = reason;
         this.eventDate = eventDate;
         this.quantity = quantity;
     }
 
-    public static ContinueReadingShieldHistory grant(Long memberId, LocalDate eventDate, int quantity) {
+    public static ContinueReadingShieldHistory grant(
+            Long memberId,
+            ContinueReadingShieldHistoryReason reason,
+            LocalDate eventDate,
+            int quantity
+    ) {
         return ContinueReadingShieldHistory.builder()
                 .memberId(memberId)
                 .type(ContinueReadingShieldHistoryType.GRANT)
+                .reason(reason)
                 .eventDate(eventDate)
                 .quantity(quantity)
                 .build();
     }
 
-    public static ContinueReadingShieldHistory use(Long memberId, LocalDate eventDate, int quantity) {
+    public static ContinueReadingShieldHistory use(
+            Long memberId,
+            ContinueReadingShieldHistoryReason reason,
+            LocalDate eventDate,
+            int quantity
+    ) {
         return ContinueReadingShieldHistory.builder()
                 .memberId(memberId)
                 .type(ContinueReadingShieldHistoryType.USE)
+                .reason(reason)
                 .eventDate(eventDate)
                 .quantity(quantity)
                 .build();

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistory.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistory.java
@@ -1,0 +1,80 @@
+package me.bombom.api.v1.reading.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import me.bombom.api.v1.common.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = {
+        @UniqueConstraint(
+                name = "uk_continue_reading_shield_history_member_type_date",
+                columnNames = { "member_id", "type", "event_date" }
+        )
+})
+public class ContinueReadingShieldHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContinueReadingShieldHistoryType type;
+
+    @Column(nullable = false)
+    private LocalDate eventDate;
+
+    @Column(nullable = false, columnDefinition = "SMALLINT")
+    private int quantity;
+
+    @Builder
+    public ContinueReadingShieldHistory(
+            Long id,
+            @NonNull Long memberId,
+            @NonNull ContinueReadingShieldHistoryType type,
+            @NonNull LocalDate eventDate,
+            int quantity
+    ) {
+        this.id = id;
+        this.memberId = memberId;
+        this.type = type;
+        this.eventDate = eventDate;
+        this.quantity = quantity;
+    }
+
+    public static ContinueReadingShieldHistory grant(Long memberId, LocalDate eventDate, int quantity) {
+        return ContinueReadingShieldHistory.builder()
+                .memberId(memberId)
+                .type(ContinueReadingShieldHistoryType.GRANT)
+                .eventDate(eventDate)
+                .quantity(quantity)
+                .build();
+    }
+
+    public static ContinueReadingShieldHistory use(Long memberId, LocalDate eventDate, int quantity) {
+        return ContinueReadingShieldHistory.builder()
+                .memberId(memberId)
+                .type(ContinueReadingShieldHistoryType.USE)
+                .eventDate(eventDate)
+                .quantity(quantity)
+                .build();
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistoryReason.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistoryReason.java
@@ -1,0 +1,9 @@
+package me.bombom.api.v1.reading.domain;
+
+public enum ContinueReadingShieldHistoryReason {
+
+    SIGNUP,
+    MONTHLY_RESET,
+    MIGRATION_BACKFILL,
+    DAILY_RESET_PROTECT
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistoryReason.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistoryReason.java
@@ -5,5 +5,5 @@ public enum ContinueReadingShieldHistoryReason {
     SIGNUP,
     MONTHLY_RESET,
     MIGRATION_BACKFILL,
-    DAILY_RESET_PROTECT
+    DAILY_RESET_PROTECTION_USE
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistoryType.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistoryType.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.reading.domain;
 
 public enum ContinueReadingShieldHistoryType {
+
     GRANT,
     USE
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistoryType.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldHistoryType.java
@@ -1,0 +1,6 @@
+package me.bombom.api.v1.reading.domain;
+
+public enum ContinueReadingShieldHistoryType {
+    GRANT,
+    USE
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
@@ -1,0 +1,55 @@
+package me.bombom.api.v1.reading.repository;
+
+import java.time.LocalDate;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistory;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ContinueReadingShieldHistoryRepository extends JpaRepository<ContinueReadingShieldHistory, Long> {
+
+    boolean existsByMemberIdAndTypeAndEventDate(
+            Long memberId,
+            ContinueReadingShieldHistoryType type,
+            LocalDate eventDate
+    );
+
+    long countByMemberIdAndTypeAndEventDate(
+            Long memberId,
+            ContinueReadingShieldHistoryType type,
+            LocalDate eventDate
+    );
+
+    @Modifying
+    @Query(value = """
+        INSERT IGNORE INTO continue_reading_shield_history (
+            member_id,
+            type,
+            event_date,
+            quantity,
+            created_at,
+            updated_at
+        )
+        SELECT
+            shield.member_id,
+            'GRANT',
+            :eventDate,
+            :quantity,
+            NOW(6),
+            NOW(6)
+        FROM continue_reading_shield shield
+        LEFT JOIN continue_reading_shield_history history
+            ON history.member_id = shield.member_id
+            AND history.type = 'GRANT'
+            AND history.event_date = :eventDate
+        WHERE history.id IS NULL
+    """, nativeQuery = true)
+    int insertMonthlyGrantHistories(
+            @Param("eventDate") LocalDate eventDate,
+            @Param("quantity") int quantity
+    );
+
+    void deleteByMemberId(Long memberId);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
@@ -31,7 +31,7 @@ public interface ContinueReadingShieldHistoryRepository extends JpaRepository<Co
             :quantity
         FROM continue_reading_shield shield
     """, nativeQuery = true)
-    int insertMonthlyGrantHistories(
+    int bulkInsertMonthlyGrantHistories(
             @Param("eventDate") LocalDate eventDate,
             @Param("quantity") int quantity
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
@@ -10,12 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface ContinueReadingShieldHistoryRepository extends JpaRepository<ContinueReadingShieldHistory, Long> {
 
-    boolean existsByMemberIdAndTypeAndEventDate(
-            Long memberId,
-            ContinueReadingShieldHistoryType type,
-            LocalDate eventDate
-    );
-
     long countByMemberIdAndTypeAndEventDate(
             Long memberId,
             ContinueReadingShieldHistoryType type,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
@@ -40,11 +40,6 @@ public interface ContinueReadingShieldHistoryRepository extends JpaRepository<Co
             NOW(6),
             NOW(6)
         FROM continue_reading_shield shield
-        LEFT JOIN continue_reading_shield_history history
-            ON history.member_id = shield.member_id
-            AND history.type = 'GRANT'
-            AND history.event_date = :eventDate
-        WHERE history.id IS NULL
     """, nativeQuery = true)
     int insertMonthlyGrantHistories(
             @Param("eventDate") LocalDate eventDate,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.reading.repository;
 
 import java.time.LocalDate;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistory;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryReason;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -10,9 +11,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface ContinueReadingShieldHistoryRepository extends JpaRepository<ContinueReadingShieldHistory, Long> {
 
-    long countByMemberIdAndTypeAndEventDate(
+    long countByMemberIdAndTypeAndReasonAndEventDate(
             Long memberId,
             ContinueReadingShieldHistoryType type,
+            ContinueReadingShieldHistoryReason reason,
             LocalDate eventDate
     );
 
@@ -21,17 +23,20 @@ public interface ContinueReadingShieldHistoryRepository extends JpaRepository<Co
         INSERT IGNORE INTO continue_reading_shield_history (
             member_id,
             type,
+            reason,
             event_date,
             quantity
         )
         SELECT
             shield.member_id,
             'GRANT',
+            :reason,
             :eventDate,
             :quantity
         FROM continue_reading_shield shield
     """, nativeQuery = true)
     int bulkInsertMonthlyGrantHistories(
+            @Param("reason") String reason,
             @Param("eventDate") LocalDate eventDate,
             @Param("quantity") int quantity
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldHistoryRepository.java
@@ -28,17 +28,13 @@ public interface ContinueReadingShieldHistoryRepository extends JpaRepository<Co
             member_id,
             type,
             event_date,
-            quantity,
-            created_at,
-            updated_at
+            quantity
         )
         SELECT
             shield.member_id,
             'GRANT',
             :eventDate,
-            :quantity,
-            NOW(6),
-            NOW(6)
+            :quantity
         FROM continue_reading_shield shield
     """, nativeQuery = true)
     int insertMonthlyGrantHistories(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
@@ -1,0 +1,42 @@
+package me.bombom.api.v1.reading.repository;
+
+import jakarta.persistence.LockModeType;
+import java.time.LocalDate;
+import java.util.Optional;
+import me.bombom.api.v1.reading.domain.ContinueReadingShield;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ContinueReadingShieldRepository extends JpaRepository<ContinueReadingShield, Long> {
+
+    Optional<ContinueReadingShield> findByMemberId(Long memberId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+        SELECT shield
+        FROM ContinueReadingShield shield
+        WHERE shield.memberId = :memberId
+    """)
+    Optional<ContinueReadingShield> findByMemberIdForUpdate(@Param("memberId") Long memberId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+        UPDATE continue_reading_shield shield
+        LEFT JOIN continue_reading_shield_history history
+            ON history.member_id = shield.member_id
+            AND history.type = 'GRANT'
+            AND history.event_date = :eventDate
+        SET shield.remaining_count = :remainingCount,
+            shield.updated_at = NOW(6)
+        WHERE history.id IS NULL
+    """, nativeQuery = true)
+    int resetMonthlyIfNotGranted(
+            @Param("eventDate") LocalDate eventDate,
+            @Param("remainingCount") int remainingCount
+    );
+
+    void deleteByMemberId(Long memberId);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
@@ -29,8 +29,7 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
             ON history.member_id = shield.member_id
             AND history.type = 'GRANT'
             AND history.event_date = :eventDate
-        SET shield.remaining_count = :remainingCount,
-            shield.updated_at = NOW(6)
+        SET shield.remaining_count = :remainingCount
         WHERE history.id IS NULL
     """, nativeQuery = true)
     int resetMonthlyIfNotGranted(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
@@ -12,7 +12,7 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
 
     Optional<ContinueReadingShield> findByMemberId(Long memberId);
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query(value = """
         UPDATE continue_reading_shield shield
         SET shield.remaining_count = shield.remaining_count - :quantity
@@ -26,13 +26,13 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
                     AND history.event_date = :eventDate
             )
     """, nativeQuery = true)
-    int useIfAvailable(
+    int bulkUseIfAvailable(
             @Param("memberId") Long memberId,
             @Param("eventDate") LocalDate eventDate,
             @Param("quantity") int quantity
     );
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Modifying
     @Query(value = """
         UPDATE continue_reading_shield shield
         LEFT JOIN continue_reading_shield_history history
@@ -42,7 +42,7 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
         SET shield.remaining_count = :remainingCount
         WHERE history.id IS NULL
     """, nativeQuery = true)
-    int resetMonthlyIfNotGranted(
+    int bulkResetMonthlyIfNotGranted(
             @Param("eventDate") LocalDate eventDate,
             @Param("remainingCount") int remainingCount
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
@@ -23,11 +23,13 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
                 FROM continue_reading_shield_history history
                 WHERE history.member_id = :memberId
                     AND history.type = 'USE'
+                    AND history.reason = :reason
                     AND history.event_date = :eventDate
             )
     """, nativeQuery = true)
     int bulkDecreaseRemainingCountIfUsable(
             @Param("memberId") Long memberId,
+            @Param("reason") String reason,
             @Param("eventDate") LocalDate eventDate,
             @Param("quantity") int quantity
     );
@@ -38,11 +40,13 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
         LEFT JOIN continue_reading_shield_history history
             ON history.member_id = shield.member_id
             AND history.type = 'GRANT'
+            AND history.reason = :reason
             AND history.event_date = :eventDate
         SET shield.remaining_count = :remainingCount
         WHERE history.id IS NULL
     """, nativeQuery = true)
     int bulkResetMonthlyIfNotGranted(
+            @Param("reason") String reason,
             @Param("eventDate") LocalDate eventDate,
             @Param("remainingCount") int remainingCount
     );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
@@ -26,7 +26,7 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
                     AND history.event_date = :eventDate
             )
     """, nativeQuery = true)
-    int bulkUseIfAvailable(
+    int bulkDecreaseRemainingCountIfUsable(
             @Param("memberId") Long memberId,
             @Param("eventDate") LocalDate eventDate,
             @Param("quantity") int quantity

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
@@ -1,11 +1,9 @@
 package me.bombom.api.v1.reading.repository;
 
-import jakarta.persistence.LockModeType;
 import java.time.LocalDate;
 import java.util.Optional;
 import me.bombom.api.v1.reading.domain.ContinueReadingShield;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,13 +12,25 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
 
     Optional<ContinueReadingShield> findByMemberId(Long memberId);
 
-    @Lock(LockModeType.PESSIMISTIC_WRITE)
-    @Query("""
-        SELECT shield
-        FROM ContinueReadingShield shield
-        WHERE shield.memberId = :memberId
-    """)
-    Optional<ContinueReadingShield> findByMemberIdForUpdate(@Param("memberId") Long memberId);
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query(value = """
+        UPDATE continue_reading_shield shield
+        SET shield.remaining_count = shield.remaining_count - :quantity
+        WHERE shield.member_id = :memberId
+            AND shield.remaining_count >= :quantity
+            AND NOT EXISTS (
+                SELECT 1
+                FROM continue_reading_shield_history history
+                WHERE history.member_id = :memberId
+                    AND history.type = 'USE'
+                    AND history.event_date = :eventDate
+            )
+    """, nativeQuery = true)
+    int useIfAvailable(
+            @Param("memberId") Long memberId,
+            @Param("eventDate") LocalDate eventDate,
+            @Param("quantity") int quantity
+    );
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query(value = """

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
@@ -16,15 +16,15 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
     @Query(value = """
         UPDATE continue_reading_shield shield
         SET shield.reward_remaining_count = CASE
-                WHEN shield.monthly_remaining_count >= :quantity THEN shield.reward_remaining_count
-                ELSE shield.reward_remaining_count - (:quantity - shield.monthly_remaining_count)
+                WHEN shield.monthly_remaining_count >= :deductCount THEN shield.reward_remaining_count
+                ELSE shield.reward_remaining_count - (:deductCount - shield.monthly_remaining_count)
             END,
             shield.monthly_remaining_count = CASE
-                WHEN shield.monthly_remaining_count >= :quantity THEN shield.monthly_remaining_count - :quantity
+                WHEN shield.monthly_remaining_count >= :deductCount THEN shield.monthly_remaining_count - :deductCount
                 ELSE 0
             END
         WHERE shield.member_id = :memberId
-            AND shield.monthly_remaining_count + shield.reward_remaining_count >= :quantity
+            AND shield.monthly_remaining_count + shield.reward_remaining_count >= :deductCount
             AND NOT EXISTS (
                 SELECT 1
                 FROM continue_reading_shield_history history
@@ -38,7 +38,7 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
             @Param("memberId") Long memberId,
             @Param("reason") String reason,
             @Param("eventDate") LocalDate eventDate,
-            @Param("quantity") int quantity
+            @Param("deductCount") int deductCount
     );
 
     @Modifying

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingShieldRepository.java
@@ -15,9 +15,16 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
     @Modifying
     @Query(value = """
         UPDATE continue_reading_shield shield
-        SET shield.remaining_count = shield.remaining_count - :quantity
+        SET shield.reward_remaining_count = CASE
+                WHEN shield.monthly_remaining_count >= :quantity THEN shield.reward_remaining_count
+                ELSE shield.reward_remaining_count - (:quantity - shield.monthly_remaining_count)
+            END,
+            shield.monthly_remaining_count = CASE
+                WHEN shield.monthly_remaining_count >= :quantity THEN shield.monthly_remaining_count - :quantity
+                ELSE 0
+            END
         WHERE shield.member_id = :memberId
-            AND shield.remaining_count >= :quantity
+            AND shield.monthly_remaining_count + shield.reward_remaining_count >= :quantity
             AND NOT EXISTS (
                 SELECT 1
                 FROM continue_reading_shield_history history
@@ -42,7 +49,7 @@ public interface ContinueReadingShieldRepository extends JpaRepository<ContinueR
             AND history.type = 'GRANT'
             AND history.reason = :reason
             AND history.event_date = :eventDate
-        SET shield.remaining_count = :remainingCount
+        SET shield.monthly_remaining_count = :remainingCount
         WHERE history.id IS NULL
     """, nativeQuery = true)
     int bulkResetMonthlyIfNotGranted(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/scheduler/ReadingScheduler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/scheduler/ReadingScheduler.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.reading.scheduler;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.reading.service.ContinueReadingShieldService;
 import me.bombom.api.v1.reading.service.ReadingService;
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -19,12 +20,14 @@ public class ReadingScheduler {
     private static final String MONTHLY_CRON = "0 0 0 1 * ?";
 
     private final ReadingService readingService;
+    private final ContinueReadingShieldService continueReadingShieldService;
 
     @Scheduled(cron = DAILY_CRON, zone = TIME_ZONE)
     @SchedulerLock(name = "daily_reset_reading_count", lockAtLeastFor = "PT4S", lockAtMostFor = "PT9S")
     public void dailyResetReadingCount() {
         log.info("오늘 읽기 초기화 실행");
         readingService.resetContinueReadingCount();
+        continueReadingShieldService.resetMonthlyShieldsIfFirstDay();
         readingService.resetTodayReadingCount();
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -41,7 +41,7 @@ public class ContinueReadingShieldService {
     public boolean useShield(Long memberId, LocalDate targetDate) {
         int updatedRows = continueReadingShieldRepository.bulkDecreaseRemainingCountIfUsable(
                 memberId,
-                ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECT.name(),
+                ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECTION_USE.name(),
                 targetDate,
                 SHIELD_QUANTITY
         );
@@ -51,7 +51,7 @@ public class ContinueReadingShieldService {
         continueReadingShieldHistoryRepository.save(
                 ContinueReadingShieldHistory.use(
                         memberId,
-                        ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECT,
+                        ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECTION_USE,
                         targetDate,
                         SHIELD_QUANTITY
                 )

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -32,7 +32,7 @@ public class ContinueReadingShieldService {
 
     @Transactional
     public boolean useShield(Long memberId, LocalDate targetDate) {
-        int updatedRows = continueReadingShieldRepository.useIfAvailable(memberId, targetDate, SHIELD_QUANTITY);
+        int updatedRows = continueReadingShieldRepository.bulkUseIfAvailable(memberId, targetDate, SHIELD_QUANTITY);
         if (updatedRows == 0) {
             return false;
         }
@@ -49,8 +49,8 @@ public class ContinueReadingShieldService {
             return;
         }
         LocalDate monthStartDate = today.withDayOfMonth(1);
-        continueReadingShieldRepository.resetMonthlyIfNotGranted(monthStartDate, SHIELD_QUANTITY);
-        continueReadingShieldHistoryRepository.insertMonthlyGrantHistories(monthStartDate, SHIELD_QUANTITY);
+        continueReadingShieldRepository.bulkResetMonthlyIfNotGranted(monthStartDate, SHIELD_QUANTITY);
+        continueReadingShieldHistoryRepository.bulkInsertMonthlyGrantHistories(monthStartDate, SHIELD_QUANTITY);
     }
 
     @Transactional

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -19,7 +19,7 @@ public class ContinueReadingShieldService {
     private static final int INITIAL_GRANT_COUNT = 1;
     private static final int DEDUCT_COUNT = 1;
     private static final int MONTHLY_GRANT_COUNT = 1;
-    private static final int MONTHLY_SHIELD_GRANT_EVENT_DAY = 1;
+    private static final int MONTHLY_SHIELD_GRANT_DAY = 1;
 
     private final ContinueReadingShieldRepository continueReadingShieldRepository;
     private final ContinueReadingShieldHistoryRepository continueReadingShieldHistoryRepository;
@@ -64,10 +64,10 @@ public class ContinueReadingShieldService {
     @Transactional
     public void resetMonthlyShieldsIfFirstDay() {
         LocalDate today = currentDate();
-        if (today.getDayOfMonth() != MONTHLY_SHIELD_GRANT_EVENT_DAY) {
+        if (today.getDayOfMonth() != MONTHLY_SHIELD_GRANT_DAY) {
             return;
         }
-        LocalDate monthlyShieldGrantEventDate = today.withDayOfMonth(MONTHLY_SHIELD_GRANT_EVENT_DAY);
+        LocalDate monthlyShieldGrantEventDate = today.withDayOfMonth(MONTHLY_SHIELD_GRANT_DAY);
         continueReadingShieldRepository.bulkResetMonthlyIfNotGranted(
                 ContinueReadingShieldHistoryReason.MONTHLY_RESET.name(),
                 monthlyShieldGrantEventDate,
@@ -87,7 +87,7 @@ public class ContinueReadingShieldService {
     }
 
     private LocalDate currentMonthlyShieldGrantEventDate() {
-        return currentDate().withDayOfMonth(MONTHLY_SHIELD_GRANT_EVENT_DAY);
+        return currentDate().withDayOfMonth(MONTHLY_SHIELD_GRANT_DAY);
     }
 
     private LocalDate currentDate() {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -33,7 +33,11 @@ public class ContinueReadingShieldService {
 
     @Transactional
     public boolean useShield(Long memberId, LocalDate targetDate) {
-        int updatedRows = continueReadingShieldRepository.bulkUseIfAvailable(memberId, targetDate, SHIELD_QUANTITY);
+        int updatedRows = continueReadingShieldRepository.bulkDecreaseRemainingCountIfUsable(
+                memberId,
+                targetDate,
+                SHIELD_QUANTITY
+        );
         if (updatedRows == 0) {
             return false;
         }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -3,16 +3,13 @@ package me.bombom.api.v1.reading.service;
 import java.time.Clock;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.reading.domain.ContinueReadingShield;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistory;
-import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
 import me.bombom.api.v1.reading.repository.ContinueReadingShieldHistoryRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingShieldRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -35,20 +32,8 @@ public class ContinueReadingShieldService {
 
     @Transactional
     public boolean useShield(Long memberId, LocalDate targetDate) {
-        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberIdForUpdate(memberId)
-                .orElse(null);
-        if (shield == null) {
-            log.warn("연속 읽기 보호막 정보가 없어 보호막 사용을 건너뜁니다. memberId={}", memberId);
-            return false;
-        }
-        if (continueReadingShieldHistoryRepository.existsByMemberIdAndTypeAndEventDate(
-                memberId,
-                ContinueReadingShieldHistoryType.USE,
-                targetDate
-        )) {
-            return false;
-        }
-        if (!shield.useIfAvailable()) {
+        int updatedRows = continueReadingShieldRepository.useIfAvailable(memberId, targetDate, SHIELD_QUANTITY);
+        if (updatedRows == 0) {
             return false;
         }
         continueReadingShieldHistoryRepository.save(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -17,7 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContinueReadingShieldService {
 
     private static final int INITIAL_GRANT_COUNT = 1;
-    private static final int SHIELD_DEDUCT_COUNT = 1;
+    private static final int DEDUCT_COUNT = 1;
     private static final int MONTHLY_GRANT_COUNT = 1;
     private static final int MONTHLY_SHIELD_GRANT_EVENT_DAY = 1;
 
@@ -45,7 +45,7 @@ public class ContinueReadingShieldService {
                 memberId,
                 ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECTION_USE.name(),
                 targetDate,
-                SHIELD_DEDUCT_COUNT
+                DEDUCT_COUNT
         );
         if (updatedRows == 0) {
             return false;
@@ -55,7 +55,7 @@ public class ContinueReadingShieldService {
                         memberId,
                         ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECTION_USE,
                         targetDate,
-                        SHIELD_DEDUCT_COUNT
+                        DEDUCT_COUNT
                 )
         );
         return true;

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContinueReadingShieldService {
 
     private static final int SHIELD_QUANTITY = 1;
+    private static final int MONTHLY_SHIELD_GRANT_EVENT_DAY = 1;
 
     private final ContinueReadingShieldRepository continueReadingShieldRepository;
     private final ContinueReadingShieldHistoryRepository continueReadingShieldHistoryRepository;
@@ -26,7 +27,7 @@ public class ContinueReadingShieldService {
         ContinueReadingShield shield = ContinueReadingShield.create(memberId);
         continueReadingShieldRepository.save(shield);
         continueReadingShieldHistoryRepository.save(
-                ContinueReadingShieldHistory.grant(memberId, currentMonthStartDate(), SHIELD_QUANTITY)
+                ContinueReadingShieldHistory.grant(memberId, currentMonthlyShieldGrantEventDate(), SHIELD_QUANTITY)
         );
     }
 
@@ -45,12 +46,15 @@ public class ContinueReadingShieldService {
     @Transactional
     public void resetMonthlyShieldsIfFirstDay() {
         LocalDate today = LocalDate.now(clock);
-        if (today.getDayOfMonth() != 1) {
+        if (today.getDayOfMonth() != MONTHLY_SHIELD_GRANT_EVENT_DAY) {
             return;
         }
-        LocalDate monthStartDate = today.withDayOfMonth(1);
-        continueReadingShieldRepository.bulkResetMonthlyIfNotGranted(monthStartDate, SHIELD_QUANTITY);
-        continueReadingShieldHistoryRepository.bulkInsertMonthlyGrantHistories(monthStartDate, SHIELD_QUANTITY);
+        LocalDate monthlyShieldGrantEventDate = today.withDayOfMonth(MONTHLY_SHIELD_GRANT_EVENT_DAY);
+        continueReadingShieldRepository.bulkResetMonthlyIfNotGranted(monthlyShieldGrantEventDate, SHIELD_QUANTITY);
+        continueReadingShieldHistoryRepository.bulkInsertMonthlyGrantHistories(
+                monthlyShieldGrantEventDate,
+                SHIELD_QUANTITY
+        );
     }
 
     @Transactional
@@ -59,7 +63,7 @@ public class ContinueReadingShieldService {
         continueReadingShieldRepository.deleteByMemberId(memberId);
     }
 
-    private LocalDate currentMonthStartDate() {
-        return LocalDate.now(clock).withDayOfMonth(1);
+    private LocalDate currentMonthlyShieldGrantEventDate() {
+        return LocalDate.now(clock).withDayOfMonth(MONTHLY_SHIELD_GRANT_EVENT_DAY);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -1,0 +1,80 @@
+package me.bombom.api.v1.reading.service;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.reading.domain.ContinueReadingShield;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistory;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
+import me.bombom.api.v1.reading.repository.ContinueReadingShieldHistoryRepository;
+import me.bombom.api.v1.reading.repository.ContinueReadingShieldRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContinueReadingShieldService {
+
+    private static final int SHIELD_QUANTITY = 1;
+
+    private final ContinueReadingShieldRepository continueReadingShieldRepository;
+    private final ContinueReadingShieldHistoryRepository continueReadingShieldHistoryRepository;
+    private final Clock clock;
+
+    @Transactional
+    public void initializeShield(Long memberId) {
+        ContinueReadingShield shield = ContinueReadingShield.create(memberId);
+        continueReadingShieldRepository.save(shield);
+        continueReadingShieldHistoryRepository.save(
+                ContinueReadingShieldHistory.grant(memberId, currentMonthStartDate(), SHIELD_QUANTITY)
+        );
+    }
+
+    @Transactional
+    public boolean useShield(Long memberId, LocalDate targetDate) {
+        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberIdForUpdate(memberId)
+                .orElse(null);
+        if (shield == null) {
+            log.warn("연속 읽기 보호막 정보가 없어 보호막 사용을 건너뜁니다. memberId={}", memberId);
+            return false;
+        }
+        if (continueReadingShieldHistoryRepository.existsByMemberIdAndTypeAndEventDate(
+                memberId,
+                ContinueReadingShieldHistoryType.USE,
+                targetDate
+        )) {
+            return false;
+        }
+        if (!shield.useIfAvailable()) {
+            return false;
+        }
+        continueReadingShieldHistoryRepository.save(
+                ContinueReadingShieldHistory.use(memberId, targetDate, SHIELD_QUANTITY)
+        );
+        return true;
+    }
+
+    @Transactional
+    public void resetMonthlyShieldsIfFirstDay() {
+        LocalDate today = LocalDate.now(clock);
+        if (today.getDayOfMonth() != 1) {
+            return;
+        }
+        LocalDate monthStartDate = today.withDayOfMonth(1);
+        continueReadingShieldRepository.resetMonthlyIfNotGranted(monthStartDate, SHIELD_QUANTITY);
+        continueReadingShieldHistoryRepository.insertMonthlyGrantHistories(monthStartDate, SHIELD_QUANTITY);
+    }
+
+    @Transactional
+    public void deleteByMemberId(Long memberId) {
+        continueReadingShieldHistoryRepository.deleteByMemberId(memberId);
+        continueReadingShieldRepository.deleteByMemberId(memberId);
+    }
+
+    private LocalDate currentMonthStartDate() {
+        return LocalDate.now(clock).withDayOfMonth(1);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -33,7 +33,7 @@ public class ContinueReadingShieldService {
                 ContinueReadingShieldHistory.grant(
                         memberId,
                         ContinueReadingShieldHistoryReason.SIGNUP,
-                        currentMonthlyShieldGrantEventDate(),
+                        currentDate(),
                         INITIAL_GRANT_COUNT
                 )
         );
@@ -63,7 +63,7 @@ public class ContinueReadingShieldService {
 
     @Transactional
     public void resetMonthlyShieldsIfFirstDay() {
-        LocalDate today = LocalDate.now(clock);
+        LocalDate today = currentDate();
         if (today.getDayOfMonth() != MONTHLY_SHIELD_GRANT_EVENT_DAY) {
             return;
         }
@@ -87,6 +87,10 @@ public class ContinueReadingShieldService {
     }
 
     private LocalDate currentMonthlyShieldGrantEventDate() {
-        return LocalDate.now(clock).withDayOfMonth(MONTHLY_SHIELD_GRANT_EVENT_DAY);
+        return currentDate().withDayOfMonth(MONTHLY_SHIELD_GRANT_EVENT_DAY);
+    }
+
+    private LocalDate currentDate() {
+        return LocalDate.now(clock);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.reading.domain.ContinueReadingShield;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistory;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryReason;
 import me.bombom.api.v1.reading.repository.ContinueReadingShieldHistoryRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingShieldRepository;
 import org.springframework.stereotype.Service;
@@ -27,7 +28,12 @@ public class ContinueReadingShieldService {
         ContinueReadingShield shield = ContinueReadingShield.create(memberId);
         continueReadingShieldRepository.save(shield);
         continueReadingShieldHistoryRepository.save(
-                ContinueReadingShieldHistory.grant(memberId, currentMonthlyShieldGrantEventDate(), SHIELD_QUANTITY)
+                ContinueReadingShieldHistory.grant(
+                        memberId,
+                        ContinueReadingShieldHistoryReason.SIGNUP,
+                        currentMonthlyShieldGrantEventDate(),
+                        SHIELD_QUANTITY
+                )
         );
     }
 
@@ -35,6 +41,7 @@ public class ContinueReadingShieldService {
     public boolean useShield(Long memberId, LocalDate targetDate) {
         int updatedRows = continueReadingShieldRepository.bulkDecreaseRemainingCountIfUsable(
                 memberId,
+                ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECT.name(),
                 targetDate,
                 SHIELD_QUANTITY
         );
@@ -42,7 +49,12 @@ public class ContinueReadingShieldService {
             return false;
         }
         continueReadingShieldHistoryRepository.save(
-                ContinueReadingShieldHistory.use(memberId, targetDate, SHIELD_QUANTITY)
+                ContinueReadingShieldHistory.use(
+                        memberId,
+                        ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECT,
+                        targetDate,
+                        SHIELD_QUANTITY
+                )
         );
         return true;
     }
@@ -54,8 +66,13 @@ public class ContinueReadingShieldService {
             return;
         }
         LocalDate monthlyShieldGrantEventDate = today.withDayOfMonth(MONTHLY_SHIELD_GRANT_EVENT_DAY);
-        continueReadingShieldRepository.bulkResetMonthlyIfNotGranted(monthlyShieldGrantEventDate, SHIELD_QUANTITY);
+        continueReadingShieldRepository.bulkResetMonthlyIfNotGranted(
+                ContinueReadingShieldHistoryReason.MONTHLY_RESET.name(),
+                monthlyShieldGrantEventDate,
+                SHIELD_QUANTITY
+        );
         continueReadingShieldHistoryRepository.bulkInsertMonthlyGrantHistories(
+                ContinueReadingShieldHistoryReason.MONTHLY_RESET.name(),
                 monthlyShieldGrantEventDate,
                 SHIELD_QUANTITY
         );

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -16,7 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ContinueReadingShieldService {
 
-    private static final int SHIELD_QUANTITY = 1;
+    private static final int INITIAL_GRANT_COUNT = 1;
+    private static final int SHIELD_DEDUCT_COUNT = 1;
+    private static final int MONTHLY_GRANT_COUNT = 1;
     private static final int MONTHLY_SHIELD_GRANT_EVENT_DAY = 1;
 
     private final ContinueReadingShieldRepository continueReadingShieldRepository;
@@ -32,7 +34,7 @@ public class ContinueReadingShieldService {
                         memberId,
                         ContinueReadingShieldHistoryReason.SIGNUP,
                         currentMonthlyShieldGrantEventDate(),
-                        SHIELD_QUANTITY
+                        INITIAL_GRANT_COUNT
                 )
         );
     }
@@ -43,7 +45,7 @@ public class ContinueReadingShieldService {
                 memberId,
                 ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECTION_USE.name(),
                 targetDate,
-                SHIELD_QUANTITY
+                SHIELD_DEDUCT_COUNT
         );
         if (updatedRows == 0) {
             return false;
@@ -53,7 +55,7 @@ public class ContinueReadingShieldService {
                         memberId,
                         ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECTION_USE,
                         targetDate,
-                        SHIELD_QUANTITY
+                        SHIELD_DEDUCT_COUNT
                 )
         );
         return true;
@@ -69,12 +71,12 @@ public class ContinueReadingShieldService {
         continueReadingShieldRepository.bulkResetMonthlyIfNotGranted(
                 ContinueReadingShieldHistoryReason.MONTHLY_RESET.name(),
                 monthlyShieldGrantEventDate,
-                SHIELD_QUANTITY
+                MONTHLY_GRANT_COUNT
         );
         continueReadingShieldHistoryRepository.bulkInsertMonthlyGrantHistories(
                 ContinueReadingShieldHistoryReason.MONTHLY_RESET.name(),
                 monthlyShieldGrantEventDate,
-                SHIELD_QUANTITY
+                MONTHLY_GRANT_COUNT
         );
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -86,10 +86,6 @@ public class ContinueReadingShieldService {
         continueReadingShieldRepository.deleteByMemberId(memberId);
     }
 
-    private LocalDate currentMonthlyShieldGrantEventDate() {
-        return currentDate().withDayOfMonth(MONTHLY_SHIELD_GRANT_DAY);
-    }
-
     private LocalDate currentDate() {
         return LocalDate.now(clock);
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -82,6 +82,7 @@ public class ReadingService {
     private final MonthlyRankingScheduleProperties scheduleProps;
     private final ContinueReadingRankingScheduleProperties continueReadingRankingScheduleProperties;
     private final BadgeService badgeService;
+    private final ContinueReadingShieldService continueReadingShieldService;
     private final ApplicationEventPublisher applicationEventPublisher;
     private final Clock clock;
 
@@ -89,6 +90,7 @@ public class ReadingService {
     public void initializeReadingInformation(Long memberId) {
         ContinueReadingRealtime newContinueReadingRealtime = ContinueReadingRealtime.create(memberId);
         continueReadingRepository.save(newContinueReadingRealtime);
+        continueReadingShieldService.initializeShield(memberId);
 
         continueReadingRankingSnapshotRepository.save(
             ContinueReadingSnapshot.create(
@@ -137,7 +139,7 @@ public class ReadingService {
         }
 
         todayReadingRepository.findTotalNonZeroAndReadZero()
-            .forEach(this::applyResetContinueReadingCount);
+            .forEach(todayReading -> applyResetContinueReadingCount(todayReading, targetDate));
     }
 
     @Transactional
@@ -383,6 +385,7 @@ public class ReadingService {
             monthlyReadingSnapshotRepository.deleteByMemberId(memberId);
             monthlyReadingRealtimeRepository.deleteByMemberId(memberId);
             yearlyReadingRepository.bulkDeleteByMemberId(memberId);
+            continueReadingShieldService.deleteByMemberId(memberId);
         } catch (Exception e) {
             log.error("회원 읽기 정보 삭제 실패. memberId = {}", memberId, e.getStackTrace());
         }
@@ -439,13 +442,19 @@ public class ReadingService {
         return lowestRankContinueReadingSnapshot.getRankOrder() + 1;
     }
 
-    private void applyResetContinueReadingCount(TodayReading todayReading) {
+    private void applyResetContinueReadingCount(TodayReading todayReading, LocalDate targetDate) {
         Long memberId = todayReading.getMemberId();
         ContinueReadingRealtime continueReading = continueReadingRepository.findByMemberId(memberId)
             .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                 .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                 .addContext(ErrorContextKeys.ENTITY_TYPE, "ContinueReadingRealtime")
                 .addContext(ErrorContextKeys.OPERATION, "applyResetContinueReadingCount"));
+        if (!continueReading.hasDayCount()) {
+            return;
+        }
+        if (continueReadingShieldService.useShield(memberId, targetDate)) {
+            return;
+        }
         continueReading.resetDayCount();
     }
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -449,7 +449,7 @@ public class ReadingService {
                 .addContext(ErrorContextKeys.MEMBER_ID, memberId)
                 .addContext(ErrorContextKeys.ENTITY_TYPE, "ContinueReadingRealtime")
                 .addContext(ErrorContextKeys.OPERATION, "applyResetContinueReadingCount"));
-        if (!continueReading.hasDayCount()) {
+        if (!continueReading.hasActiveStreak()) {
             return;
         }
         if (continueReadingShieldService.useShield(memberId, targetDate)) {

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
@@ -1,10 +1,11 @@
 CREATE TABLE continue_reading_shield
 (
-    id              BIGINT      NOT NULL AUTO_INCREMENT,
-    member_id       BIGINT      NOT NULL,
-    remaining_count TINYINT     NOT NULL DEFAULT 0,
-    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-    updated_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    id                      BIGINT      NOT NULL AUTO_INCREMENT,
+    member_id               BIGINT      NOT NULL,
+    monthly_remaining_count TINYINT     NOT NULL DEFAULT 0,
+    reward_remaining_count   TINYINT     NOT NULL DEFAULT 0,
+    created_at              DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at              DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     PRIMARY KEY (id),
     CONSTRAINT uk_continue_reading_shield_member_id UNIQUE (member_id)
 );
@@ -26,11 +27,13 @@ CREATE TABLE continue_reading_shield_history
 
 INSERT INTO continue_reading_shield (
     member_id,
-    remaining_count
+    monthly_remaining_count,
+    reward_remaining_count
 )
 SELECT
     id,
-    1
+    1,
+    0
 FROM member;
 
 INSERT INTO continue_reading_shield_history (

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
@@ -2,7 +2,7 @@ CREATE TABLE continue_reading_shield
 (
     id              BIGINT      NOT NULL AUTO_INCREMENT,
     member_id       BIGINT      NOT NULL,
-    remaining_count SMALLINT    NOT NULL DEFAULT 0,
+    remaining_count TINYINT     NOT NULL DEFAULT 0,
     created_at      DATETIME(6) DEFAULT NULL,
     updated_at      DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (id),
@@ -15,7 +15,7 @@ CREATE TABLE continue_reading_shield_history
     member_id  BIGINT      NOT NULL,
     type       VARCHAR(20) NOT NULL,
     event_date DATE        NOT NULL,
-    quantity   SMALLINT    NOT NULL,
+    quantity   TINYINT     NOT NULL,
     created_at DATETIME(6) DEFAULT NULL,
     updated_at DATETIME(6) DEFAULT NULL,
     PRIMARY KEY (id),

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
@@ -3,8 +3,8 @@ CREATE TABLE continue_reading_shield
     id              BIGINT      NOT NULL AUTO_INCREMENT,
     member_id       BIGINT      NOT NULL,
     remaining_count TINYINT     NOT NULL DEFAULT 0,
-    created_at      DATETIME(6) DEFAULT NULL,
-    updated_at      DATETIME(6) DEFAULT NULL,
+    created_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at      DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     PRIMARY KEY (id),
     CONSTRAINT uk_continue_reading_shield_member_id UNIQUE (member_id)
 );
@@ -16,8 +16,8 @@ CREATE TABLE continue_reading_shield_history
     type       VARCHAR(20) NOT NULL,
     event_date DATE        NOT NULL,
     quantity   TINYINT     NOT NULL,
-    created_at DATETIME(6) DEFAULT NULL,
-    updated_at DATETIME(6) DEFAULT NULL,
+    created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     PRIMARY KEY (id),
     CONSTRAINT uk_continue_reading_shield_history_member_type_date
         UNIQUE (member_id, type, event_date)
@@ -25,30 +25,22 @@ CREATE TABLE continue_reading_shield_history
 
 INSERT INTO continue_reading_shield (
     member_id,
-    remaining_count,
-    created_at,
-    updated_at
+    remaining_count
 )
 SELECT
     id,
-    1,
-    NOW(6),
-    NOW(6)
+    1
 FROM member;
 
 INSERT INTO continue_reading_shield_history (
     member_id,
     type,
     event_date,
-    quantity,
-    created_at,
-    updated_at
+    quantity
 )
 SELECT
     id,
     'GRANT',
     DATE_FORMAT(UTC_TIMESTAMP(6) + INTERVAL 9 HOUR, '%Y-%m-01'),
-    1,
-    NOW(6),
-    NOW(6)
+    1
 FROM member;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
@@ -1,0 +1,54 @@
+CREATE TABLE continue_reading_shield
+(
+    id              BIGINT      NOT NULL AUTO_INCREMENT,
+    member_id       BIGINT      NOT NULL,
+    remaining_count SMALLINT    NOT NULL DEFAULT 0,
+    created_at      DATETIME(6) DEFAULT NULL,
+    updated_at      DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_continue_reading_shield_member_id UNIQUE (member_id)
+);
+
+CREATE TABLE continue_reading_shield_history
+(
+    id         BIGINT      NOT NULL AUTO_INCREMENT,
+    member_id  BIGINT      NOT NULL,
+    type       VARCHAR(20) NOT NULL,
+    event_date DATE        NOT NULL,
+    quantity   SMALLINT    NOT NULL,
+    created_at DATETIME(6) DEFAULT NULL,
+    updated_at DATETIME(6) DEFAULT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uk_continue_reading_shield_history_member_type_date
+        UNIQUE (member_id, type, event_date)
+);
+
+INSERT INTO continue_reading_shield (
+    member_id,
+    remaining_count,
+    created_at,
+    updated_at
+)
+SELECT
+    id,
+    1,
+    NOW(6),
+    NOW(6)
+FROM member;
+
+INSERT INTO continue_reading_shield_history (
+    member_id,
+    type,
+    event_date,
+    quantity,
+    created_at,
+    updated_at
+)
+SELECT
+    id,
+    'GRANT',
+    DATE_FORMAT(UTC_TIMESTAMP(6) + INTERVAL 9 HOUR, '%Y-%m-01'),
+    1,
+    NOW(6),
+    NOW(6)
+FROM member;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.0.0__create_continue_reading_shield_tables.sql
@@ -14,13 +14,14 @@ CREATE TABLE continue_reading_shield_history
     id         BIGINT      NOT NULL AUTO_INCREMENT,
     member_id  BIGINT      NOT NULL,
     type       VARCHAR(20) NOT NULL,
+    reason     VARCHAR(30) NOT NULL,
     event_date DATE        NOT NULL,
     quantity   TINYINT     NOT NULL,
     created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
     updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
     PRIMARY KEY (id),
-    CONSTRAINT uk_continue_reading_shield_history_member_type_date
-        UNIQUE (member_id, type, event_date)
+    CONSTRAINT uk_continue_reading_shield_history_member_type_reason_date
+        UNIQUE (member_id, type, reason, event_date)
 );
 
 INSERT INTO continue_reading_shield (
@@ -35,12 +36,14 @@ FROM member;
 INSERT INTO continue_reading_shield_history (
     member_id,
     type,
+    reason,
     event_date,
     quantity
 )
 SELECT
     id,
     'GRANT',
+    'MIGRATION_BACKFILL',
     DATE_FORMAT(UTC_TIMESTAMP(6) + INTERVAL 9 HOUR, '%Y-%m-01'),
     1
 FROM member;

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.0.1__rename_daily_reset_shield_history_reason.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.0.1__rename_daily_reset_shield_history_reason.sql
@@ -1,0 +1,3 @@
+UPDATE continue_reading_shield_history
+SET reason = 'DAILY_RESET_PROTECTION_USE'
+WHERE reason = 'DAILY_RESET_PROTECT';

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/domain/ContinueReadingShieldTest.java
@@ -1,0 +1,27 @@
+package me.bombom.api.v1.reading.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class ContinueReadingShieldTest {
+
+    @Test
+    void 보호막_잔여_개수는_음수일_수_없다() {
+        assertThatThrownBy(() -> ContinueReadingShield.builder()
+                .memberId(1L)
+                .monthlyRemainingCount(-1)
+                .rewardRemainingCount(0)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("보호막 잔여 개수는 음수일 수 없습니다.");
+
+        assertThatThrownBy(() -> ContinueReadingShield.builder()
+                .memberId(1L)
+                .monthlyRemainingCount(0)
+                .rewardRemainingCount(-1)
+                .build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("보호막 잔여 개수는 음수일 수 없습니다.");
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/scheduler/ReadingSchedulerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/scheduler/ReadingSchedulerTest.java
@@ -1,13 +1,16 @@
 package me.bombom.api.v1.reading.scheduler;
 
+import me.bombom.api.v1.reading.service.ContinueReadingShieldService;
 import me.bombom.api.v1.reading.service.ReadingService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.context.ActiveProfiles;
 
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -21,14 +24,19 @@ class ReadingSchedulerTest {
     @Mock
     private ReadingService readingService;
 
+    @Mock
+    private ContinueReadingShieldService continueReadingShieldService;
+
     @Test
     void daily_ResetReadingCount_스케줄러는_연속_및_읽기_정보를_초기화한다() {
         // when
         readingScheduler.dailyResetReadingCount();
 
         // then
-        verify(readingService, times(1)).resetContinueReadingCount();
-        verify(readingService, times(1)).resetTodayReadingCount();
+        InOrder inOrder = inOrder(readingService, continueReadingShieldService);
+        inOrder.verify(readingService, times(1)).resetContinueReadingCount();
+        inOrder.verify(continueReadingShieldService, times(1)).resetMonthlyShieldsIfFirstDay();
+        inOrder.verify(readingService, times(1)).resetTodayReadingCount();
     }
 
     @Test

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
@@ -105,7 +105,7 @@ class ContinueReadingShieldServiceTest {
             softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
                     ContinueReadingShieldHistoryType.USE,
-                    ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECT,
+                    ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECTION_USE,
                     targetDate
             )).isEqualTo(1L);
         });
@@ -240,7 +240,7 @@ class ContinueReadingShieldServiceTest {
             softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
                     ContinueReadingShieldHistoryType.USE,
-                    ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECT,
+                    ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECTION_USE,
                     targetDate
             )).isEqualTo(1L);
             softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
@@ -1,0 +1,187 @@
+package me.bombom.api.v1.reading.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.UUID;
+import me.bombom.api.v1.TestFixture;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
+import me.bombom.api.v1.reading.domain.ContinueReadingShield;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
+import me.bombom.api.v1.reading.domain.TodayReading;
+import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
+import me.bombom.api.v1.reading.repository.ContinueReadingShieldHistoryRepository;
+import me.bombom.api.v1.reading.repository.ContinueReadingShieldRepository;
+import me.bombom.api.v1.reading.repository.TodayReadingRepository;
+import me.bombom.support.IntegrationTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+
+@IntegrationTest
+@Import(ContinueReadingShieldServiceTest.FixedClockConfig.class)
+class ContinueReadingShieldServiceTest {
+
+    private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
+    private static final LocalDate FIXED_DATE = LocalDate.of(2026, 5, 1);
+    private static final LocalDate MONTH_START_DATE = LocalDate.of(2026, 5, 1);
+
+    @Autowired
+    private ContinueReadingShieldService continueReadingShieldService;
+
+    @Autowired
+    private ReadingService readingService;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TodayReadingRepository todayReadingRepository;
+
+    @Autowired
+    private ContinueReadingRealtimeRepository continueReadingRealtimeRepository;
+
+    @Autowired
+    private ContinueReadingShieldRepository continueReadingShieldRepository;
+
+    @Autowired
+    private ContinueReadingShieldHistoryRepository continueReadingShieldHistoryRepository;
+
+    @BeforeEach
+    void setUp() {
+        continueReadingShieldHistoryRepository.deleteAllInBatch();
+        continueReadingShieldRepository.deleteAllInBatch();
+        continueReadingRealtimeRepository.deleteAllInBatch();
+        todayReadingRepository.deleteAllInBatch();
+        memberRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void 가입_초기화_시_보호막_1개와_월_지급_이력을_생성한다() {
+        Member member = createMember();
+
+        continueReadingShieldService.initializeShield(member.getId());
+
+        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(shield.getRemainingCount()).isEqualTo(1);
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+                    member.getId(),
+                    ContinueReadingShieldHistoryType.GRANT,
+                    MONTH_START_DATE
+            )).isEqualTo(1L);
+        });
+    }
+
+    @Test
+    void 보호막은_같은_날_한_번만_사용된다() {
+        Member member = createMember();
+        continueReadingShieldRepository.save(ContinueReadingShield.create(member.getId()));
+        LocalDate targetDate = LocalDate.of(2026, 4, 30);
+
+        boolean firstResult = continueReadingShieldService.useShield(member.getId(), targetDate);
+        boolean secondResult = continueReadingShieldService.useShield(member.getId(), targetDate);
+
+        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(firstResult).isTrue();
+            softly.assertThat(secondResult).isFalse();
+            softly.assertThat(shield.getRemainingCount()).isZero();
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+                    member.getId(),
+                    ContinueReadingShieldHistoryType.USE,
+                    targetDate
+            )).isEqualTo(1L);
+        });
+    }
+
+    @Test
+    void 월초_보호막_리셋은_같은_월에_한_번만_적용된다() {
+        Member member = createMember();
+        continueReadingShieldRepository.save(ContinueReadingShield.builder()
+                .memberId(member.getId())
+                .remainingCount(0)
+                .build());
+
+        continueReadingShieldService.resetMonthlyShieldsIfFirstDay();
+
+        ContinueReadingShield grantedShield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
+        assertThat(grantedShield.getRemainingCount()).isEqualTo(1);
+
+        continueReadingShieldService.useShield(member.getId(), LocalDate.of(2026, 5, 1));
+        continueReadingShieldService.resetMonthlyShieldsIfFirstDay();
+
+        ContinueReadingShield usedShield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(usedShield.getRemainingCount()).isZero();
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+                    member.getId(),
+                    ContinueReadingShieldHistoryType.GRANT,
+                    MONTH_START_DATE
+            )).isEqualTo(1L);
+        });
+    }
+
+    @Test
+    void 월경계에서는_전날_미독을_보호막으로_처리한_뒤_이번달_보호막을_1개로_리셋한다() {
+        Member member = createMember();
+        LocalDate targetDate = LocalDate.of(2026, 4, 30);
+        todayReadingRepository.save(TodayReading.builder()
+                .memberId(member.getId())
+                .totalCount(3)
+                .currentCount(0)
+                .readCount(0)
+                .build());
+        continueReadingRealtimeRepository.save(ContinueReadingRealtime.builder()
+                .memberId(member.getId())
+                .dayCount(10)
+                .maxDayCount(15)
+                .build());
+        continueReadingShieldRepository.save(ContinueReadingShield.create(member.getId()));
+
+        readingService.resetContinueReadingCount();
+        continueReadingShieldService.resetMonthlyShieldsIfFirstDay();
+
+        ContinueReadingRealtime continueReading = continueReadingRealtimeRepository.findByMemberId(member.getId()).orElseThrow();
+        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(continueReading.getDayCount()).isEqualTo(10);
+            softly.assertThat(continueReading.getMaxDayCount()).isEqualTo(15);
+            softly.assertThat(shield.getRemainingCount()).isEqualTo(1);
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+                    member.getId(),
+                    ContinueReadingShieldHistoryType.USE,
+                    targetDate
+            )).isEqualTo(1L);
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+                    member.getId(),
+                    ContinueReadingShieldHistoryType.GRANT,
+                    MONTH_START_DATE
+            )).isEqualTo(1L);
+        });
+    }
+
+    private Member createMember() {
+        String suffix = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        return memberRepository.save(TestFixture.createUniqueMember("shield_" + suffix, "shield_pid_" + suffix));
+    }
+
+    @TestConfiguration
+    static class FixedClockConfig {
+
+        @Bean
+        @Primary
+        Clock fixedClock() {
+            return Clock.fixed(FIXED_DATE.atStartOfDay(SEOUL_ZONE).toInstant(), SEOUL_ZONE);
+        }
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
@@ -12,6 +12,7 @@ import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
 import me.bombom.api.v1.reading.domain.ContinueReadingShield;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryReason;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
 import me.bombom.api.v1.reading.domain.TodayReading;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
@@ -74,9 +75,10 @@ class ContinueReadingShieldServiceTest {
         ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
         assertSoftly(softly -> {
             softly.assertThat(shield.getRemainingCount()).isEqualTo(1);
-            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
                     ContinueReadingShieldHistoryType.GRANT,
+                    ContinueReadingShieldHistoryReason.SIGNUP,
                     MONTH_START_DATE
             )).isEqualTo(1L);
         });
@@ -96,9 +98,10 @@ class ContinueReadingShieldServiceTest {
             softly.assertThat(firstResult).isTrue();
             softly.assertThat(secondResult).isFalse();
             softly.assertThat(shield.getRemainingCount()).isZero();
-            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
                     ContinueReadingShieldHistoryType.USE,
+                    ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECT,
                     targetDate
             )).isEqualTo(1L);
         });
@@ -123,9 +126,10 @@ class ContinueReadingShieldServiceTest {
         ContinueReadingShield usedShield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
         assertSoftly(softly -> {
             softly.assertThat(usedShield.getRemainingCount()).isZero();
-            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
                     ContinueReadingShieldHistoryType.GRANT,
+                    ContinueReadingShieldHistoryReason.MONTHLY_RESET,
                     MONTH_START_DATE
             )).isEqualTo(1L);
         });
@@ -157,14 +161,16 @@ class ContinueReadingShieldServiceTest {
             softly.assertThat(continueReading.getDayCount()).isEqualTo(10);
             softly.assertThat(continueReading.getMaxDayCount()).isEqualTo(15);
             softly.assertThat(shield.getRemainingCount()).isEqualTo(1);
-            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
                     ContinueReadingShieldHistoryType.USE,
+                    ContinueReadingShieldHistoryReason.DAILY_RESET_PROTECT,
                     targetDate
             )).isEqualTo(1L);
-            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
                     ContinueReadingShieldHistoryType.GRANT,
+                    ContinueReadingShieldHistoryReason.MONTHLY_RESET,
                     MONTH_START_DATE
             )).isEqualTo(1L);
         });

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
@@ -74,6 +74,8 @@ class ContinueReadingShieldServiceTest {
 
         ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
         assertSoftly(softly -> {
+            softly.assertThat(shield.getMonthlyRemainingCount()).isEqualTo(1);
+            softly.assertThat(shield.getRewardRemainingCount()).isZero();
             softly.assertThat(shield.getRemainingCount()).isEqualTo(1);
             softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
@@ -97,6 +99,8 @@ class ContinueReadingShieldServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(firstResult).isTrue();
             softly.assertThat(secondResult).isFalse();
+            softly.assertThat(shield.getMonthlyRemainingCount()).isZero();
+            softly.assertThat(shield.getRewardRemainingCount()).isZero();
             softly.assertThat(shield.getRemainingCount()).isZero();
             softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
@@ -112,19 +116,26 @@ class ContinueReadingShieldServiceTest {
         Member member = createMember();
         continueReadingShieldRepository.save(ContinueReadingShield.builder()
                 .memberId(member.getId())
-                .remainingCount(0)
+                .monthlyRemainingCount(0)
+                .rewardRemainingCount(0)
                 .build());
 
         continueReadingShieldService.resetMonthlyShieldsIfFirstDay();
 
         ContinueReadingShield grantedShield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
-        assertThat(grantedShield.getRemainingCount()).isEqualTo(1);
+        assertSoftly(softly -> {
+            softly.assertThat(grantedShield.getMonthlyRemainingCount()).isEqualTo(1);
+            softly.assertThat(grantedShield.getRewardRemainingCount()).isZero();
+            softly.assertThat(grantedShield.getRemainingCount()).isEqualTo(1);
+        });
 
         continueReadingShieldService.useShield(member.getId(), LocalDate.of(2026, 5, 1));
         continueReadingShieldService.resetMonthlyShieldsIfFirstDay();
 
         ContinueReadingShield usedShield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
         assertSoftly(softly -> {
+            softly.assertThat(usedShield.getMonthlyRemainingCount()).isZero();
+            softly.assertThat(usedShield.getRewardRemainingCount()).isZero();
             softly.assertThat(usedShield.getRemainingCount()).isZero();
             softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     member.getId(),
@@ -132,6 +143,51 @@ class ContinueReadingShieldServiceTest {
                     ContinueReadingShieldHistoryReason.MONTHLY_RESET,
                     MONTH_START_DATE
             )).isEqualTo(1L);
+        });
+    }
+
+    @Test
+    void 월초_보호막_리셋은_보상_보호막을_이월한다() {
+        Member member = createMember();
+        continueReadingShieldRepository.save(ContinueReadingShield.builder()
+                .memberId(member.getId())
+                .monthlyRemainingCount(0)
+                .rewardRemainingCount(2)
+                .build());
+
+        continueReadingShieldService.resetMonthlyShieldsIfFirstDay();
+
+        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(shield.getMonthlyRemainingCount()).isEqualTo(1);
+            softly.assertThat(shield.getRewardRemainingCount()).isEqualTo(2);
+            softly.assertThat(shield.getRemainingCount()).isEqualTo(3);
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
+                    member.getId(),
+                    ContinueReadingShieldHistoryType.GRANT,
+                    ContinueReadingShieldHistoryReason.MONTHLY_RESET,
+                    MONTH_START_DATE
+            )).isEqualTo(1L);
+        });
+    }
+
+    @Test
+    void 보호막_사용은_월_지급분을_먼저_차감한다() {
+        Member member = createMember();
+        continueReadingShieldRepository.save(ContinueReadingShield.builder()
+                .memberId(member.getId())
+                .monthlyRemainingCount(1)
+                .rewardRemainingCount(1)
+                .build());
+
+        boolean result = continueReadingShieldService.useShield(member.getId(), LocalDate.of(2026, 4, 30));
+
+        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(result).isTrue();
+            softly.assertThat(shield.getMonthlyRemainingCount()).isZero();
+            softly.assertThat(shield.getRewardRemainingCount()).isEqualTo(1);
+            softly.assertThat(shield.getRemainingCount()).isEqualTo(1);
         });
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
@@ -192,6 +192,26 @@ class ContinueReadingShieldServiceTest {
     }
 
     @Test
+    void 보호막_사용은_월_지급분이_없으면_보상_지급분을_차감한다() {
+        Member member = createMember();
+        continueReadingShieldRepository.save(ContinueReadingShield.builder()
+                .memberId(member.getId())
+                .monthlyRemainingCount(0)
+                .rewardRemainingCount(2)
+                .build());
+
+        boolean result = continueReadingShieldService.useShield(member.getId(), LocalDate.of(2026, 4, 30));
+
+        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow();
+        assertSoftly(softly -> {
+            softly.assertThat(result).isTrue();
+            softly.assertThat(shield.getMonthlyRemainingCount()).isZero();
+            softly.assertThat(shield.getRewardRemainingCount()).isEqualTo(1);
+            softly.assertThat(shield.getRemainingCount()).isEqualTo(1);
+        });
+    }
+
+    @Test
     void 월경계에서는_전날_미독을_보호막으로_처리한_뒤_이번달_보호막을_1개로_리셋한다() {
         Member member = createMember();
         LocalDate targetDate = LocalDate.of(2026, 4, 30);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ContinueReadingShieldServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.UUID;
@@ -33,7 +34,7 @@ import org.springframework.context.annotation.Primary;
 class ContinueReadingShieldServiceTest {
 
     private static final ZoneId SEOUL_ZONE = ZoneId.of("Asia/Seoul");
-    private static final LocalDate FIXED_DATE = LocalDate.of(2026, 5, 1);
+    private static final LocalDate SIGNUP_DATE = LocalDate.of(2026, 5, 15);
     private static final LocalDate MONTH_START_DATE = LocalDate.of(2026, 5, 1);
 
     @Autowired
@@ -57,8 +58,12 @@ class ContinueReadingShieldServiceTest {
     @Autowired
     private ContinueReadingShieldHistoryRepository continueReadingShieldHistoryRepository;
 
+    @Autowired
+    private Clock clock;
+
     @BeforeEach
     void setUp() {
+        fixClockTo(MONTH_START_DATE);
         continueReadingShieldHistoryRepository.deleteAllInBatch();
         continueReadingShieldRepository.deleteAllInBatch();
         continueReadingRealtimeRepository.deleteAllInBatch();
@@ -67,7 +72,8 @@ class ContinueReadingShieldServiceTest {
     }
 
     @Test
-    void 가입_초기화_시_보호막_1개와_월_지급_이력을_생성한다() {
+    void 가입_초기화_시_보호막_1개와_가입일_지급_이력을_생성한다() {
+        fixClockTo(SIGNUP_DATE);
         Member member = createMember();
 
         continueReadingShieldService.initializeShield(member.getId());
@@ -81,7 +87,7 @@ class ContinueReadingShieldServiceTest {
                     member.getId(),
                     ContinueReadingShieldHistoryType.GRANT,
                     ContinueReadingShieldHistoryReason.SIGNUP,
-                    MONTH_START_DATE
+                    SIGNUP_DATE
             )).isEqualTo(1L);
         });
     }
@@ -257,13 +263,47 @@ class ContinueReadingShieldServiceTest {
         return memberRepository.save(TestFixture.createUniqueMember("shield_" + suffix, "shield_pid_" + suffix));
     }
 
+    private void fixClockTo(LocalDate date) {
+        ((MutableClock) clock).setDate(date);
+    }
+
     @TestConfiguration
     static class FixedClockConfig {
 
         @Bean
         @Primary
         Clock fixedClock() {
-            return Clock.fixed(FIXED_DATE.atStartOfDay(SEOUL_ZONE).toInstant(), SEOUL_ZONE);
+            return new MutableClock(MONTH_START_DATE, SEOUL_ZONE);
+        }
+    }
+
+    private static class MutableClock extends Clock {
+
+        private final ZoneId zone;
+        private Instant instant;
+
+        private MutableClock(LocalDate date, ZoneId zone) {
+            this.zone = zone;
+            setDate(date);
+        }
+
+        private void setDate(LocalDate date) {
+            this.instant = date.atStartOfDay(zone).toInstant();
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return zone;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            return Clock.fixed(instant, zone);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
         }
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceResetContinueReadingCountTest.java
@@ -2,6 +2,8 @@ package me.bombom.api.v1.reading.service;
 
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -39,6 +41,9 @@ class ReadingServiceResetContinueReadingCountTest {
     private HolidayRepository holidayRepository;
 
     @Mock
+    private ContinueReadingShieldService continueReadingShieldService;
+
+    @Mock
     private Clock clock;
 
     @Test
@@ -48,6 +53,7 @@ class ReadingServiceResetContinueReadingCountTest {
         readingService.resetContinueReadingCount();
 
         verify(todayReadingRepository, never()).findTotalNonZeroAndReadZero();
+        verify(continueReadingShieldService, never()).useShield(anyLong(), any());
     }
 
     @Test
@@ -57,6 +63,7 @@ class ReadingServiceResetContinueReadingCountTest {
         readingService.resetContinueReadingCount();
 
         verify(todayReadingRepository, never()).findTotalNonZeroAndReadZero();
+        verify(continueReadingShieldService, never()).useShield(anyLong(), any());
     }
 
     @Test
@@ -68,12 +75,14 @@ class ReadingServiceResetContinueReadingCountTest {
         readingService.resetContinueReadingCount();
 
         verify(todayReadingRepository, never()).findTotalNonZeroAndReadZero();
+        verify(continueReadingShieldService, never()).useShield(anyLong(), any());
     }
 
     @Test
-    void 어제가_평일이면_연속_읽기_횟수를_초기화하고_최대_스트릭은_유지한다() {
+    void 어제가_평일이고_보호막이_없으면_연속_읽기_횟수를_초기화하고_최대_스트릭은_유지한다() {
         fixClockTo(LocalDate.of(2026, 4, 28)); // Tuesday
-        given(holidayRepository.existsByDate(LocalDate.of(2026, 4, 27))).willReturn(false);
+        LocalDate targetDate = LocalDate.of(2026, 4, 27);
+        given(holidayRepository.existsByDate(targetDate)).willReturn(false);
         TodayReading todayReading = TodayReading.builder()
                 .memberId(1L)
                 .totalCount(3)
@@ -87,6 +96,7 @@ class ReadingServiceResetContinueReadingCountTest {
                 .build();
         given(todayReadingRepository.findTotalNonZeroAndReadZero()).willReturn(List.of(todayReading));
         given(continueReadingRepository.findByMemberId(1L)).willReturn(Optional.of(continueReading));
+        given(continueReadingShieldService.useShield(1L, targetDate)).willReturn(false);
 
         readingService.resetContinueReadingCount();
 
@@ -94,6 +104,62 @@ class ReadingServiceResetContinueReadingCountTest {
             softly.assertThat(continueReading.getDayCount()).isZero();
             softly.assertThat(continueReading.getMaxDayCount()).isEqualTo(15);
         });
+    }
+
+    @Test
+    void 어제가_평일이고_보호막이_있으면_연속_읽기_횟수를_유지한다() {
+        fixClockTo(LocalDate.of(2026, 4, 28)); // Tuesday
+        LocalDate targetDate = LocalDate.of(2026, 4, 27);
+        given(holidayRepository.existsByDate(targetDate)).willReturn(false);
+        TodayReading todayReading = TodayReading.builder()
+                .memberId(1L)
+                .totalCount(3)
+                .currentCount(0)
+                .readCount(0)
+                .build();
+        ContinueReadingRealtime continueReading = ContinueReadingRealtime.builder()
+                .memberId(1L)
+                .dayCount(10)
+                .maxDayCount(15)
+                .build();
+        given(todayReadingRepository.findTotalNonZeroAndReadZero()).willReturn(List.of(todayReading));
+        given(continueReadingRepository.findByMemberId(1L)).willReturn(Optional.of(continueReading));
+        given(continueReadingShieldService.useShield(1L, targetDate)).willReturn(true);
+
+        readingService.resetContinueReadingCount();
+
+        assertSoftly(softly -> {
+            softly.assertThat(continueReading.getDayCount()).isEqualTo(10);
+            softly.assertThat(continueReading.getMaxDayCount()).isEqualTo(15);
+        });
+    }
+
+    @Test
+    void 연속_읽기_횟수가_0이면_보호막을_차감하지_않는다() {
+        fixClockTo(LocalDate.of(2026, 4, 28)); // Tuesday
+        LocalDate targetDate = LocalDate.of(2026, 4, 27);
+        given(holidayRepository.existsByDate(targetDate)).willReturn(false);
+        TodayReading todayReading = TodayReading.builder()
+                .memberId(1L)
+                .totalCount(3)
+                .currentCount(0)
+                .readCount(0)
+                .build();
+        ContinueReadingRealtime continueReading = ContinueReadingRealtime.builder()
+                .memberId(1L)
+                .dayCount(0)
+                .maxDayCount(15)
+                .build();
+        given(todayReadingRepository.findTotalNonZeroAndReadZero()).willReturn(List.of(todayReading));
+        given(continueReadingRepository.findByMemberId(1L)).willReturn(Optional.of(continueReading));
+
+        readingService.resetContinueReadingCount();
+
+        assertSoftly(softly -> {
+            softly.assertThat(continueReading.getDayCount()).isZero();
+            softly.assertThat(continueReading.getMaxDayCount()).isEqualTo(15);
+        });
+        verify(continueReadingShieldService, never()).useShield(anyLong(), any());
     }
 
     @Test
@@ -105,6 +171,7 @@ class ReadingServiceResetContinueReadingCountTest {
         readingService.resetContinueReadingCount();
 
         verify(continueReadingRepository, never()).findByMemberId(1L);
+        verify(continueReadingShieldService, never()).useShield(anyLong(), any());
     }
 
     private void fixClockTo(LocalDate date) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -21,6 +21,7 @@ import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
 import me.bombom.api.v1.reading.domain.ContinueReadingRankHistory;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
 import me.bombom.api.v1.reading.domain.ContinueReadingSnapshot;
 import me.bombom.api.v1.reading.domain.MonthlyReadingRankHistory;
 import me.bombom.api.v1.reading.domain.MonthlyReadingSnapshot;
@@ -35,6 +36,8 @@ import me.bombom.api.v1.reading.dto.response.MemberMonthlyReadingRankResponse;
 import me.bombom.api.v1.reading.dto.response.MonthlyReadingRankingResponse;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingRankHistoryRepository;
+import me.bombom.api.v1.reading.repository.ContinueReadingShieldHistoryRepository;
+import me.bombom.api.v1.reading.repository.ContinueReadingShieldRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingSnapshotRepository;
 import me.bombom.api.v1.reading.repository.MonthlyReadingRankHistoryRepository;
 import me.bombom.api.v1.reading.repository.MonthlyReadingRealtimeRepository;
@@ -66,6 +69,12 @@ class ReadingServiceTest {
 
     @Autowired
     private ContinueReadingRankHistoryRepository continueReadingRankHistoryRepository;
+
+    @Autowired
+    private ContinueReadingShieldRepository continueReadingShieldRepository;
+
+    @Autowired
+    private ContinueReadingShieldHistoryRepository continueReadingShieldHistoryRepository;
 
     @Autowired
     private TodayReadingRepository todayReadingRepository;
@@ -104,6 +113,8 @@ class ReadingServiceTest {
     void setUp() {
         // 기존 데이터 삭제
         badgeRepository.deleteAllInBatch();
+        continueReadingShieldHistoryRepository.deleteAllInBatch();
+        continueReadingShieldRepository.deleteAllInBatch();
         monthlyReadingRankHistoryRepository.deleteAllInBatch();
         continueReadingRankHistoryRepository.deleteAllInBatch();
         yearlyReadingRepository.deleteAllInBatch();
@@ -343,6 +354,13 @@ class ReadingServiceTest {
             softly.assertThat(result.data().get(1).nickname()).isEqualTo(newMember.getNickname());
             softly.assertThat(result.data().get(1).rank()).isEqualTo(2L);
             softly.assertThat(result.data().get(1).dayCount()).isEqualTo(0);
+            softly.assertThat(continueReadingShieldRepository.findByMemberId(newMember.getId()).orElseThrow()
+                    .getRemainingCount()).isEqualTo(1);
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+                    newMember.getId(),
+                    ContinueReadingShieldHistoryType.GRANT,
+                    LocalDate.now(clock).withDayOfMonth(1)
+            )).isEqualTo(1L);
         });
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -361,7 +361,7 @@ class ReadingServiceTest {
                     newMember.getId(),
                     ContinueReadingShieldHistoryType.GRANT,
                     ContinueReadingShieldHistoryReason.SIGNUP,
-                    LocalDate.now(clock).withDayOfMonth(1)
+                    LocalDate.now(clock)
             )).isEqualTo(1L);
         });
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -21,6 +21,7 @@ import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
 import me.bombom.api.v1.reading.domain.ContinueReadingRankHistory;
+import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryReason;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
 import me.bombom.api.v1.reading.domain.ContinueReadingSnapshot;
 import me.bombom.api.v1.reading.domain.MonthlyReadingRankHistory;
@@ -356,9 +357,10 @@ class ReadingServiceTest {
             softly.assertThat(result.data().get(1).dayCount()).isEqualTo(0);
             softly.assertThat(continueReadingShieldRepository.findByMemberId(newMember.getId()).orElseThrow()
                     .getRemainingCount()).isEqualTo(1);
-            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndEventDate(
+            softly.assertThat(continueReadingShieldHistoryRepository.countByMemberIdAndTypeAndReasonAndEventDate(
                     newMember.getId(),
                     ContinueReadingShieldHistoryType.GRANT,
+                    ContinueReadingShieldHistoryReason.SIGNUP,
                     LocalDate.now(clock).withDayOfMonth(1)
             )).isEqualTo(1L);
         });


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

<img width="215" height="305" alt="image" src="https://github.com/user-attachments/assets/f44d85fc-cbbf-4322-9c19-564ba0371e13" />


연속읽기 보호막 기능을 추가했습니다.

<details>
  <summary>상세 내용</summary>

- 보호막 보유 회원이 일일 연속읽기 초기화 대상이면 `dayCount`를 0으로 만들지 않고 보호막 1개를 자동 차감합니다.   
- 신규 가입자에게 보호막 1개를 지급합니다.   
- 기존 회원에게도 마이그레이션으로 보호막 1개와 현재 월 `GRANT`(지급) 이력을 생성합니다.   
- 매월 1일 보호막 보유량을 1개로 리셋합니다.   
- 보호막 지급/사용 이력을 `continue_reading_shield_history`에 기록합니다.   
- 이번 PR에서는 보호막 수량 확인  API는 포함되지 않습니다.
- 보호막 이력에 `reason`을 추가했습니다.
  - `SIGNUP`: 신규 가입 시 기본 보호막 지급
  - `MONTHLY_RESET`: 매월 1일 보호막 보유량 1개로 리셋
  - `MIGRATION_BACKFILL`: 기존 회원 대상 마이그레이션 지급
  - `DAILY_RESET_PROTECT`: 일일 연속읽기 초기화 보호를 위한 보호막 사용
</details>




## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
기존에는 하루라도 읽지 않으면 연속읽기 일수가 바로 초기화됐습니다.
보호막을 도입해 사용자가 한 번의 미독으로 연속읽기 기록을 잃지 않도록 완충 장치를 제공합니다.

또한 월 단위로 보호막을 1개만 지급해야 하므로, 단순 수량 저장뿐 아니라 `GRANT` / `USE` 이력을 함께 저장해 중복 지급과 중복 사용을 방지했습니다.


## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
### continue_reading_shield 테이블 추가

- 회원별 보호막 잔여 수량을 저장합니다.
- `member_id` unique 제약으로 회원당 하나의 보호막 상태만 갖도록 했습니다.
- 보호막 잔여 수량은 지급 유형별로 분리했습니다.
  - `monthly_remaining_count`: 매월 기본 제공되는 보호막 수량입니다. 매월 1일 1개로 리셋되며 이월되지 않습니다.
  - `reward_remaining_count`: 이벤트/보상 등으로 지급되는 보호막 수량입니다. 월 리셋 대상이 아니며 이월됩니다.

### continue_reading_shield_history 테이블 추가

- `type`은 보호막 수량의 방향을 나타냅니다.
  - `GRANT`: 보호막 지급
  - `USE`: 보호막 사용
- `reason`은 이력이 발생한 원인을 나타냅니다.
  - `SIGNUP`: 신규 가입 지급
  - `MONTHLY_RESET`: 매월 1일 월별 기본 보호막을 1개로 리셋합니다.
  - `MIGRATION_BACKFILL`: 기존 회원 마이그레이션 지급
  - `DAILY_RESET_PROTECT`: 일일 초기화 보호를 위한 사용
- `member_id`, `type`, `reason`, `event_date` unique 제약으로 같은 원인의 중복 지급/사용을 방지했습니다.

### 이월 기준

- 이월되지 않는 대상: 월별 기본 제공 보호막
- 이월되는 대상: 이벤트/보상 등 별도 지급 보호막

### ContinueReadingShieldService 추가

- 가입 시 월별 기본 보호막 1개를 초기화하고 `SIGNUP` 이력을 생성합니다.
- 일일 초기화 보호 시 보호막을 1개 차감하고 `DAILY_RESET_PROTECT` 이력을 생성합니다.
  - 월별 기본 보호막을 먼저 차감합니다.
  - 월별 기본 보호막이 부족하면 보상 보호막을 차감합니다.
- 매월 1일 월별 기본 보호막을 1개로 리셋하고 `MONTHLY_RESET` 이력을 생성합니다.
  - 보상 보호막은 월 리셋 시 차감하거나 초기화하지 않습니다.
- 회원 탈퇴 시 보호막 상태와 이력을 함께 삭제합니다.

### 기존 회원 backfill

- 기존 회원 전원에게 월별 기본 보호막 1개를 생성합니다.
- 현재 월 기준 `MIGRATION_BACKFILL` 이력을 생성합니다.

### ReadingService.resetContinueReadingCount() 연결

- `dayCount > 0`인 경우에만 보호막 사용을 시도합니다.
- 보호막 사용에 성공하면 streak을 유지합니다.
- 보호막이 없거나 이미 사용한 경우 기존처럼 `dayCount = 0`으로 초기화합니다.

### ReadingScheduler.dailyResetReadingCount() 순서 조정

- 전날 미독으로 인한 연속읽기 초기화를 먼저 처리합니다.
- 이후 매월 1일이면 월별 기본 보호막을 1개로 리셋합니다.
- 마지막으로 오늘 읽기 수를 초기화합니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 코드에 코멘트 남겨놓았습니다.  
- 기능 먼저 구현되고 공지사항을 통해 유저들에게 알릴 생각입니다. 
- 프론트에서 이번에 새로온 상추가 설계 끝나면 UI도 바로 구현 예정입니다.