### PR TITLE
[BE][BOM-1199] 월간 읽기 랭킹 쿼리 개선

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingSnapshotRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/MonthlyReadingSnapshotRepository.java
@@ -16,10 +16,10 @@ public interface MonthlyReadingSnapshotRepository extends JpaRepository<MonthlyR
 
 	@Query(value = """
 		SELECT
-			m.nickname AS nickname,
-			mr.rank_order AS `rank`,
-			mr.current_count AS monthlyReadCount,
-			mr.next_rank_difference AS nextRankDifference,
+			ranked.nickname AS nickname,
+			ranked.rank_order AS `rank`,
+			ranked.current_count AS monthlyReadCount,
+			ranked.next_rank_difference AS nextRankDifference,
 			rb.badge_grade AS rankingBadgeGrade,
 			rb.period_year AS rankingBadgeYear,
 			rb.period_month AS rankingBadgeMonth,
@@ -27,32 +27,44 @@ public interface MonthlyReadingSnapshotRepository extends JpaRepository<MonthlyR
 			cb_latest.challenge_name AS challengeBadgeName,
 			cb_latest.challenge_generation AS challengeBadgeGeneration,
 			sb_latest.streak_day_count AS streakDayCount
-		FROM monthly_reading_snapshot mr
-		JOIN member m ON mr.member_id = m.id
-		LEFT JOIN badge rb ON rb.member_id = mr.member_id
+		FROM (
+			SELECT
+				mr.member_id,
+				m.nickname,
+				mr.rank_order,
+				mr.current_count,
+				mr.next_rank_difference
+			FROM monthly_reading_snapshot mr
+			JOIN member m ON mr.member_id = m.id
+			WHERE mr.rank_order IS NOT NULL
+			ORDER BY mr.rank_order, m.nickname
+			LIMIT :limit
+		) ranked
+		LEFT JOIN badge rb ON rb.member_id = ranked.member_id
 			AND rb.badge_category = 'RANKING'
 			AND rb.period_year = :lastMonthYear
 			AND rb.period_month = :lastMonthValue
 		LEFT JOIN LATERAL (
-			SELECT cb.*
+			SELECT
+				cb.badge_grade,
+				cb.challenge_name,
+				cb.challenge_generation
 			FROM badge cb
-			WHERE cb.member_id = mr.member_id
+			WHERE cb.member_id = ranked.member_id
 				AND cb.badge_category = 'CHALLENGE'
 			ORDER BY cb.created_at DESC
 			LIMIT 1
 		) cb_latest ON true
 		LEFT JOIN LATERAL (
-			SELECT sb.*
+			SELECT sb.streak_day_count
 			FROM badge sb
-			WHERE sb.member_id = mr.member_id
+			WHERE sb.member_id = ranked.member_id
 				AND sb.badge_category = 'STREAK'
 			ORDER BY sb.streak_day_count DESC,
 			sb.created_at DESC
 			LIMIT 1
 		) sb_latest ON true
-		WHERE mr.rank_order IS NOT NULL
-		ORDER BY mr.rank_order, m.nickname
-		LIMIT :limit
+		ORDER BY ranked.rank_order, ranked.nickname
 	""", nativeQuery = true)
 	List<MonthlyReadingRankFlat> findMonthlyRanking(
 			@Param("limit") int limit,
@@ -113,7 +125,10 @@ public interface MonthlyReadingSnapshotRepository extends JpaRepository<MonthlyR
 			AND rb.period_year = :lastMonthYear
 			AND rb.period_month = :lastMonthValue
 		LEFT JOIN LATERAL (
-			SELECT cb.*
+			SELECT
+				cb.badge_grade,
+				cb.challenge_name,
+				cb.challenge_generation
 			FROM badge cb
 			WHERE cb.member_id = mr.member_id
 				AND cb.badge_category = 'CHALLENGE'
@@ -121,7 +136,7 @@ public interface MonthlyReadingSnapshotRepository extends JpaRepository<MonthlyR
 			LIMIT 1
 		) cb_latest ON true
 		LEFT JOIN LATERAL (
-			SELECT sb.*
+			SELECT sb.streak_day_count
 			FROM badge sb
 			WHERE sb.member_id = mr.member_id
 				AND sb.badge_category = 'STREAK'

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.3.0__add_badge_query_indexes.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.3.0__add_badge_query_indexes.sql
@@ -1,0 +1,8 @@
+CREATE INDEX idx_badge_member_category_period
+    ON badge (member_id, badge_category, period_year, period_month);
+
+CREATE INDEX idx_badge_member_category_created_at
+    ON badge (member_id, badge_category, created_at DESC);
+
+CREATE INDEX idx_badge_member_category_streak
+    ON badge (member_id, badge_category, streak_day_count DESC, created_at DESC);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/service/ReadingServiceTest.java
@@ -1,6 +1,7 @@
 package me.bombom.api.v1.reading.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 import java.time.Clock;
@@ -34,6 +35,7 @@ import me.bombom.api.v1.reading.domain.YearlyReading;
 import me.bombom.api.v1.reading.dto.response.ContinueReadingRankingResponse;
 import me.bombom.api.v1.reading.dto.response.MemberContinueReadingRankResponse;
 import me.bombom.api.v1.reading.dto.response.MemberMonthlyReadingRankResponse;
+import me.bombom.api.v1.reading.dto.response.MonthlyReadingRankResponse;
 import me.bombom.api.v1.reading.dto.response.MonthlyReadingRankingResponse;
 import me.bombom.api.v1.reading.repository.ContinueReadingRealtimeRepository;
 import me.bombom.api.v1.reading.repository.ContinueReadingRankHistoryRepository;
@@ -780,6 +782,32 @@ class ReadingServiceTest {
             softly.assertThat(result.data()).hasSize(1);
             softly.assertThat(result.data().get(0).badges()).isNull();
         });
+    }
+
+    @Test
+    void 월간_랭킹_조회_시_limit_수만큼_순위와_닉네임_순으로_조회한다() {
+        Member secondNickname = memberRepository.save(TestFixture.createUniqueMember("나", "provider1"));
+        Member firstNickname = memberRepository.save(TestFixture.createUniqueMember("가", "provider2"));
+        Member nextRank = memberRepository.save(TestFixture.createUniqueMember("다", "provider3"));
+
+        monthlyReadingSnapshotRepository.save(
+                TestFixture.monthlyReadingSnapshotWithRank(secondNickname, 30, 1, 0)
+        );
+        monthlyReadingSnapshotRepository.save(
+                TestFixture.monthlyReadingSnapshotWithRank(firstNickname, 30, 1, 0)
+        );
+        monthlyReadingSnapshotRepository.save(TestFixture.monthlyReadingSnapshotWithRank(nextRank, 20, 2, 10));
+
+        // when
+        MonthlyReadingRankingResponse result = readingService.getMonthlyReadingRank(2);
+
+        // then
+        assertThat(result.data())
+                .extracting(MonthlyReadingRankResponse::nickname, MonthlyReadingRankResponse::rank)
+                .containsExactly(
+                        tuple("가", 1L),
+                        tuple("나", 1L)
+                );
     }
 
     @Test


