### PR TITLE
[BOM-1179] fix: AI Breakfast 구독 해제 링크 파싱 수정

### DIFF
--- a/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
+++ b/backend/mail-server/src/main/java/news/bombomemail/article/util/UnsubscribeUrlExtractor.java
@@ -27,7 +27,7 @@ public class UnsubscribeUrlExtractor {
         textPattern.set(Pattern.compile("^[\\[(\\s]*(" + textKeywordGroup + ")", Pattern.CASE_INSENSITIVE));
         adjacentTextPattern.set(
                 Pattern.compile(
-                        "(?:" + textKeywordGroup + ")\\s{0,3}<a\\s[^>]*href=\"([^\"]+)\"",
+                        "(?:" + textKeywordGroup + ")\\s*<a\\s[^>]*href=\"([^\"]+)\"",
                         Pattern.CASE_INSENSITIVE
                 )
         );

--- a/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
+++ b/backend/mail-server/src/test/java/news/bombomemail/article/util/UnsubscribeUrlExtractorTest.java
@@ -111,6 +111,23 @@ class UnsubscribeUrlExtractorTest {
     }
 
     @Test
+    void beehiiv_HTML에서_unsubscribe와_앵커_사이에_줄바꿈과_들여쓰기가_있어도_추출한다() {
+        String html = """
+                <tbody><tr><td align="center" valign="top">
+                <p style="font-family:'Arial',Helvetica,sans-serif;color:#222222!important;">
+                 Update your email preferences
+                or unsubscribe
+                        <a class="link" href="https://link.mail.beehiiv.com/v1/c/fake-token"
+                        style="text-decoration:underline;text-decoration-color:#222222!important;color:#222222!important;">
+                        here</a>
+                </p></td></tr></tbody>
+                """;
+
+        assertThat(extractor.extract(html))
+                .isEqualTo("https://link.mail.beehiiv.com/v1/c/fake-token");
+    }
+
+    @Test
     void 앵커_직전_텍스트에_수신거부_키워드가_있으면_추출한다() {
         String html = "<p>수신거부 <a href=\"https://example.com/u/abc\">여기</a></p>";
         assertThat(extractor.extract(html))


### PR DESCRIPTION
## 📌 What
beehiiv 메일의 구독 해제 링크가 파싱되지 않는 문제를 수정했습니다.

## ❓ Why
AI Breakfast처럼 구독 해제 문구가 `Update your email preferences or unsubscribe` 형태이고 실제 링크 텍스트는 `here`인 메일은 앵커 텍스트만으로 구독 해제 URL을 식별하기 어렵습니다.

기존에는 `unsubscribe` 키워드와 `<a>` 태그 사이 공백을 최대 3개까지만 허용해, 메일 HTML에 줄바꿈이나 들여쓰기가 포함되면 링크를 찾지 못했습니다.

<img width="589" height="312" alt="image" src="https://github.com/user-attachments/assets/a08287ad-eecf-4b32-99e1-7037cebe970f" />

이 문제는 구독 취소 링크를 잘못 파싱해서 발생했습니다. [잘못 파싱된 링크](https://link.mail.beehiiv.com/v1/c/Xvx33PtlXgm2bInHZTb2xk9OBvipsOYwAFDGp2KYkjwlu2p47LARtK8a4%2FDu%0AWxQYuH06FeOcflfRj05ntVGdL53DX%2Bi5jcIQiYvR0Gw%2BAf7sLdcHEGt9%2Fv9m%0A3dQrRy5WAz4SkWANjycL3b8rC%2BXdGlwNrjerKY7ws6qPaYWGDZYRn4E%2FR29K%0AtJyCAY8XoYejAAv3qO80UyKFlibSP43u7A%3D%3D%0A/92fe344c06924cbd)

## 🔧 How
`UnsubscribeUrlExtractor`의 인접 텍스트 패턴에서 `unsubscribe` 키워드와 `<a>` 태그 사이 공백을 `\s*`로 허용했습니다.

beehiiv HTML처럼 키워드와 앵커 사이에 줄바꿈과 들여쓰기가 있는 케이스를 회귀 테스트로 추가했습니다.

## 👀 Review Point (Optional)
