### PR TITLE
[BOM-1170] feat: 연속 읽기 보호막 조회 API 구현

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/controller/ReadingControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/controller/ReadingControllerApi.java
@@ -73,7 +73,7 @@ public interface ReadingControllerApi {
 
     @Operation(
             summary = "나의 스트릭 순위 조회",
-            description = "실시간 연속 읽기 일수 기준 나의 순위를 반환합니다. day_count가 0이면 월간 순위와 같이 최하위 구간의 공동 순위로 포함됩니다. continue_reading_snapshot 행이 없으면 404입니다."
+            description = "실시간 연속 읽기 일수 기준 나의 순위와 연속 읽기 보호막 현황을 반환합니다. day_count가 0이면 월간 순위와 같이 최하위 구간의 공동 순위로 포함됩니다. continue_reading_snapshot 행이 없으면 404입니다."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "나의 스트릭 순위 조회 성공"),

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/MemberContinueReadingRankResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/MemberContinueReadingRankResponse.java
@@ -16,15 +16,22 @@ public record MemberContinueReadingRankResponse(
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         int dayCount,
 
-        BadgesResponse badges
+        BadgesResponse badges,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        StreakShieldResponse streakShield
 ) {
 
-    public static MemberContinueReadingRankResponse from(ContinueReadingRankFlat flat) {
+    public static MemberContinueReadingRankResponse of(
+            ContinueReadingRankFlat flat,
+            StreakShieldResponse streakShield
+    ) {
         return new MemberContinueReadingRankResponse(
                 flat.nickname(),
                 flat.rank(),
                 flat.dayCount(),
-                BadgesResponse.from(flat)
+                BadgesResponse.from(flat),
+                streakShield
         );
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/StreakShieldResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/StreakShieldResponse.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.reading.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import me.bombom.api.v1.reading.domain.ContinueReadingShield;
+
+public record StreakShieldResponse(
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        StreakShieldStatus status,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        int remainingCount,
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        int monthlyLimit
+) {
+
+    public static StreakShieldResponse of(ContinueReadingShield shield, int monthlyLimit) {
+        int remainingCount = shield.getRemainingCount();
+        return new StreakShieldResponse(
+                StreakShieldStatus.from(remainingCount),
+                remainingCount,
+                monthlyLimit
+        );
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/StreakShieldResponse.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/StreakShieldResponse.java
@@ -5,7 +5,6 @@ import me.bombom.api.v1.reading.domain.ContinueReadingShield;
 
 public record StreakShieldResponse(
 
-        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
         StreakShieldStatus status,
 
         @Schema(requiredMode = Schema.RequiredMode.REQUIRED)

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/StreakShieldStatus.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/dto/response/StreakShieldStatus.java
@@ -1,0 +1,15 @@
+package me.bombom.api.v1.reading.dto.response;
+
+public enum StreakShieldStatus {
+
+    AVAILABLE,
+    USED,
+    ;
+
+    public static StreakShieldStatus from(int remainingCount) {
+        if (remainingCount > 0) {
+            return AVAILABLE;
+        }
+        return USED;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ContinueReadingShieldService.java
@@ -3,9 +3,13 @@ package me.bombom.api.v1.reading.service;
 import java.time.Clock;
 import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.common.exception.CIllegalArgumentException;
+import me.bombom.api.v1.common.exception.ErrorContextKeys;
+import me.bombom.api.v1.common.exception.ErrorDetail;
 import me.bombom.api.v1.reading.domain.ContinueReadingShield;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistory;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryReason;
+import me.bombom.api.v1.reading.dto.response.StreakShieldResponse;
 import me.bombom.api.v1.reading.repository.ContinueReadingShieldHistoryRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingShieldRepository;
 import org.springframework.stereotype.Service;
@@ -59,6 +63,14 @@ public class ContinueReadingShieldService {
                 )
         );
         return true;
+    }
+
+    public StreakShieldResponse getStreakShield(Long memberId) {
+        ContinueReadingShield shield = continueReadingShieldRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
+                        .addContext(ErrorContextKeys.MEMBER_ID, memberId)
+                        .addContext(ErrorContextKeys.ENTITY_TYPE, "ContinueReadingShield"));
+        return StreakShieldResponse.of(shield, MONTHLY_GRANT_COUNT);
     }
 
     @Transactional

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/service/ReadingService.java
@@ -40,6 +40,7 @@ import me.bombom.api.v1.reading.dto.response.MemberMonthlyReadingRankResponse;
 import me.bombom.api.v1.reading.dto.response.MonthlyReadingRankResponse;
 import me.bombom.api.v1.reading.dto.response.MonthlyReadingRankingResponse;
 import me.bombom.api.v1.reading.dto.response.ReadingInformationResponse;
+import me.bombom.api.v1.reading.dto.response.StreakShieldResponse;
 import me.bombom.api.v1.reading.dto.response.WeeklyGoalCountResponse;
 import me.bombom.api.v1.reading.event.ContinueReadingIncreasedEvent;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
@@ -332,7 +333,10 @@ public class ReadingService {
                 member.getId(),
                 lastMonth.getYear(),
                 lastMonth.getMonthValue()
-            ).map(MemberContinueReadingRankResponse::from)
+            ).map(flat -> {
+                StreakShieldResponse streakShield = continueReadingShieldService.getStreakShield(member.getId());
+                return MemberContinueReadingRankResponse.of(flat, streakShield);
+            })
             .orElseThrow(() -> new CIllegalArgumentException(ErrorDetail.ENTITY_NOT_FOUND)
                 .addContext(ErrorContextKeys.MEMBER_ID, member.getId())
                 .addContext(ErrorContextKeys.ENTITY_TYPE, "ContinueReadingSnapshot"));

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/coupon/controller/CouponControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/coupon/controller/CouponControllerTest.java
@@ -15,7 +15,7 @@ import me.bombom.api.v1.coupon.domain.CouponIssue;
 import me.bombom.api.v1.coupon.repository.CouponIssueRepository;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
-import me.bombom.support.IntegrationTest;
+import me.bombom.support.integration.IntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/controller/ReadingControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/controller/ReadingControllerTest.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import me.bombom.support.acceptance.AcceptanceTest;
 import me.bombom.support.acceptance.ResetsAcceptanceData;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 @AcceptanceTest({
         "acceptance/common/member.json",
@@ -18,6 +20,9 @@ import org.junit.jupiter.api.Test;
 class ReadingControllerTest {
 
     private static final long MEMBER_ID_VALUE = 1L;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
 
     @Test
     void 인증된_사용자는_읽기_현황을_조회할_수_있다() {
@@ -120,11 +125,35 @@ class ReadingControllerTest {
     @Test
     void 인증된_사용자는_내_연속_읽기_랭킹을_조회할_수_있다() {
         Map<String, Object> response = authenticatedGet("/api/v1/members/me/reading/streak/rank/me");
+        Map<String, Object> streakShield = nested(response, "streakShield");
 
         assertSoftly(softly -> {
             softly.assertThat(response.get("nickname")).isEqualTo("인수테스트회원");
             softly.assertThat(response.get("rank")).isEqualTo(1);
             softly.assertThat(response.get("dayCount")).isEqualTo(10);
+            softly.assertThat(streakShield.get("status")).isEqualTo("AVAILABLE");
+            softly.assertThat(streakShield.get("remainingCount")).isEqualTo(1);
+            softly.assertThat(streakShield.get("monthlyLimit")).isEqualTo(1);
+        });
+    }
+
+    @Test
+    @ResetsAcceptanceData
+    void 인증된_사용자는_사용_완료된_연속_읽기_보호막_현황을_조회할_수_있다() {
+        jdbcTemplate.update("""
+                UPDATE continue_reading_shield
+                SET monthly_remaining_count = 0,
+                    reward_remaining_count = 0
+                WHERE member_id = ?
+                """, MEMBER_ID_VALUE);
+
+        Map<String, Object> response = authenticatedGet("/api/v1/members/me/reading/streak/rank/me");
+        Map<String, Object> streakShield = nested(response, "streakShield");
+
+        assertSoftly(softly -> {
+            softly.assertThat(streakShield.get("status")).isEqualTo("USED");
+            softly.assertThat(streakShield.get("remainingCount")).isEqualTo(0);
+            softly.assertThat(streakShield.get("monthlyLimit")).isEqualTo(1);
         });
     }
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -20,6 +20,7 @@ import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import me.bombom.api.v1.reading.domain.ContinueReadingRealtime;
 import me.bombom.api.v1.reading.domain.ContinueReadingRankHistory;
+import me.bombom.api.v1.reading.domain.ContinueReadingShield;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryReason;
 import me.bombom.api.v1.reading.domain.ContinueReadingShieldHistoryType;
 import me.bombom.api.v1.reading.domain.ContinueReadingSnapshot;
@@ -373,6 +374,28 @@ class ReadingServiceTest {
             softly.assertThat(result.rank()).isEqualTo(3L);
             softly.assertThat(result.dayCount()).isEqualTo(10);
             softly.assertThat(result.nickname()).isEqualTo(member.getNickname());
+            softly.assertThat(result.streakShield().status().name()).isEqualTo("AVAILABLE");
+            softly.assertThat(result.streakShield().remainingCount()).isEqualTo(1);
+            softly.assertThat(result.streakShield().monthlyLimit()).isEqualTo(1);
+        });
+    }
+
+    @Test
+    void 보상_보호막만_남아도_나의_연속_읽기_보호막은_사용_가능으로_조회된다() {
+        연속_읽기_랭킹_기본_데이터를_저장한다();
+        continueReadingShieldRepository.deleteByMemberId(member.getId());
+        continueReadingShieldRepository.save(ContinueReadingShield.builder()
+                .memberId(member.getId())
+                .monthlyRemainingCount(0)
+                .rewardRemainingCount(2)
+                .build());
+
+        MemberContinueReadingRankResponse result = readingService.getMemberContinueReadingRank(member);
+
+        assertSoftly(softly -> {
+            softly.assertThat(result.streakShield().status().name()).isEqualTo("AVAILABLE");
+            softly.assertThat(result.streakShield().remainingCount()).isEqualTo(2);
+            softly.assertThat(result.streakShield().monthlyLimit()).isEqualTo(1);
         });
     }
 
@@ -400,6 +423,7 @@ class ReadingServiceTest {
             softly.assertThat(result.dayCount()).isEqualTo(0);
             softly.assertThat(result.rank()).isEqualTo(2L);
             softly.assertThat(result.nickname()).isEqualTo(member.getNickname());
+            softly.assertThat(result.streakShield().status().name()).isEqualTo("AVAILABLE");
         });
     }
 
@@ -917,6 +941,7 @@ class ReadingServiceTest {
     private void 연속_읽기_랭킹_기본_데이터를_저장한다() {
         member = 회원을_저장한다();
         continueReading = continueReadingRepository.save(TestFixture.continueReadingFixture(member));
+        continueReadingShieldRepository.save(ContinueReadingShield.create(member.getId()));
         continueReadingRankingSnapshotRepository.save(
                 ContinueReadingSnapshot.create(member.getId(), continueReading.getDayCount(), 1L)
         );

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -383,7 +383,8 @@ class ReadingServiceTest {
     @Test
     void 보상_보호막만_남아도_나의_연속_읽기_보호막은_사용_가능으로_조회된다() {
         연속_읽기_랭킹_기본_데이터를_저장한다();
-        continueReadingShieldRepository.deleteByMemberId(member.getId());
+        Long shieldId = continueReadingShieldRepository.findByMemberId(member.getId()).orElseThrow().getId();
+        continueReadingShieldRepository.deleteById(shieldId);
         continueReadingShieldRepository.save(ContinueReadingShield.builder()
                 .memberId(member.getId())
                 .monthlyRemainingCount(0)

--- a/backend/bom-bom-server/src/test/resources/acceptance/reading/reading.json
+++ b/backend/bom-bom-server/src/test/resources/acceptance/reading/reading.json
@@ -21,6 +21,9 @@
   "continue_reading_snapshot": [
     { "id": 1, "member_id": 1, "day_count": 10, "rank_order": 1 }
   ],
+  "continue_reading_shield": [
+    { "id": 1, "member_id": 1, "monthly_remaining_count": 1, "reward_remaining_count": 0 }
+  ],
   "monthly_reading_snapshot": [
     { "id": 1, "member_id": 1, "current_count": 7, "rank_order": 1, "next_rank_difference": 0 }
   ],


### PR DESCRIPTION
## 📌 What

나의 연속 읽기 랭킹 API 응답에 연속 읽기 보호막 현황을 추가했습니다.

<img width="326" height="317" alt="image" src="https://github.com/user-attachments/assets/c85dd276-81e6-4974-a9d4-8c73111f45d9" />

`GET /api/v1/members/me/reading/streak/rank/me` 해당 API에 딱 빨간색 부분만 추가되었습니다.
<img width="427" height="255" alt="image" src="https://github.com/user-attachments/assets/34770439-dc7d-418d-98d7-b73558a31483" />



## ❓ Why

- 연속 독서왕 화면에서 사용자가 연속 읽기 보호막을 사용할 수 있는지 함께 보여줘야 했습니다.
- 기존 나의 연속 읽기 랭킹 응답은 닉네임, 순위, 연속 읽기 일수, 뱃지만 반환해서 프론트에서 보호막 아이콘과 사용 완료 상태를 판단할 수 없었습니다.

## 🔧 How

### 응답 DTO

- `MemberContinueReadingRankResponse`에 `streakShield`를 추가했습니다.
- `StreakShieldResponse`를 추가해 보호막 상태를 `{ status, remainingCount, monthlyLimit }` 형태로 반환합니다.
- `StreakShieldStatus`는 잔여 개수가 있으면 `AVAILABLE`, 없으면 `USED`로 계산합니다.

### 조회 흐름

- `ContinueReadingShieldService.getStreakShield()`에서 로그인 회원의 shield row를 조회합니다.
- `ReadingService.getMemberContinueReadingRank()`에서 기존 랭킹 조회 결과와 보호막 현황을 조합합니다.
- shield row가 없으면 기존 읽기 조회 흐름처럼 `ENTITY_NOT_FOUND`로 처리합니다.


## 👀 Review Point (Optional)

- `remainingCount`를 월 지급분과 보상 지급분 합계로 내려주는 방향이 화면 요구사항과 맞는지 확인 부탁드립니다.
- `monthlyLimit`은 현재 정책값인 `1`로 고정해 내려줍니다. 보상 보호막이 있으면 `remainingCount`가 `monthlyLimit`보다 클 수 있습니다.