### PR DESCRIPTION
## 📌 What

메인 페이지에서 호출하는 `GET /api/v1/members/me/reading/month/rank?limit=20`의 월간 읽기 랭킹 조회 쿼리를 개선합니다.
- 월간 랭킹 상위 `:limit`명을 먼저 확정한 뒤 해당 회원에게만 배지를 조인하도록 조회 순서를 변경했습니다.
- `RANKING`, `CHALLENGE`, `STREAK` 배지 조회 패턴에 맞는 복합 인덱스 3개를 추가했습니다.

## ❓ Why

## 장애 시 확인된 현상

(최대한 이해하기 쉽게 작성해봤습니다)

운영 슬로우 쿼리 로그에서 월간 읽기 랭킹 조회가 다음과 같이 실행되고 있음을 확인했습니다.

- `Query_time: 3.320699s`
- `Rows_sent: 20`
- `Rows_examined: 556,630`
- `Lock_time: 0.000004s`

응답으로 20건을 반환하기 위해 55만 건 이상을 검사하고 있었습니다. `Lock_time`은 거의 발생하지 않았기 때문에 잠금 대기가 아니라, 과도한 조인과 논리 읽기 비용이 병목이라고 판단했습니다.

운영 데이터로 수행한 기존 쿼리의 `EXPLAIN ANALYZE`에서도 동일한 문제가 확인됐습니다. 전체 실행 시간은 약 1.28초였지만 최종 정렬에는 약 8ms만 사용됐으며, 대부분의 시간은 배지 조인에서 소요됐습니다.

