### PR TITLE
feat: 읽지 않은 아티클 조회 옵션 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/dto/request/ArticlesOptionsRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/dto/request/ArticlesOptionsRequest.java
@@ -11,10 +11,20 @@ public record ArticlesOptionsRequest(
         LocalDate date,
 
         @Positive(message = "id는 1 이상의 값이어야 합니다.")
-        Long newsletterId
+        Long newsletterId,
+
+        Boolean unreadOnly
 ) {
 
+    public ArticlesOptionsRequest {
+        unreadOnly = Boolean.TRUE.equals(unreadOnly);
+    }
+
     public static ArticlesOptionsRequest of(LocalDate date, Long newsletterId) {
-        return new ArticlesOptionsRequest(date, newsletterId);
+        return new ArticlesOptionsRequest(date, newsletterId, false);
+    }
+
+    public static ArticlesOptionsRequest of(LocalDate date, Long newsletterId, boolean unreadOnly) {
+        return new ArticlesOptionsRequest(date, newsletterId, unreadOnly);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/article/repository/ArticleRepositoryImpl.java
@@ -181,7 +181,8 @@ public class ArticleRepositoryImpl implements CustomArticleRepository {
     }
 
 
-    private long getRecentTotalCountNative(Long memberId, ArticleSearchOptionsRequest options, LocalDate fiveDaysAgoDate) {
+    private long getRecentTotalCountNative(Long memberId, ArticleSearchOptionsRequest options,
+                                           LocalDate fiveDaysAgoDate) {
         StringBuilder sql = new StringBuilder();
         List<Object> params = new ArrayList<>();
 
@@ -502,6 +503,16 @@ public class ArticleRepositoryImpl implements CustomArticleRepository {
     }
 
     private JPAQuery<Long> getTotalQuery(Long memberId, ArticlesOptionsRequest options) {
+        if (options.unreadOnly()) {
+            return jpaQueryFactory.select(article.count())
+                    .from(article)
+                    .join(newsletter).on(article.newsletterId.eq(newsletter.id))
+                    .join(category).on(newsletter.categoryId.eq(category.id))
+                    .where(createMemberWhereClause(memberId))
+                    .where(createDateWhereClause(options.date()))
+                    .where(createNewsletterIdWhereClause(options.newsletterId()))
+                    .where(article.isRead.isFalse());
+        }
         return jpaQueryFactory.select(article.count())
                 .from(article)
                 .join(newsletter).on(article.newsletterId.eq(newsletter.id))
@@ -512,6 +523,31 @@ public class ArticleRepositoryImpl implements CustomArticleRepository {
     }
 
     private List<ArticleResponse> getContent(Long memberId, ArticlesOptionsRequest options, Pageable pageable) {
+        if (options.unreadOnly()) {
+            return jpaQueryFactory.select(new QArticleResponse(
+                            article.id,
+                            article.title,
+                            article.contentsSummary,
+                            article.arrivedDateTime,
+                            article.thumbnailUrl,
+                            article.expectedReadTime,
+                            article.isRead,
+                            getIsBookmarked(memberId),
+                            new QNewsletterSummaryResponse(newsletter.name, newsletter.imageUrl, category.name)
+                    ))
+                    .from(article)
+                    .join(newsletter).on(article.newsletterId.eq(newsletter.id))
+                    .join(category).on(newsletter.categoryId.eq(category.id))
+                    .where(createMemberWhereClause(memberId))
+                    .where(createDateWhereClause(options.date()))
+                    .where(createNewsletterIdWhereClause(options.newsletterId()))
+                    .where(article.isRead.isFalse())
+                    .orderBy(getOrderSpecifiers(pageable).toArray(OrderSpecifier[]::new))
+                    .offset(pageable.getOffset())
+                    .limit(pageable.getPageSize())
+                    .fetch();
+        }
+
         return jpaQueryFactory.select(new QArticleResponse(
                         article.id,
                         article.title,

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/controller/ArticleControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/controller/ArticleControllerTest.java
@@ -63,6 +63,22 @@ class ArticleControllerTest {
     }
 
     @Test
+    @ResetsAcceptanceData
+    void 읽지_않은_아티클만_조회한다() {
+        markAsRead(1);
+
+        Map<String, Object> response = getArticles(Map.of("unreadOnly", true));
+
+        assertSoftly(softly -> {
+            softly.assertThat(response.get("totalElements")).isEqualTo(10);
+            softly.assertThat(content(response)).hasSize(10);
+            softly.assertThat(content(response))
+                    .extracting(article -> article.get("isRead"))
+                    .containsOnly(false);
+        });
+    }
+
+    @Test
     void 뉴스_키워드_검색() {
         Map<String, Object> response = searchArticles(Map.of("keyword", "뉴스"));
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/service/ArticleServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/article/service/ArticleServiceTest.java
@@ -188,6 +188,32 @@ class ArticleServiceTest {
         });
     }
 
+    @Test
+    void 아티클_목록_조회_읽지_않은_아티클만_조회한다() {
+        // given
+        Article readArticle = articles.getFirst();
+        readArticle.markAsRead();
+        articleRepository.saveAndFlush(readArticle);
+
+        Pageable pageable = PageRequest.of(0, 20);
+
+        // when
+        Page<ArticleResponse> result = articleService.getArticles(
+                member,
+                ArticlesOptionsRequest.of(null, null, true),
+                pageable
+        );
+
+        // then
+        assertSoftly(softly -> {
+            softly.assertThat(result.getTotalElements()).isEqualTo(10);
+            softly.assertThat(result.getContent()).hasSize(10);
+            softly.assertThat(result.getContent())
+                    .extracting(ArticleResponse::isRead)
+                    .containsOnly(false);
+        });
+    }
+
 //
 //    @Test
 //    void 아티클_목록_조회_제목_검색_테스트() {


### PR DESCRIPTION
## What

- 아티클 목록 조회 API에 `unreadOnly` 조회 옵션을 추가했습니다.
- `unreadOnly=true`일 때 읽지 않은 아티클만 반환하도록 목록 content와 total count에 동일한 조건을 적용했습니다.

## Why

<img width="568" height="157" alt="image" src="https://github.com/user-attachments/assets/51befd5e-82a0-470d-8e65-6dd0f8ad4b4c" />

- 유저 요청 건이라 빠르게 처리하고자 합니다.

## How

- `ArticlesOptionsRequest.unreadOnly`를 `Boolean`으로 받고 compact constructor에서 `Boolean.TRUE.equals(...)`로 정규화했습니다.
- `ArticleRepositoryImpl`의 목록 조회 count/content 쿼리에 `article.isRead.isFalse()` 조건을 추가했습니다.
- `ArticleControllerTest`에서 `markAsRead(1)` 후 `GET /api/v1/articles?unreadOnly=true` 응답을 검증했습니다.
- `ArticleServiceTest`에서 서비스-DB 경로의 unread 필터 회귀 테스트를 추가했습니다.

## Review Points

- `unreadOnly` query option 네이밍과 기본값 처리 방식이 API 의도와 맞는지 확인 부탁드립니다.
- count 쿼리와 content 쿼리 모두 동일하게 unread 조건이 적용되는지 봐주시면 좋습니다.
