### PR TITLE
[BOM-1161] feat: 마이페이지 월별 카테고리 통계 api

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleReadHistoryRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleReadHistoryRepository.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import me.bombom.api.v1.article.domain.ArticleReadHistory;
+import me.bombom.api.v1.member.dto.CategoryReadCount;
 import me.bombom.api.v1.reading.dto.DailyReadCount;
 import me.bombom.api.v1.reading.dto.FrequentReadNewsletter;
 import me.bombom.api.v1.reading.dto.ReadCountComparison;
@@ -17,6 +18,26 @@ public interface ArticleReadHistoryRepository extends JpaRepository<ArticleReadH
     Optional<ArticleReadHistory> findByMemberIdAndArticleId(Long memberId, Long articleId);
 
     int countByMemberId(Long memberId);
+
+    @Query("""
+            SELECT new me.bombom.api.v1.member.dto.CategoryReadCount(
+                c.id,
+                c.name,
+                COUNT(h.id)
+            )
+            FROM ArticleReadHistory h
+            JOIN Category c ON c.id = h.categoryId
+            WHERE h.memberId = :memberId
+              AND h.readAt >= :start
+              AND h.readAt < :end
+            GROUP BY c.id, c.name
+            ORDER BY COUNT(h.id) DESC, c.id ASC
+            """)
+    List<CategoryReadCount> countReadsByCategory(
+            @Param("memberId") Long memberId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
 
     @Query("""
             SELECT new me.bombom.api.v1.reading.dto.ReadCountComparison(

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageController.java
@@ -40,6 +40,7 @@ public class MyPageController implements MyPageApi, MyPageControllerApi {
         return myPageService.getRankSummary(member, type);
     }
 
+    @Override
     @GetMapping("/category-stats")
     public CategoryStatsResponse getCategoryStats(
             @LoginMember Member member,

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageController.java
@@ -3,6 +3,7 @@ package me.bombom.api.v1.member.controller;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.dto.response.CategoryStatsResponse;
 import me.bombom.api.v1.member.dto.response.RankSummaryResponse;
 import me.bombom.api.v1.member.service.MemberService;
 import me.bombom.api.v1.member.service.MyPageService;
@@ -37,5 +38,13 @@ public class MyPageController implements MyPageApi, MyPageControllerApi {
             return myPageService.getRankSummary(member);
         }
         return myPageService.getRankSummary(member, type);
+    }
+
+    @GetMapping("/category-stats")
+    public CategoryStatsResponse getCategoryStats(
+            @LoginMember Member member,
+            @RequestParam(required = false) String yearMonth
+    ) {
+        return myPageService.getCategoryStats(member, yearMonth);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageController.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.member.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
@@ -7,9 +8,11 @@ import me.bombom.api.v1.member.dto.response.CategoryStatsResponse;
 import me.bombom.api.v1.member.dto.response.RankSummaryResponse;
 import me.bombom.api.v1.member.service.MemberService;
 import me.bombom.api.v1.member.service.MyPageService;
+import me.bombom.openapi.monthlyreport.model.MonthlyReportRequest;
 import me.bombom.openapi.mypage.api.MyPageApi;
 import me.bombom.openapi.mypage.model.MemberJoinDaysResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,8 +47,8 @@ public class MyPageController implements MyPageApi, MyPageControllerApi {
     @GetMapping("/category-stats")
     public CategoryStatsResponse getCategoryStats(
             @LoginMember Member member,
-            @RequestParam(required = false) String yearMonth
+            @Valid @ModelAttribute MonthlyReportRequest request
     ) {
-        return myPageService.getCategoryStats(member, yearMonth);
+        return myPageService.getCategoryStats(member, request);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageControllerApi.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.dto.response.CategoryStatsResponse;
 import me.bombom.api.v1.member.dto.response.RankSummaryResponse;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -38,5 +39,23 @@ public interface MyPageControllerApi {
                     schema = @Schema(allowableValues = {"streak", "reading"})
             )
             @RequestParam(required = false) String type
+    );
+
+    @Operation(
+            summary = "마이페이지 월별 카테고리 통계 조회",
+            description = "로그인한 회원이 지정한 월에 읽은 뉴스의 카테고리별 통계를 조회합니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "마이페이지 월별 카테고리 통계 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 yearMonth 형식", content = @Content)
+    })
+    CategoryStatsResponse getCategoryStats(
+            @Parameter(hidden = true) @LoginMember Member member,
+            @Parameter(
+                    description = "조회할 연월",
+                    example = "2026-05",
+                    schema = @Schema(pattern = "^\\d{4}-\\d{2}$")
+            )
+            @RequestParam(required = false) String yearMonth
     );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/controller/MyPageControllerApi.java
@@ -7,10 +7,14 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import me.bombom.api.v1.common.resolver.LoginMember;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.dto.response.CategoryStatsResponse;
 import me.bombom.api.v1.member.dto.response.RankSummaryResponse;
+import me.bombom.openapi.monthlyreport.model.MonthlyReportRequest;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "MyPage", description = "마이페이지 관련 API")
@@ -47,15 +51,10 @@ public interface MyPageControllerApi {
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "마이페이지 월별 카테고리 통계 조회 성공"),
-            @ApiResponse(responseCode = "400", description = "잘못된 yearMonth 형식", content = @Content)
+            @ApiResponse(responseCode = "400", description = "잘못된 연·월 파라미터 요청", content = @Content)
     })
     CategoryStatsResponse getCategoryStats(
             @Parameter(hidden = true) @LoginMember Member member,
-            @Parameter(
-                    description = "조회할 연월",
-                    example = "2026-05",
-                    schema = @Schema(pattern = "^\\d{4}-\\d{2}$")
-            )
-            @RequestParam(required = false) String yearMonth
+            @Valid @ModelAttribute @ParameterObject MonthlyReportRequest request
     );
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/CategoryReadCount.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/CategoryReadCount.java
@@ -1,0 +1,8 @@
+package me.bombom.api.v1.member.dto;
+
+public record CategoryReadCount(
+        Long id,
+        String name,
+        long count
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/CategoryStatsItemResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/CategoryStatsItemResponse.java
@@ -1,11 +1,21 @@
 package me.bombom.api.v1.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import me.bombom.api.v1.member.dto.CategoryReadCount;
 
 public record CategoryStatsItemResponse(
+
+        @NotNull
         Long id,
+
+        @NotNull
         String name,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long count,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int percent
 ) {
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/CategoryStatsItemResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/CategoryStatsItemResponse.java
@@ -1,0 +1,21 @@
+package me.bombom.api.v1.member.dto.response;
+
+import me.bombom.api.v1.member.dto.CategoryReadCount;
+
+public record CategoryStatsItemResponse(
+        Long id,
+        String name,
+        long count,
+        int percent
+) {
+
+    public static CategoryStatsItemResponse of(CategoryReadCount categoryReadCount, long total) {
+        int percent = total == 0 ? 0 : (int) Math.round(categoryReadCount.count() * 100.0 / total);
+        return new CategoryStatsItemResponse(
+                categoryReadCount.id(),
+                categoryReadCount.name(),
+                categoryReadCount.count(),
+                percent
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/CategoryStatsResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/CategoryStatsResponse.java
@@ -1,10 +1,16 @@
 package me.bombom.api.v1.member.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import me.bombom.api.v1.member.dto.CategoryReadCount;
 
 public record CategoryStatsResponse(
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         long total,
+
+        @NotNull
         List<CategoryStatsItemResponse> categories
 ) {
 

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/CategoryStatsResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/dto/response/CategoryStatsResponse.java
@@ -1,0 +1,20 @@
+package me.bombom.api.v1.member.dto.response;
+
+import java.util.List;
+import me.bombom.api.v1.member.dto.CategoryReadCount;
+
+public record CategoryStatsResponse(
+        long total,
+        List<CategoryStatsItemResponse> categories
+) {
+
+    public static CategoryStatsResponse from(List<CategoryReadCount> categoryReadCounts) {
+        long total = categoryReadCounts.stream()
+                .mapToLong(CategoryReadCount::count)
+                .sum();
+        List<CategoryStatsItemResponse> categories = categoryReadCounts.stream()
+                .map(categoryReadCount -> CategoryStatsItemResponse.of(categoryReadCount, total))
+                .toList();
+        return new CategoryStatsResponse(total, categories);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MyPageService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MyPageService.java
@@ -2,6 +2,9 @@ package me.bombom.api.v1.member.service;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +13,8 @@ import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorContextKeys;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.dto.CategoryReadCount;
+import me.bombom.api.v1.member.dto.response.CategoryStatsResponse;
 import me.bombom.api.v1.member.dto.response.RankCardResponse;
 import me.bombom.api.v1.member.dto.response.RankHistoryResponse;
 import me.bombom.api.v1.member.dto.response.RankSummaryResponse;
@@ -47,6 +52,18 @@ public class MyPageService {
                 createRankCard(member.getId(), MyPageRankType.STREAK),
                 createRankCard(member.getId(), MyPageRankType.READING)
         ));
+    }
+
+    public CategoryStatsResponse getCategoryStats(Member member, String yearMonthValue) {
+        YearMonth yearMonth = parseYearMonth(yearMonthValue);
+        LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
+        LocalDateTime end = yearMonth.plusMonths(1).atDay(1).atStartOfDay();
+        List<CategoryReadCount> categoryReadCounts = articleReadHistoryRepository.countReadsByCategory(
+                member.getId(),
+                start,
+                end
+        );
+        return CategoryStatsResponse.from(categoryReadCounts);
     }
 
     private RankCardResponse createRankCard(Long memberId, MyPageRankType rankType) {
@@ -111,6 +128,19 @@ public class MyPageService {
             return null;
         }
         return rankHistories.getLast().rank();
+    }
+
+    private YearMonth parseYearMonth(String yearMonth) {
+        if (yearMonth == null || yearMonth.isBlank()) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION)
+                    .addContext("yearMonth", yearMonth);
+        }
+        try {
+            return YearMonth.parse(yearMonth);
+        } catch (DateTimeParseException e) {
+            throw new CIllegalArgumentException(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION)
+                    .addContext("yearMonth", yearMonth);
+        }
     }
 
     private CIllegalArgumentException entityNotFound(Long memberId, String entityType) {

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MyPageService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/service/MyPageService.java
@@ -4,7 +4,6 @@ import java.time.Clock;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
-import java.time.format.DateTimeParseException;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +24,7 @@ import me.bombom.api.v1.reading.domain.MonthlyReadingRankHistory;
 import me.bombom.api.v1.reading.repository.ContinueReadingRankHistoryRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
 import me.bombom.api.v1.reading.repository.MonthlyReadingRankHistoryRepository;
+import me.bombom.openapi.monthlyreport.model.MonthlyReportRequest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,8 +54,8 @@ public class MyPageService {
         ));
     }
 
-    public CategoryStatsResponse getCategoryStats(Member member, String yearMonthValue) {
-        YearMonth yearMonth = parseYearMonth(yearMonthValue);
+    public CategoryStatsResponse getCategoryStats(Member member, MonthlyReportRequest request) {
+        YearMonth yearMonth = YearMonth.of(request.year(), request.month());
         LocalDateTime start = yearMonth.atDay(1).atStartOfDay();
         LocalDateTime end = yearMonth.plusMonths(1).atDay(1).atStartOfDay();
         List<CategoryReadCount> categoryReadCounts = articleReadHistoryRepository.countReadsByCategory(
@@ -128,19 +128,6 @@ public class MyPageService {
             return null;
         }
         return rankHistories.getLast().rank();
-    }
-
-    private YearMonth parseYearMonth(String yearMonth) {
-        if (yearMonth == null || yearMonth.isBlank()) {
-            throw new CIllegalArgumentException(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION)
-                    .addContext("yearMonth", yearMonth);
-        }
-        try {
-            return YearMonth.parse(yearMonth);
-        } catch (DateTimeParseException e) {
-            throw new CIllegalArgumentException(ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION)
-                    .addContext("yearMonth", yearMonth);
-        }
     }
 
     private CIllegalArgumentException entityNotFound(Long memberId, String entityType) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MyPageServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MyPageServiceTest.java
@@ -15,8 +15,11 @@ import me.bombom.api.v1.article.repository.ArticleReadHistoryRepository;
 import me.bombom.api.v1.common.exception.CIllegalArgumentException;
 import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.dto.response.CategoryStatsResponse;
 import me.bombom.api.v1.member.dto.response.RankSummaryResponse;
 import me.bombom.api.v1.member.repository.MemberRepository;
+import me.bombom.api.v1.newsletter.domain.Category;
+import me.bombom.api.v1.newsletter.repository.CategoryRepository;
 import me.bombom.api.v1.reading.domain.ContinueReadingRankHistory;
 import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
 import me.bombom.api.v1.reading.domain.MonthlyReadingRankHistory;
@@ -53,6 +56,9 @@ class MyPageServiceTest {
     private MemberRepository memberRepository;
 
     @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
     private MutableClock clock;
 
     private Member member;
@@ -64,6 +70,7 @@ class MyPageServiceTest {
         continueReadingRankHistoryRepository.deleteAllInBatch();
         continueReadingRealtimeRepository.deleteAllInBatch();
         memberRepository.deleteAllInBatch();
+        categoryRepository.deleteAllInBatch();
 
         clock.setInstant(Instant.parse("2026-06-17T00:00:00Z"), SEOUL_ZONE);
 
@@ -160,14 +167,88 @@ class MyPageServiceTest {
                 .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION);
     }
 
+    @Test
+    void yearMonth가_있으면_읽은_뉴스_카테고리_월간_통계를_조회한다() {
+        // given
+        Category selfImprovement = categoryRepository.save(Category.builder()
+                .name("자기계발")
+                .build());
+        Category economy = categoryRepository.save(Category.builder()
+                .name("경제")
+                .build());
+        articleReadHistoryRepository.saveAll(createArticleReadHistories(
+                selfImprovement.getId(),
+                12,
+                1,
+                LocalDateTime.of(2026, 5, 1, 0, 0)
+        ));
+        articleReadHistoryRepository.saveAll(createArticleReadHistories(
+                economy.getId(),
+                10,
+                100,
+                LocalDateTime.of(2026, 5, 2, 0, 0)
+        ));
+        articleReadHistoryRepository.save(ArticleReadHistory.builder()
+                .memberId(member.getId())
+                .articleId(1_000L)
+                .newsletterId(1L)
+                .categoryId(selfImprovement.getId())
+                .readAt(LocalDateTime.of(2026, 6, 1, 0, 0))
+                .build());
+
+        // when
+        CategoryStatsResponse response = myPageService.getCategoryStats(member, "2026-05");
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(response.total()).isEqualTo(22);
+            softly.assertThat(response.categories())
+                    .extracting("id", "name", "count", "percent")
+                    .containsExactly(
+                            org.assertj.core.groups.Tuple.tuple(selfImprovement.getId(), "자기계발", 12L, 55),
+                            org.assertj.core.groups.Tuple.tuple(economy.getId(), "경제", 10L, 45)
+                    );
+        });
+    }
+
+    @Test
+    void yearMonth_형식이_잘못되면_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> myPageService.getCategoryStats(member, "2026-5"))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION);
+    }
+
+    @Test
+    void yearMonth가_없으면_예외가_발생한다() {
+        // when & then
+        assertThatThrownBy(() -> myPageService.getCategoryStats(member, null))
+                .isInstanceOf(CIllegalArgumentException.class)
+                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION);
+    }
+
     private List<ArticleReadHistory> createArticleReadHistories(int count) {
-        return LongStream.rangeClosed(1, count)
+        return createArticleReadHistories(
+                1L,
+                count,
+                1,
+                LocalDateTime.of(2026, 5, 1, 0, 0)
+        );
+    }
+
+    private List<ArticleReadHistory> createArticleReadHistories(
+            Long categoryId,
+            int count,
+            long startArticleId,
+            LocalDateTime readAt
+    ) {
+        return LongStream.range(startArticleId, startArticleId + count)
                 .mapToObj(articleId -> ArticleReadHistory.builder()
                         .memberId(member.getId())
                         .articleId(articleId)
                         .newsletterId(1L)
-                        .categoryId(1L)
-                        .readAt(LocalDateTime.of(2026, 5, 1, 0, 0))
+                        .categoryId(categoryId)
+                        .readAt(readAt)
                         .build())
                 .toList();
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MyPageServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MyPageServiceTest.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.member.service;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.assertj.core.groups.Tuple.tuple;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -101,7 +102,7 @@ class MyPageServiceTest {
             softly.assertThat(response.cards().getFirst().rankHistory())
                     .extracting("month", "label", "rank")
                     .containsExactly(
-                            org.assertj.core.groups.Tuple.tuple("2026-05", "5월", 4L)
+                            tuple("2026-05", "5월", 4L)
                     );
         });
     }
@@ -140,8 +141,8 @@ class MyPageServiceTest {
             softly.assertThat(response.cards().getFirst().rankHistory())
                     .extracting("month", "label", "rank")
                     .containsExactly(
-                            org.assertj.core.groups.Tuple.tuple("2025-12", "25.12", 20L),
-                            org.assertj.core.groups.Tuple.tuple("2026-05", "5월", 3L)
+                            tuple("2025-12", "25.12", 20L),
+                            tuple("2026-05", "5월", 3L)
                     );
         });
     }
@@ -206,8 +207,8 @@ class MyPageServiceTest {
             softly.assertThat(response.categories())
                     .extracting("id", "name", "count", "percent")
                     .containsExactly(
-                            org.assertj.core.groups.Tuple.tuple(selfImprovement.getId(), "자기계발", 12L, 55),
-                            org.assertj.core.groups.Tuple.tuple(economy.getId(), "경제", 10L, 45)
+                            tuple(selfImprovement.getId(), "자기계발", 12L, 55),
+                            tuple(economy.getId(), "경제", 10L, 45)
                     );
         });
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MyPageServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/service/MyPageServiceTest.java
@@ -26,6 +26,7 @@ import me.bombom.api.v1.reading.domain.MonthlyReadingRankHistory;
 import me.bombom.api.v1.reading.repository.ContinueReadingRankHistoryRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
 import me.bombom.api.v1.reading.repository.MonthlyReadingRankHistoryRepository;
+import me.bombom.openapi.monthlyreport.model.MonthlyReportRequest;
 import me.bombom.support.integration.IntegrationTest;
 import me.bombom.support.time.MutableClock;
 import org.junit.jupiter.api.BeforeEach;
@@ -168,7 +169,7 @@ class MyPageServiceTest {
     }
 
     @Test
-    void yearMonth가_있으면_읽은_뉴스_카테고리_월간_통계를_조회한다() {
+    void 연월_조건이_있으면_읽은_뉴스_카테고리_월간_통계를_조회한다() {
         // given
         Category selfImprovement = categoryRepository.save(Category.builder()
                 .name("자기계발")
@@ -197,7 +198,7 @@ class MyPageServiceTest {
                 .build());
 
         // when
-        CategoryStatsResponse response = myPageService.getCategoryStats(member, "2026-05");
+        CategoryStatsResponse response = myPageService.getCategoryStats(member, new MonthlyReportRequest(2026, 5));
 
         // then
         assertSoftly(softly -> {
@@ -209,22 +210,6 @@ class MyPageServiceTest {
                             org.assertj.core.groups.Tuple.tuple(economy.getId(), "경제", 10L, 45)
                     );
         });
-    }
-
-    @Test
-    void yearMonth_형식이_잘못되면_예외가_발생한다() {
-        // when & then
-        assertThatThrownBy(() -> myPageService.getCategoryStats(member, "2026-5"))
-                .isInstanceOf(CIllegalArgumentException.class)
-                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION);
-    }
-
-    @Test
-    void yearMonth가_없으면_예외가_발생한다() {
-        // when & then
-        assertThatThrownBy(() -> myPageService.getCategoryStats(member, null))
-                .isInstanceOf(CIllegalArgumentException.class)
-                .hasFieldOrPropertyWithValue("errorDetail", ErrorDetail.INVALID_REQUEST_PARAMETER_VALIDATION);
     }
 
     private List<ArticleReadHistory> createArticleReadHistories(int count) {


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->

마이페이지 월별 읽은 뉴스 카테고리 통계 API를 구현했습니다.

- GET /api/v1/members/me/category-stats?yearMonth=2026-05

[데스크탑]
<img width="161" height="142" alt="image" src="https://github.com/user-attachments/assets/a0961eeb-e667-4d2b-9b20-f3785b0852dd" />

[모바일]
<img width="345" height="78" alt="image" src="https://github.com/user-attachments/assets/fceba364-4e66-4ef6-b36b-626bf99924cb" />


## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
사용자가 특정 월에 어떤 카테고리의 뉴스를 많이 읽었는지 보여주기 위해

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

article_read_history 기준으로 회원의 월별 읽기 기록을 조회하고, category_id 기준으로 그룹핑하여 카테고리별 읽은 개수를 집계했습니다.

yearMonth는 YYYY-MM 형식으로 받으며, 해당 월의 시작 시각부터 다음 달 시작 시각 전까지를 조회 범위로 사용했습니다.


## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
OpenAPI codegen 반영은 이번 작업에서는 진행하지 않고, 기존 수동 DTO 방식으로 우선 구현했습니다.