### PR TITLE
feat: 애플 회원 sub(provider_id) 값 변경

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeClient.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeClient.java
@@ -1,0 +1,6 @@
+package me.bombom.api.v1.auth.migration;
+
+public interface AppleUserExchangeClient {
+
+    String exchangeSub(String transferSub);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeProperties.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeProperties.java
@@ -1,0 +1,34 @@
+package me.bombom.api.v1.auth.migration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+@ConfigurationProperties("oauth2.apple.exchange")
+public record AppleUserExchangeProperties(
+        String teamId,
+        String keyId,
+        String clientId,
+        String privateKey,
+        boolean execute
+) {
+
+    private static final String TEAM_ID_PATTERN = "[A-Z0-9]{10}";
+
+    public void validateForExecution() {
+        if (!execute) {
+            throw new IllegalStateException("Apple 새 팀 sub 교환 실행 플래그가 활성화되지 않았습니다.");
+        }
+        if (teamId == null || !teamId.matches(TEAM_ID_PATTERN)) {
+            throw new IllegalStateException("Apple 새 팀 sub 교환 대상 Team ID가 올바르지 않습니다.");
+        }
+        if (!StringUtils.hasText(keyId)) {
+            throw new IllegalStateException("Apple 새 팀 sub 교환 Key ID가 필요합니다.");
+        }
+        if (!StringUtils.hasText(clientId)) {
+            throw new IllegalStateException("Apple 새 팀 sub 교환 client ID가 필요합니다.");
+        }
+        if (!StringUtils.hasText(privateKey)) {
+            throw new IllegalStateException("Apple 새 팀 sub 교환 private key가 필요합니다.");
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeRestClient.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeRestClient.java
@@ -1,0 +1,113 @@
+package me.bombom.api.v1.auth.migration;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.auth.AppleClientSecretSupplier;
+import me.bombom.api.v1.auth.ApplePrivateKeyLoader;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+public class AppleUserExchangeRestClient implements AppleUserExchangeClient {
+
+    private static final String APPLE_TOKEN_URI = "https://appleid.apple.com/auth/token";
+    private static final String APPLE_USER_MIGRATION_URI = "https://appleid.apple.com/auth/usermigrationinfo";
+
+    private final RestClient.Builder restClientBuilder;
+    private final AppleUserExchangeProperties properties;
+
+    public AppleUserExchangeRestClient(RestClient.Builder restClientBuilder, AppleUserExchangeProperties properties) {
+        this.restClientBuilder = restClientBuilder;
+        this.properties = properties;
+    }
+
+    @Override
+    public String exchangeSub(String transferSub) {
+        String clientSecret = appleClientSecretSupplier().get();
+        String accessToken = requestExchangeAccessToken(clientSecret);
+        Map<String, Object> response = restClientBuilder.build().post()
+                .uri(APPLE_USER_MIGRATION_URI)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .header("Authorization", "Bearer " + accessToken)
+                .body(userExchangeRequestBody(transferSub, clientSecret))
+                .retrieve()
+                .onStatus(status -> status.is4xxClientError() || status.is5xxServerError(),
+                        (request, res) -> {
+                            String body = new String(res.getBody().readAllBytes());
+                            log.error("Apple usermigrationinfo(교환) 호출 실패 - status: {}, errorCode: {}",
+                                    res.getStatusCode(), extractErrorCode(body));
+                            throw HttpClientErrorException.create(
+                                    res.getStatusCode(), res.getStatusText(), res.getHeaders(), body.getBytes(), null);
+                        })
+                .body(new ParameterizedTypeReference<>() {
+                });
+        return requiredString(response, "sub");
+    }
+
+    private String requestExchangeAccessToken(String clientSecret) {
+        Map<String, Object> response = restClientBuilder.build().post()
+                .uri(APPLE_TOKEN_URI)
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .body(accessTokenRequestBody(clientSecret))
+                .retrieve()
+                .body(new ParameterizedTypeReference<>() {
+                });
+        return requiredString(response, "access_token");
+    }
+
+    private MultiValueMap<String, String> accessTokenRequestBody(String clientSecret) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("grant_type", "client_credentials");
+        body.add("scope", "user.migration");
+        body.add("client_id", properties.clientId());
+        body.add("client_secret", clientSecret);
+        return body;
+    }
+
+    private MultiValueMap<String, String> userExchangeRequestBody(String transferSub, String clientSecret) {
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("transfer_sub", transferSub);
+        body.add("client_id", properties.clientId());
+        body.add("client_secret", clientSecret);
+        return body;
+    }
+
+    private AppleClientSecretSupplier appleClientSecretSupplier() {
+        return new AppleClientSecretSupplier(
+                properties.teamId(),
+                properties.keyId(),
+                properties.clientId(),
+                new ApplePrivateKeyLoader().loadFromPem(properties.privateKey())
+        );
+    }
+
+    private String requiredString(Map<String, Object> response, String key) {
+        if (response == null || !(response.get(key) instanceof String value) || !StringUtils.hasText(value)) {
+            throw new IllegalStateException("Apple 새 팀 sub 교환 응답에 " + key + " 값이 없습니다.");
+        }
+        return value;
+    }
+
+    private String extractErrorCode(String body) {
+        if (body == null) {
+            return null;
+        }
+        int start = body.indexOf("\"error\":\"");
+        if (start < 0) {
+            return null;
+        }
+        start += "\"error\":\"".length();
+        int end = body.indexOf('"', start);
+        if (end < 0) {
+            return null;
+        }
+        return body.substring(start, end);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeResult.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeResult.java
@@ -1,0 +1,8 @@
+package me.bombom.api.v1.auth.migration;
+
+public record AppleUserExchangeResult(
+        long targetCount,
+        long migratedCount,
+        long failedCount
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeRunner.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeRunner.java
@@ -1,0 +1,34 @@
+package me.bombom.api.v1.auth.migration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@Profile("apple-user-exchange")
+@RequiredArgsConstructor
+public class AppleUserExchangeRunner implements ApplicationRunner {
+
+    private final AppleUserExchangeProperties properties;
+    private final AppleUserExchangeService service;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        log.info("Apple 새 팀 sub 교환 설정 - targetTeamId: {}, execute: {}",
+                properties.teamId(), properties.execute());
+
+        if (!properties.execute()) {
+            log.info("Apple 새 팀 sub 교환 dry-run - 대상 수: {}", service.preview());
+            return;
+        }
+
+        properties.validateForExecution();
+        AppleUserExchangeResult result = service.exchangeAll();
+        log.info("Apple 새 팀 sub 교환 완료 - 대상 수: {}, 저장 수: {}, 실패 수: {}",
+                result.targetCount(), result.migratedCount(), result.failedCount());
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/migration/AppleUserExchangeService.java
@@ -1,0 +1,59 @@
+package me.bombom.api.v1.auth.migration;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleUserExchangeService {
+
+    private static final String APPLE_PROVIDER = "apple";
+
+    private final MemberRepository memberRepository;
+    private final AppleUserExchangeClient appleUserExchangeClient;
+    private final Clock clock;
+
+    public long preview() {
+        return memberRepository.countByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNull(APPLE_PROVIDER);
+    }
+
+    public AppleUserExchangeResult exchangeAll() {
+        long targetCount = preview();
+        long migratedCount = 0L;
+        long failedCount = 0L;
+        long lastMemberId = 0L;
+
+        while (true) {
+            List<Member> members = memberRepository
+                    .findFirst100ByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNullAndIdGreaterThanOrderByIdAsc(
+                            APPLE_PROVIDER, lastMemberId);
+            if (members.isEmpty()) {
+                return new AppleUserExchangeResult(targetCount, migratedCount, failedCount);
+            }
+
+            for (Member member : members) {
+                lastMemberId = member.getId();
+                try {
+                    String newSub = appleUserExchangeClient.exchangeSub(member.getAppleTransferSub());
+                    if (!StringUtils.hasText(newSub)) {
+                        throw new IllegalStateException("Apple 새 팀 sub 교환 응답에 sub 값이 없습니다.");
+                    }
+                    member.updateAppleSubMigration(newSub, LocalDateTime.now(clock));
+                    memberRepository.save(member);
+                    migratedCount++;
+                } catch (RuntimeException e) {
+                    failedCount++;
+                    log.warn("Apple 새 팀 sub 교환 실패 - memberId: {}, 사유: {}", member.getId(), e.getMessage(), e);
+                }
+            }
+        }
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/domain/Member.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.io.Serializable;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -42,6 +43,8 @@ public class Member extends BaseEntity implements Serializable {
 
     @Column(unique = true, length = 255)
     private String appleTransferSub;
+
+    private LocalDateTime appleSubMigratedAt;
 
     @Column(nullable = false, length = 50)
     private String email;
@@ -110,5 +113,10 @@ public class Member extends BaseEntity implements Serializable {
 
     public void updateAppleTransferSub(String transferSub) {
         this.appleTransferSub = transferSub;
+    }
+
+    public void updateAppleSubMigration(String newProviderId, LocalDateTime migratedAt) {
+        this.providerId = newProviderId;
+        this.appleSubMigratedAt = migratedAt;
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/member/repository/MemberRepository.java
@@ -20,6 +20,11 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     List<Member> findFirst100ByProviderAndAppleTransferSubIsNullAndIdGreaterThanOrderByIdAsc(String provider, Long id);
 
+    long countByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNull(String provider);
+
+    List<Member> findFirst100ByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNullAndIdGreaterThanOrderByIdAsc(
+            String provider, Long id);
+
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);

--- a/backend/bom-bom-server/src/main/resources/db/migration/V37.5.0__add_member_apple_sub_migrated_at.sql
+++ b/backend/bom-bom-server/src/main/resources/db/migration/V37.5.0__add_member_apple_sub_migrated_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE member
+    ADD COLUMN apple_sub_migrated_at DATETIME NULL;

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserExchangePropertiesTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserExchangePropertiesTest.java
@@ -1,0 +1,46 @@
+package me.bombom.api.v1.auth.migration;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class AppleUserExchangePropertiesTest {
+
+    private static final String VALID_PEM = "-----BEGIN PRIVATE KEY-----\ndummy\n-----END PRIVATE KEY-----";
+
+    @Test
+    void 유효하지_않은_Team_ID면_실행을_거부한다() {
+        AppleUserExchangeProperties properties =
+                new AppleUserExchangeProperties("invalid", "key_id", "com.example.app", VALID_PEM, true);
+
+        assertThatThrownBy(properties::validateForExecution)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void execute가_false이면_실행을_거부한다() {
+        AppleUserExchangeProperties properties =
+                new AppleUserExchangeProperties("A1B2C3D4E5", "key_id", "com.example.app", VALID_PEM, false);
+
+        assertThatThrownBy(properties::validateForExecution)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void privateKey가_없으면_실행을_거부한다() {
+        AppleUserExchangeProperties properties =
+                new AppleUserExchangeProperties("A1B2C3D4E5", "key_id", "com.example.app", null, true);
+
+        assertThatThrownBy(properties::validateForExecution)
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+    @Test
+    void keyId가_없으면_실행을_거부한다() {
+        AppleUserExchangeProperties properties =
+                new AppleUserExchangeProperties("A1B2C3D4E5", null, "com.example.app", VALID_PEM, true);
+
+        assertThatThrownBy(properties::validateForExecution)
+                .isInstanceOf(IllegalStateException.class);
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserExchangeRestClientTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserExchangeRestClientTest.java
@@ -1,0 +1,85 @@
+package me.bombom.api.v1.auth.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowableOfType;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.content;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.interfaces.ECPrivateKey;
+import java.security.spec.ECGenParameterSpec;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+
+class AppleUserExchangeRestClientTest {
+
+    private MockRestServiceServer server;
+    private AppleUserExchangeRestClient client;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        RestClient.Builder builder = RestClient.builder();
+        server = MockRestServiceServer.bindTo(builder).build();
+
+        KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
+        generator.initialize(new ECGenParameterSpec("secp256r1"));
+        KeyPair keyPair = generator.generateKeyPair();
+        ECPrivateKey privateKey = (ECPrivateKey) keyPair.getPrivate();
+        String pem = "-----BEGIN PRIVATE KEY-----\n"
+                + Base64.getEncoder().encodeToString(privateKey.getEncoded())
+                + "\n-----END PRIVATE KEY-----";
+
+        AppleUserExchangeProperties properties =
+                new AppleUserExchangeProperties("A1B2C3D4E5", "KEY123ID45", "com.example.app", pem, true);
+        client = new AppleUserExchangeRestClient(builder, properties);
+    }
+
+    @Test
+    void transfer_sub로_새_팀의_sub를_교환한다() {
+        server.expect(requestTo("https://appleid.apple.com/auth/token"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("grant_type=client_credentials")))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("scope=user.migration")))
+                .andRespond(withSuccess("{\"access_token\":\"exchange-token\"}", MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://appleid.apple.com/auth/usermigrationinfo"))
+                .andExpect(method(HttpMethod.POST))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer exchange-token"))
+                .andExpect(content().string(org.hamcrest.Matchers.containsString("transfer_sub=old-transfer-sub")))
+                .andRespond(withSuccess("{\"sub\":\"new-team-sub\"}", MediaType.APPLICATION_JSON));
+
+        String newSub = client.exchangeSub("old-transfer-sub");
+
+        assertThat(newSub).isEqualTo("new-team-sub");
+        server.verify();
+    }
+
+    @Test
+    void Apple가_invalid_request를_반환하면_에러_바디를_포함해_예외를_던진다() {
+        server.expect(requestTo("https://appleid.apple.com/auth/token"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withSuccess("{\"access_token\":\"exchange-token\"}", MediaType.APPLICATION_JSON));
+        server.expect(requestTo("https://appleid.apple.com/auth/usermigrationinfo"))
+                .andExpect(method(HttpMethod.POST))
+                .andRespond(withBadRequest()
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .body("{\"error\":\"invalid_request\"}"));
+
+        HttpClientErrorException exception = catchThrowableOfType(
+                () -> client.exchangeSub("old-transfer-sub"), HttpClientErrorException.class);
+
+        assertThat(exception.getResponseBodyAsString()).contains("invalid_request");
+        server.verify();
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserExchangeRunnerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserExchangeRunnerTest.java
@@ -1,0 +1,37 @@
+package me.bombom.api.v1.auth.migration;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.ApplicationArguments;
+
+class AppleUserExchangeRunnerTest {
+
+    private final AppleUserExchangeService service = mock(AppleUserExchangeService.class);
+
+    @Test
+    void execute가_false이면_미리보기만_수행한다() throws Exception {
+        AppleUserExchangeProperties properties = new AppleUserExchangeProperties(
+                "A1B2C3D4E5", "KEY123ID45", "com.example.app", "dummy-pem", false);
+        given(service.preview()).willReturn(5L);
+
+        new AppleUserExchangeRunner(properties, service).run(mock(ApplicationArguments.class));
+
+        verify(service).preview();
+        verify(service, never()).exchangeAll();
+    }
+
+    @Test
+    void execute가_true이면_검증후_배치를_수행한다() throws Exception {
+        AppleUserExchangeProperties properties = new AppleUserExchangeProperties(
+                "A1B2C3D4E5", "KEY123ID45", "com.example.app", "dummy-pem", true);
+        given(service.exchangeAll()).willReturn(new AppleUserExchangeResult(5L, 5L, 0L));
+
+        new AppleUserExchangeRunner(properties, service).run(mock(ApplicationArguments.class));
+
+        verify(service).exchangeAll();
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserExchangeServiceTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/migration/AppleUserExchangeServiceTest.java
@@ -1,0 +1,114 @@
+package me.bombom.api.v1.auth.migration;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.enums.Gender;
+import me.bombom.api.v1.member.repository.MemberRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AppleUserExchangeServiceTest {
+
+    private static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+    private static final Clock FIXED_CLOCK =
+            Clock.fixed(Instant.parse("2026-08-18T12:00:00Z"), ZONE);
+
+    @Mock
+    private MemberRepository memberRepository;
+
+    @Mock
+    private AppleUserExchangeClient appleUserExchangeClient;
+
+    private AppleUserExchangeService service;
+
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        service = new AppleUserExchangeService(memberRepository, appleUserExchangeClient, FIXED_CLOCK);
+    }
+
+    @Test
+    void 미처리_transfer_sub_보유_회원의_providerId를_새_sub로_갱신한다() {
+        Member member = appleMember(1L, "old-team-sub", "transfer-sub");
+        given(memberRepository.countByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNull("apple"))
+                .willReturn(1L);
+        given(memberRepository
+                .findFirst100ByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNullAndIdGreaterThanOrderByIdAsc(
+                        "apple", 0L))
+                .willReturn(List.of(member));
+        given(memberRepository
+                .findFirst100ByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNullAndIdGreaterThanOrderByIdAsc(
+                        "apple", 1L))
+                .willReturn(List.of());
+        given(appleUserExchangeClient.exchangeSub("transfer-sub")).willReturn("new-team-sub");
+
+        AppleUserExchangeResult result = service.exchangeAll();
+
+        assertSoftly(softly -> {
+            softly.assertThat(member.getProviderId()).isEqualTo("new-team-sub");
+            softly.assertThat(member.getAppleSubMigratedAt())
+                    .isEqualTo(LocalDateTime.now(FIXED_CLOCK));
+            softly.assertThat(result.targetCount()).isEqualTo(1L);
+            softly.assertThat(result.migratedCount()).isEqualTo(1L);
+            softly.assertThat(result.failedCount()).isEqualTo(0L);
+        });
+        verify(memberRepository).save(member);
+    }
+
+    @Test
+    void Apple_호출에_실패한_회원은_건너뛰고_다음_회원을_계속_처리한다() {
+        Member failedMember = appleMember(1L, "old-team-sub-1", "transfer-sub-1");
+        Member succeededMember = appleMember(2L, "old-team-sub-2", "transfer-sub-2");
+        given(memberRepository.countByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNull("apple"))
+                .willReturn(2L);
+        given(memberRepository
+                .findFirst100ByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNullAndIdGreaterThanOrderByIdAsc(
+                        "apple", 0L))
+                .willReturn(List.of(failedMember, succeededMember));
+        given(memberRepository
+                .findFirst100ByProviderAndAppleTransferSubIsNotNullAndAppleSubMigratedAtIsNullAndIdGreaterThanOrderByIdAsc(
+                        "apple", 2L))
+                .willReturn(List.of());
+        given(appleUserExchangeClient.exchangeSub("transfer-sub-1"))
+                .willThrow(new IllegalStateException("Apple error"));
+        given(appleUserExchangeClient.exchangeSub("transfer-sub-2")).willReturn("new-team-sub-2");
+
+        AppleUserExchangeResult result = service.exchangeAll();
+
+        assertSoftly(softly -> {
+            softly.assertThat(failedMember.getProviderId()).isEqualTo("old-team-sub-1");
+            softly.assertThat(failedMember.getAppleSubMigratedAt()).isNull();
+            softly.assertThat(succeededMember.getProviderId()).isEqualTo("new-team-sub-2");
+            softly.assertThat(result.targetCount()).isEqualTo(2L);
+            softly.assertThat(result.migratedCount()).isEqualTo(1L);
+            softly.assertThat(result.failedCount()).isEqualTo(1L);
+        });
+        verify(memberRepository, never()).save(failedMember);
+        verify(memberRepository).save(succeededMember);
+    }
+
+    private Member appleMember(Long id, String providerId, String transferSub) {
+        Member member = Member.builder()
+                .id(id)
+                .provider("apple")
+                .providerId(providerId)
+                .email(providerId + "@example.com")
+                .nickname("member-" + id)
+                .gender(Gender.NONE)
+                .roleId(1L)
+                .build();
+        member.updateAppleTransferSub(transferSub);
+        return member;
+    }
+}

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/domain/MemberTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/member/domain/MemberTest.java
@@ -1,7 +1,9 @@
 package me.bombom.api.v1.member.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
+import java.time.LocalDateTime;
 import me.bombom.api.v1.member.enums.Gender;
 import org.junit.jupiter.api.Test;
 
@@ -21,5 +23,25 @@ class MemberTest {
         member.updateAppleTransferSub("transfer-sub");
 
         assertThat(member.getAppleTransferSub()).isEqualTo("transfer-sub");
+    }
+
+    @Test
+    void Apple_새_팀_sub로_교환하면_providerId와_완료_시각이_갱신된다() {
+        Member member = Member.builder()
+                .provider("apple")
+                .providerId("old-team-sub")
+                .email("apple@example.com")
+                .nickname("apple-member")
+                .gender(Gender.NONE)
+                .roleId(1L)
+                .build();
+        LocalDateTime migratedAt = LocalDateTime.of(2026, 8, 18, 12, 0);
+
+        member.updateAppleSubMigration("new-team-sub", migratedAt);
+
+        assertSoftly(softly -> {
+            softly.assertThat(member.getProviderId()).isEqualTo("new-team-sub");
+            softly.assertThat(member.getAppleSubMigratedAt()).isEqualTo(migratedAt);
+        });
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- 기존 Developer로 발급받은 transfer_sub를 기반으로, 새로운 Developer에서 sub을 발급받아 provider_id를 교체합니다.
- 마이그레이션 완료 회원을 구분하기 위해, 마이그레이션 완료 시점에 대한 컬럼(`apple_sub_migrated_at`)을 추가합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 새로운 Developer 계정 설정으로 변경 후 후 기존 애플 회원이 로그인을 할 수 있도록 설정합니다.

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- transfer_sub과 새로운 Developer 계정 기반으로 `/auth/usermigrationinfo`를 호출하여, 새로운 sub을 발급받은 후 provider_id를 덮어씁니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
