### PR TITLE
fix: 애플 회원 마이그레이션을 위해 transfer_sub 발급 실패 시 해당 회원 건너뛰도록 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRestClient.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRestClient.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.auth.migration;
 
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.auth.AppleClientSecretSupplier;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
@@ -9,8 +10,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AppleUserMigrationRestClient implements AppleUserMigrationClient {
@@ -32,6 +35,14 @@ public class AppleUserMigrationRestClient implements AppleUserMigrationClient {
                 .header("Authorization", "Bearer " + accessToken)
                 .body(userMigrationRequestBody(existingSub, clientSecret))
                 .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        (request, res) -> {
+                            String body = new String(res.getBody().readAllBytes());
+                            log.error("Apple usermigrationinfo 호출 실패 - sub: {}, status: {}, body: {}",
+                                    existingSub, res.getStatusCode(), body);
+                            throw HttpClientErrorException.create(
+                                    res.getStatusCode(), res.getStatusText(), res.getHeaders(), body.getBytes(), null);
+                        })
                 .body(new ParameterizedTypeReference<>() {});
         return requiredString(response, "transfer_sub");
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationResult.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationResult.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.auth.migration;
 
 public record AppleUserMigrationResult(
         long targetCount,
-        long migratedCount
+        long migratedCount,
+        long failedCount
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRunner.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRunner.java
@@ -18,6 +18,9 @@ public class AppleUserMigrationRunner implements ApplicationRunner {
 
     @Override
     public void run(ApplicationArguments args) {
+        log.info("Apple 사용자 이전 설정 - clientId: {}, targetTeamId: {}, execute: {}",
+                properties.clientId(), properties.targetTeamId(), properties.execute());
+
         if (!properties.execute()) {
             log.info("Apple 사용자 이전 dry-run - 대상 수: {}", service.preview());
             return;
@@ -25,6 +28,7 @@ public class AppleUserMigrationRunner implements ApplicationRunner {
 
         properties.validateForExecution();
         AppleUserMigrationResult result = service.migrateAll();
-        log.info("Apple 사용자 이전 완료 - 대상 수: {}, 저장 수: {}", result.targetCount(), result.migratedCount());
+        log.info("Apple 사용자 이전 완료 - 대상 수: {}, 저장 수: {}, 실패 수: {}",
+                result.targetCount(), result.migratedCount(), result.failedCount());
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserMigrationService.java
@@ -2,11 +2,13 @@ package me.bombom.api.v1.auth.migration;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import me.bombom.api.v1.member.domain.Member;
 import me.bombom.api.v1.member.repository.MemberRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class AppleUserMigrationService {
@@ -23,24 +25,32 @@ public class AppleUserMigrationService {
     public AppleUserMigrationResult migrateAll() {
         long targetCount = preview();
         long migratedCount = 0L;
+        long failedCount = 0L;
         long lastMemberId = 0L;
 
         while (true) {
             List<Member> members = memberRepository
-                    .findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc(APPLE_PROVIDER, lastMemberId);
+                    .findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc(APPLE_PROVIDER,
+                            lastMemberId);
             if (members.isEmpty()) {
-                return new AppleUserMigrationResult(targetCount, migratedCount);
+                return new AppleUserMigrationResult(targetCount, migratedCount, failedCount);
             }
 
             for (Member member : members) {
-                String transferSub = appleUserMigrationClient.createTransferSub(member.getProviderId());
-                if (!StringUtils.hasText(transferSub)) {
-                    throw new IllegalStateException("Apple 사용자 이전 응답에 transfer_sub 값이 없습니다.");
-                }
-                member.updateAppleTransferSub(transferSub);
-                memberRepository.save(member);
-                migratedCount++;
                 lastMemberId = member.getId();
+                try {
+                    String transferSub = appleUserMigrationClient.createTransferSub(member.getProviderId());
+                    if (!StringUtils.hasText(transferSub)) {
+                        throw new IllegalStateException("Apple 사용자 이전 응답에 transfer_sub 값이 없습니다.");
+                    }
+                    member.updateAppleTransferSub(transferSub);
+                    memberRepository.save(member);
+                    migratedCount++;
+                } catch (RuntimeException e) {
+                    failedCount++;
+                    log.warn("Apple 사용자 이전 실패 - memberId: {}, sub: {}, 사유: {}",
+                            member.getId(), member.getProviderId(), e.getMessage(), e);
+                }
             }
         }
     }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRunnerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationRunnerTest.java
@@ -26,7 +26,7 @@ class AppleUserMigrationRunnerTest {
     @Test
     void execute가_true이면_검증후_배치를_수행한다() throws Exception {
         AppleUserMigrationProperties properties = new AppleUserMigrationProperties("A1B2C3D4E5", "com.example.app", true);
-        given(service.migrateAll()).willReturn(new AppleUserMigrationResult(12L, 12L));
+        given(service.migrateAll()).willReturn(new AppleUserMigrationResult(12L, 12L, 0L));
 
         new AppleUserMigrationRunner(properties, service).run(mock(ApplicationArguments.class));
 

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserMigrationServiceTest.java
@@ -1,7 +1,5 @@
 package me.bombom.api.v1.auth.migration;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -45,22 +43,34 @@ class AppleUserMigrationServiceTest {
             softly.assertThat(member.getAppleTransferSub()).isEqualTo("transfer-sub");
             softly.assertThat(result.targetCount()).isEqualTo(1L);
             softly.assertThat(result.migratedCount()).isEqualTo(1L);
+            softly.assertThat(result.failedCount()).isEqualTo(0L);
         });
         verify(memberRepository).save(member);
     }
 
     @Test
-    void Apple_호출에_실패하면_해당_회원값을_저장하지_않는다() {
-        Member member = appleMember(1L, "old-sub");
-        given(memberRepository.countByProviderAndAppleTransferSubIsNull("apple")).willReturn(1L);
+    void Apple_호출에_실패한_회원은_건너뛰고_다음_회원을_계속_처리한다() {
+        Member failedMember = appleMember(1L, "old-sub-1");
+        Member succeededMember = appleMember(2L, "old-sub-2");
+        given(memberRepository.countByProviderAndAppleTransferSubIsNull("apple")).willReturn(2L);
         given(memberRepository.findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc("apple", 0L))
-                .willReturn(List.of(member));
-        given(appleUserMigrationClient.createTransferSub("old-sub")).willThrow(new IllegalStateException("Apple error"));
+                .willReturn(List.of(failedMember, succeededMember));
+        given(memberRepository.findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc("apple", 2L))
+                .willReturn(List.of());
+        given(appleUserMigrationClient.createTransferSub("old-sub-1")).willThrow(new IllegalStateException("Apple error"));
+        given(appleUserMigrationClient.createTransferSub("old-sub-2")).willReturn("transfer-sub-2");
 
-        assertThatThrownBy(service::migrateAll).isInstanceOf(IllegalStateException.class);
+        AppleUserMigrationResult result = service.migrateAll();
 
-        assertThat(member.getAppleTransferSub()).isNull();
-        verify(memberRepository, never()).save(member);
+        assertSoftly(softly -> {
+            softly.assertThat(failedMember.getAppleTransferSub()).isNull();
+            softly.assertThat(succeededMember.getAppleTransferSub()).isEqualTo("transfer-sub-2");
+            softly.assertThat(result.targetCount()).isEqualTo(2L);
+            softly.assertThat(result.migratedCount()).isEqualTo(1L);
+            softly.assertThat(result.failedCount()).isEqualTo(1L);
+        });
+        verify(memberRepository, never()).save(failedMember);
+        verify(memberRepository).save(succeededMember);
     }
 
     private Member appleMember(Long id, String providerId) {


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 애플 회원 마이그레이션 과정에서, 한 회원 마이그레이션에 실패하면 예외를 던지고 종료하고 있습니다.
  - transfer_sub을 발급받기 위해 `/apple/usermigrationinfo`을 호출하는 과정에서 에러가 발생합니다.
- 마이그레이션 과정에서 400 invalid error가 발생하여 실패했는데, 정확한 디버깅이 어려운 상황입니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->

- Apple Developer 계정 변경에 따라, 기존 Developer 계정에서 Sign in with Apple로 가입한 사용자를 새로운 Developer 계정으로 마이그레이션해야 합니다.
- 이를 위해 기존 Developer 계정에서 관리하고 있는 사용자의 sub를 기반으로 Apple의 User Migration API(/apple/usermigrationinfo)를 호출하여 transfer_sub를 발급받아 저장해야 합니다.
- 현재 transfer_sub 발급 과정에서 오류가 발생하고 있습니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->

- 마이그레이션 실패 시 건너뛰고 다음 마이그레이션을 시도하도록 수정합니다.
- 마이그레이션 관련 디버깅을 위한 로깅을 추가합니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
