### PR TITLE
feat: Apple 로그인 사용자 이전 준비

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationClient.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationClient.java
@@ -1,0 +1,6 @@
+package me.bombom.api.v1.auth.migration;
+
+public interface AppleUserMigrationClient {
+
+    String createTransferSub(String existingSub);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationProperties.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationProperties.java
@@ -1,0 +1,26 @@
+package me.bombom.api.v1.auth.migration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties("oauth2.apple.migration")
+public record AppleUserMigrationProperties(
+        String targetTeamId,
+        String clientId,
+        boolean execute
+) {
+
+    private static final String TEAM_ID_PATTERN = "[A-Z0-9]{10}";
+
+    public void validateForExecution() {
+        if (!execute) {
+            throw new IllegalStateException("Apple 사용자 이전 실행 플래그가 활성화되지 않았습니다.");
+        }
+        if (targetTeamId == null || !targetTeamId.matches(TEAM_ID_PATTERN)) {
+            throw new IllegalStateException("Apple 사용자 이전 수신 Team ID가 올바르지 않습니다.");
+        }
+        if (!StringUtils.hasText(clientId)) {
+            throw new IllegalStateException("Apple 사용자 이전 client ID가 필요합니다.");
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRestClient.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRestClient.java
@@ -1,0 +1,73 @@
+package me.bombom.api.v1.auth.migration;
+
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.auth.AppleClientSecretSupplier;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class AppleUserMigrationRestClient implements AppleUserMigrationClient {
+
+    private static final String APPLE_TOKEN_URI = "https://appleid.apple.com/auth/token";
+    private static final String APPLE_USER_MIGRATION_URI = "https://appleid.apple.com/auth/usermigrationinfo";
+
+    private final RestClient.Builder restClientBuilder;
+    private final AppleClientSecretSupplier appleClientSecretSupplier;
+    private final AppleUserMigrationProperties properties;
+
+    @Override
+    public String createTransferSub(String existingSub) {
+        String clientSecret = appleClientSecretSupplier.generateFor(properties.clientId());
+        String accessToken = requestMigrationAccessToken(clientSecret);
+        Map<String, Object> response = restClientBuilder.build().post()
+                .uri(APPLE_USER_MIGRATION_URI)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(userMigrationRequestBody(existingSub, clientSecret))
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {});
+        return requiredString(response, "transfer_sub");
+    }
+
+    private String requestMigrationAccessToken(String clientSecret) {
+        Map<String, Object> response = restClientBuilder.build().post()
+                .uri(APPLE_TOKEN_URI)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(accessTokenRequestBody(clientSecret))
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {});
+        return requiredString(response, "access_token");
+    }
+
+    private MultiValueMap<String, String> accessTokenRequestBody(String clientSecret) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "client_credentials");
+        body.add("scope", "user.migration");
+        body.add("client_id", properties.clientId());
+        body.add("client_secret", clientSecret);
+        return body;
+    }
+
+    private MultiValueMap<String, String> userMigrationRequestBody(String existingSub, String clientSecret) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("sub", existingSub);
+        body.add("target", properties.targetTeamId());
+        body.add("client_id", properties.clientId());
+        body.add("client_secret", clientSecret);
+        return body;
+    }
+
+    private String requiredString(Map<String, Object> response, String key) {
+        if (response == null || !(response.get(key) instanceof String value) || !StringUtils.hasText(value)) {
+            throw new IllegalStateException("Apple 사용자 이전 응답에 " + key + " 값이 없습니다.");
+        }
+        return value;
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationResult.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationResult.java
@@ -1,0 +1,7 @@
+package me.bombom.api.v1.auth.migration;
+
+public record AppleUserMigrationResult(
+        long targetCount,
+        long migratedCount
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRunner.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRunner.java
@@ -1,0 +1,30 @@
+package me.bombom.api.v1.auth.migration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("apple-user-migration")
+@RequiredArgsConstructor
+public class AppleUserMigrationRunner implements ApplicationRunner {
+
+    private final AppleUserMigrationProperties properties;
+    private final AppleUserMigrationService service;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!properties.execute()) {
+            log.info("Apple 사용자 이전 dry-run - 대상 수: {}", service.preview());
+            return;
+        }
+
+        properties.validateForExecution();
+        AppleUserMigrationResult result = service.migrateAll();
+        log.info("Apple 사용자 이전 완료 - 대상 수: {}, 저장 수: {}", result.targetCount(), result.migratedCount());
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationService.java
@@ -1,0 +1,47 @@
+package me.bombom.api.v1.auth.migration;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Service
+@RequiredArgsConstructor
+public class AppleUserMigrationService {
+
+    private static final String APPLE_PROVIDER = "apple";
+
+    private final MemberRepository memberRepository;
+    private final AppleUserMigrationClient appleUserMigrationClient;
+
+    public long preview() {
+        return memberRepository.countByProviderAndAppleTransferSubIsNull(APPLE_PROVIDER);
+    }
+
+    public AppleUserMigrationResult migrateAll() {
+        long targetCount = preview();
+        long migratedCount = 0L;
+        long lastMemberId = 0L;
+
+        while (true) {
+            List<Member> members = memberRepository
+                    .findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc(APPLE_PROVIDER, lastMemberId);
+            if (members.isEmpty()) {
+                return new AppleUserMigrationResult(targetCount, migratedCount);
+            }
+
+            for (Member member : members) {
+                String transferSub = appleUserMigrationClient.createTransferSub(member.getProviderId());
+                if (!StringUtils.hasText(transferSub)) {
+                    throw new IllegalStateException("Apple 사용자 이전 응답에 transfer_sub 값이 없습니다.");
+                }
+                member.updateAppleTransferSub(transferSub);
+                memberRepository.save(member);
+                migratedCount++;
+                lastMemberId = member.getId();
+            }
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
@@ -40,6 +40,9 @@ public class Member extends BaseEntity implements Serializable {
     @Column(nullable = false)
     private String providerId;
 
+    @Column(unique = true, length = 255)
+    private String appleTransferSub;
+
     @Column(nullable = false, length = 50)
     private String email;
 
@@ -103,5 +106,9 @@ public class Member extends BaseEntity implements Serializable {
 
     public boolean isSameNickname(String nickname) {
         return this.nickname.equals(nickname);
+    }
+
+    public void updateAppleTransferSub(String transferSub) {
+        this.appleTransferSub = transferSub;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
@@ -1,5 +1,6 @@
 package me.bombom.api.v1.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 import me.bombom.api.v1.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,6 +15,10 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         WHERE m.provider = :provider AND m.providerId = :providerId
     """)
     Optional<Member> findByProviderAndProviderId(@Param("provider") String provider, @Param("providerId") String providerId);
+
+    long countByProviderAndAppleTransferSubIsNull(String provider);
+
+    List<Member> findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc(String provider, Long id);
 
     boolean existsByEmail(String email);
 

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.4.0__add_member_apple_transfer_sub.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.4.0__add_member_apple_transfer_sub.sql
@@ -1,0 +1,3 @@
+ALTER TABLE member
+    ADD COLUMN apple_transfer_sub VARCHAR(255) NULL,
+    ADD CONSTRAINT uk_member_apple_transfer_sub UNIQUE (apple_transfer_sub);

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationPropertiesTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationPropertiesTest.java
@@ -1,0 +1,24 @@
+package me.bombom.api.v1.auth.migration;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AppleUserMigrationPropertiesTest {
+
+    @Test
+    void 유효하지_않은_수신_Team_ID면_실행을_거부한다() {
+        AppleUserMigrationProperties properties = new AppleUserMigrationProperties("invalid", "com.example.app", true);
+
+        assertThatThrownBy(properties::validateForExecution)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void execute가_false이면_실행을_거부한다() {
+        AppleUserMigrationProperties properties = new AppleUserMigrationProperties("A1B2C3D4E5", "com.example.app", false);
+
+        assertThatThrownBy(properties::validateForExecution)
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRestClientTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRestClientTest.java
@@ -1,0 +1,63 @@
+package me.bombom.api.v1.auth.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import me.bombom.api.v1.auth.AppleClientSecretSupplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+@ExtendWith(MockitoExtension.class)
+class AppleUserMigrationRestClientTest {
+
+    @Mock
+    private AppleClientSecretSupplier appleClientSecretSupplier;
+
+    private MockRestServiceServer server;
+    private AppleUserMigrationRestClient client;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+        given(appleClientSecretSupplier.generateFor("com.example.app")).willReturn("client-secret");
+        client = new AppleUserMigrationRestClient(
+                builder,
+                appleClientSecretSupplier,
+                new AppleUserMigrationProperties("A1B2C3D4E5", "com.example.app", true)
+        );
+    }
+
+    @Test
+    void 기존_sub와_수신_Team_ID로_transfer_sub를_발급한다() {
+        server.expect(requestTo("https://appleid.apple.com/auth/token"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("grant_type=client_credentials")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("scope=user.migration")))
+                .andRespond(withSuccess("{\"access_token\":\"migration-token\"}", MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://appleid.apple.com/auth/usermigrationinfo"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer migration-token"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("sub=old-sub")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("target=A1B2C3D4E5")))
+                .andRespond(withSuccess("{\"transfer_sub\":\"transfer-sub\"}", MediaType.APPLICATION_JSON));
+
+        String transferSub = client.createTransferSub("old-sub");
+
+        assertThat(transferSub).isEqualTo("transfer-sub");
+        server.verify();
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRunnerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRunnerTest.java
@@ -1,0 +1,35 @@
+package me.bombom.api.v1.auth.migration;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.ApplicationArguments;
+
+class AppleUserMigrationRunnerTest {
+
+    private final AppleUserMigrationService service = mock(AppleUserMigrationService.class);
+
+    @Test
+    void execute가_false이면_미리보기만_수행한다() throws Exception {
+        AppleUserMigrationProperties properties = new AppleUserMigrationProperties("A1B2C3D4E5", "com.example.app", false);
+        given(service.preview()).willReturn(12L);
+
+        new AppleUserMigrationRunner(properties, service).run(mock(ApplicationArguments.class));
+
+        verify(service).preview();
+        verify(service, never()).migrateAll();
+    }
+
+    @Test
+    void execute가_true이면_검증후_배치를_수행한다() throws Exception {
+        AppleUserMigrationProperties properties = new AppleUserMigrationProperties("A1B2C3D4E5", "com.example.app", true);
+        given(service.migrateAll()).willReturn(new AppleUserMigrationResult(12L, 12L));
+
+        new AppleUserMigrationRunner(properties, service).run(mock(ApplicationArguments.class));
+
+        verify(service).migrateAll();
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationServiceTest.java
@@ -1,0 +1,77 @@
+package me.bombom.api.v1.auth.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.enums.Gender;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AppleUserMigrationServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private AppleUserMigrationClient appleUserMigrationClient;
+
+    @InjectMocks
+    private AppleUserMigrationService service;
+
+    @Test
+    void 미처리_Apple_회원에게만_transfer_sub를_저장한다() {
+        Member member = appleMember(1L, "old-sub");
+        given(memberRepository.countByProviderAndAppleTransferSubIsNull("apple")).willReturn(1L);
+        given(memberRepository.findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc("apple", 0L))
+                .willReturn(List.of(member));
+        given(memberRepository.findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc("apple", 1L))
+                .willReturn(List.of());
+        given(appleUserMigrationClient.createTransferSub("old-sub")).willReturn("transfer-sub");
+
+        AppleUserMigrationResult result = service.migrateAll();
+
+        assertSoftly(softly -> {
+            softly.assertThat(member.getAppleTransferSub()).isEqualTo("transfer-sub");
+            softly.assertThat(result.targetCount()).isEqualTo(1L);
+            softly.assertThat(result.migratedCount()).isEqualTo(1L);
+        });
+        verify(memberRepository).save(member);
+    }
+
+    @Test
+    void Apple_호출에_실패하면_해당_회원값을_저장하지_않는다() {
+        Member member = appleMember(1L, "old-sub");
+        given(memberRepository.countByProviderAndAppleTransferSubIsNull("apple")).willReturn(1L);
+        given(memberRepository.findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc("apple", 0L))
+                .willReturn(List.of(member));
+        given(appleUserMigrationClient.createTransferSub("old-sub")).willThrow(new IllegalStateException("Apple error"));
+
+        assertThatThrownBy(service::migrateAll).isInstanceOf(IllegalStateException.class);
+
+        assertThat(member.getAppleTransferSub()).isNull();
+        verify(memberRepository, never()).save(member);
+    }
+
+    private Member appleMember(Long id, String providerId) {
+        return Member.builder()
+                .id(id)
+                .provider("apple")
+                .providerId(providerId)
+                .email(providerId + "@example.com")
+                .nickname("member-" + id)
+                .gender(Gender.NONE)
+                .roleId(1L)
+                .build();
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/domain/MemberTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/domain/MemberTest.java
@@ -1,0 +1,25 @@
+package me.bombom.api.v1.member.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import me.bombom.api.v1.member.enums.Gender;
+import org.junit.jupiter.api.Test;
+
+class MemberTest {
+
+    @Test
+    void Apple_이전_식별자를_저장한다() {
+        Member member = Member.builder()
+                .provider("apple")
+                .providerId("apple-sub")
+                .email("apple@example.com")
+                .nickname("apple-member")
+                .gender(Gender.NONE)
+                .roleId(1L)
+                .build();
+
+        member.updateAppleTransferSub("transfer-sub");
+
+        assertThat(member.getAppleTransferSub()).isEqualTo("transfer-sub");
+    }
+}


### PR DESCRIPTION
## What

- Apple 로그인 회원의 `transfer_sub` 저장 컬럼과 Flyway migration을 추가했습니다.
- Apple User Migration API 호출과 재실행 가능한 일회성 배치를 추가했습니다.
- 명시 profile과 execute 플래그 없이는 실행되지 않도록 보호했습니다.

## Why

앱을 새 Apple Developer Team으로 이전하면 Apple 사용자 식별자(`sub`)가 바뀝니다. 이전 전에 `transfer_sub`를 저장해 두어야 이전 후에도 기존 회원 계정을 연결할 수 있습니다.

## How

- `member.apple_transfer_sub` nullable unique 컬럼을 추가했습니다.
- `provider = 'apple'`이며 아직 값이 없는 회원만 ID keyset 방식으로 조회합니다.
- 기존 Team의 client secret으로 Apple migration access token을 발급하고, 각 기존 `sub`로 `transfer_sub`를 받아 저장합니다.
- 이미 저장된 회원은 건너뛰므로 중단 후 재실행할 수 있습니다.
- `apple-user-migration` profile에서만 runner가 생성되며, `execute=false`에서는 대상 수만 확인합니다.

## Verification

- `./gradlew test --tests 'me.bombom.api.v1.member.domain.MemberTest' --tests 'me.bombom.api.v1.auth.migration.*' --console=plain`
- `./gradlew compileJava unitTest --console=plain`