기존 쿼리는 월간 랭킹 대상 회원 약 1,680명 전체에 대해 `RANKING`, `CHALLENGE`, `STREAK` 배지를 조회한 다음 마지막에 `LIMIT 20`을 적용했습니다. 이 과정에서 약 333행의 `badge` 테이블을 세 가지 배지 조회마다 반복 스캔하여, 한 번의 요청에서 약 167만 행을 반복 방문했습니다.

또한 `badge` 테이블에는 해당 조회 조건과 정렬을 지원하는 인덱스가 없었습니다. 이로 인해 각 LATERAL 조회에서 테이블 스캔과 정렬이 반복됐습니다.

즉, 최종 응답에 필요한 회원은 20명이지만 다음과 같은 순서로 동작하고 있었습니다.

1. 월간 랭커 약 1,680명의 배지를 모두 조회
2. 조회 결과를 정렬
3. 마지막에 상위 20명만 반환

메인 페이지에서 해당 API를 반복 호출하기 때문에, 단일 요청의 비효율이 지속적인 RDS 부하로 누적됐습니다. 운영 슬로우 쿼리 상위 2,000건을 분석한 결과에서도 이를 확인할 수 있었습니다.

- 호출당 평균 약 55만 행 검사
- 2,000회에서 누적 약 11억 행 검사
- 장애 직전인 08:30~08:59에 43회 호출
- 해당 구간 평균 실행 시간 3.82초, 최대 12.23초
- `Lock_time`은 대부분 0에 가까움

따라서 병목의 핵심은 정렬이나 잠금이 아니라, `LIMIT`을 적용하기 전에 전체 랭커를 대상으로 배지 조회를 반복하는 구조였습니다. 이 쿼리를 장애의 단독 원인으로 확정할 수는 없지만, RDS의 CPU와 논리 읽기 부하를 증가시킨 주요 기여 요인으로 판단했습니다.
    

#### 📌 DB cpu 사용률 - t4g.micro이기 때문에 10%넘으면 크레딧 사용시작 크레딧 전부 소진시 성능 저하
<img width="378" height="598" alt="image" src="https://github.com/user-attachments/assets/91d6eea4-1ddf-47e1-81d6-d6a0e4218b74" />

    

#### 📌 슬로우 쿼리 발생
<img width="1699" height="164" alt="image" src="https://github.com/user-attachments/assets/7bd3234f-584d-430c-9b16-e2fe55c0dbdf" />

    

#### 📌 해당 시간 요청 횟수
<img width="679" height="306" alt="image" src="https://github.com/user-attachments/assets/170510c5-b2e7-4fcb-9603-585df29e5c10" />


## 🔧 How

### 검토한 해결 방법

#### 1. 인덱스만 추가

코드 변경이 작고 각 배지 조회의 테이블 스캔을 제거할 수 있습니다. 하지만 `LIMIT 20` 이전에 약 1,680명 전체를 대상으로 LATERAL 조회를 수행하는 구조는 남습니다. 데이터가 증가하면 불필요한 반복 조회 비용도 계속 증가합니다.

#### 2. 상위 회원 선제 LIMIT만 적용

배지 조회 반복 횟수를 약 1,680회에서 20회로 줄일 수 있습니다. 하지만 각 반복에서 `badge` 테이블 스캔과 최신/최고 배지 정렬이 남습니다. 현재 배지 행 수가 적을 때는 효과가 있지만 배지가 누적될수록 다시 느려질 수 있습니다.

#### 3. API 응답 캐시 또는 호출 주기 조정

메인 페이지의 반복 요청 자체를 줄일 수 있습니다. 다만 캐시 무효화와 랭킹 최신성 정책이 추가로 필요하고, 캐시 미스 시 느린 쿼리 자체는 그대로입니다. 이번 티켓의 DB 병목을 직접 제거하는 방법으로는 부족하다고 판단했습니다.

#### 4. 상위 회원 선제 LIMIT + 조회별 복합 인덱스 적용 — 선택

불필요한 대상 회원 수와 회원별 배지 탐색 비용을 동시에 줄일 수 있습니다.

- 배지 조인 대상: 약 1,680명 → 최대 20명
- 배지 접근 방식: 반복 `Table scan` → 조건 및 정렬에 맞는 `Index lookup`
- 기존 응답과 정렬·배지 선택 규칙 유지
- 캐시 정책과 같은 별도 운영 복잡도 없이 원인 쿼리를 직접 개선

두 병목이 곱해지는 구조였기 때문에 한쪽만 개선하는 것보다 두 가지를 함께 적용하는 방식을 선택했습니다.

### 쿼리 변경

`monthly_reading_snapshot + member`에서 `rank_order IS NOT NULL`인 상위 `:limit`명을 파생 테이블로 먼저 확정합니다. 이후 해당 결과에만 지난달 랭킹 배지, 최신 챌린지 배지, 최고 스트릭 배지를 조인합니다.

LATERAL 서브쿼리는 다음 컬럼만 투영합니다.

- CHALLENGE: `badge_grade`, `challenge_name`, `challenge_generation`
- STREAK: `streak_day_count`

### 인덱스 변경

Flyway `V37.3.0` 마이그레이션으로 다음 인덱스를 추가합니다.

1. `(member_id, badge_category, period_year, period_month)`
   - 특정 회원의 지난달 `RANKING` 배지 조회

2. `(member_id, badge_category, created_at DESC)`
   - 특정 회원의 최신 `CHALLENGE` 배지를 `LIMIT 1`로 조회

3. `(member_id, badge_category, streak_day_count DESC, created_at DESC)`
   - 특정 회원의 최고 `STREAK` 배지를 기존 우선순위대로 `LIMIT 1`로 조회

하나의 공통 인덱스로 합치지 않은 이유는 세 조회의 필터 및 정렬 기준이 서로 다르기 때문입니다. 각 인덱스의 컬럼 순서를 실제 `WHERE + ORDER BY`와 맞춰 추가 정렬을 최소화했습니다.

### 트레이드오프

- 배지 저장 시 인덱스 3개를 함께 갱신하므로 쓰기 비용과 저장 공간이 소폭 증가합니다.
- 현재 서비스는 메인 페이지 랭킹 조회 빈도가 배지 발급 빈도보다 높으므로 읽기 성능 개선 효과가 더 크다고 판단했습니다.
- 운영 배포 시 `CREATE INDEX`가 테이블 스캔과 짧은 metadata lock을 발생시킬 수 있으므로 배포 전 장기 트랜잭션 여부를 확인합니다.


실제 운영 성능 수치는 마이그레이션 적용 후 동일 SQL의 `EXPLAIN ANALYZE`로 재측정할 예정입니다. 확인 기준은 배지 `Table scan` 제거, 배지 조인 반복 횟수 최대 20회, 반환 순서와 배지 데이터 동일 여부입니다.

## 👀 Review Point (Optional)

- 파생 테이블에서 상위 `:limit`명을 먼저 확정해도 기존 `rank_order → nickname` 정렬과 동순위 처리 규칙이 동일한지 확인 부탁드립니다.
- 세 복합 인덱스의 컬럼 순서가 각 배지 조회의 `WHERE + ORDER BY`에 적절한지 확인 부탁드립니다.
- 마이그레이션 적용 후 운영 데이터 기준 `EXPLAIN ANALYZE`를 수정 전 결과와 비교할 예정입니다.
- 혹시 이해가지 않는 부분이 있다면 언제든 말씀해주세요.
