### PR TITLE
[BOM-1213] fix: OAuth 미가입 사용자 회원가입 리다이렉트 수정

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/handler/OAuth2LoginSuccessHandler.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/auth/handler/OAuth2LoginSuccessHandler.java
@@ -128,16 +128,17 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     }
 
     private String buildRedirectUrl(HttpServletRequest request, Member member, OAuth2LoginInfo oauth2Info) {
-        String baseUrl = getBaseUrl(request);
-        baseUrl = StringUtils.trimTrailingCharacter(baseUrl, '/');
         if (member != null) {
+            String baseUrl = StringUtils.trimTrailingCharacter(getBaseUrl(request), '/');
             return baseUrl + HOME_PATH;
         }
+
+        String signupUrl = StringUtils.trimTrailingCharacter(frontendBaseUrl, '/') + SIGNUP_PATH;
         if (oauth2Info.getEmail() != null || oauth2Info.getName() != null) {
             String queryParams = buildQueryParams(oauth2Info);
-            return baseUrl + SIGNUP_PATH + queryParams;
+            return signupUrl + queryParams;
         }
-        return baseUrl + SIGNUP_PATH;
+        return signupUrl;
     }
 
     private String buildQueryParams(OAuth2LoginInfo oauth2Info) {

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/handler/OAuth2LoginSuccessHandlerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/auth/handler/OAuth2LoginSuccessHandlerTest.java
@@ -1,0 +1,88 @@
+package me.bombom.api.v1.auth.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import me.bombom.api.v1.auth.dto.CustomOAuth2User;
+import me.bombom.api.v1.auth.util.UniqueUserInfoGenerator;
+import me.bombom.api.v1.member.domain.Member;
+import me.bombom.api.v1.member.service.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class OAuth2LoginSuccessHandlerTest {
+
+    private static final String FRONTEND_BASE_URL = "https://www.bombom.news";
+    private static final Map<String, Object> NEW_MEMBER_ATTRIBUTES = Map.of(
+            "sub", "oauth-user",
+            "email", "new-member@example.com",
+            "name", "new member"
+    );
+
+    private OAuth2LoginSuccessHandler handler;
+    private UniqueUserInfoGenerator uniqueUserInfoGenerator;
+
+    @BeforeEach
+    void setUp() {
+        uniqueUserInfoGenerator = mock(UniqueUserInfoGenerator.class);
+        handler = new OAuth2LoginSuccessHandler(
+                mock(MemberService.class),
+                uniqueUserInfoGenerator
+        );
+        ReflectionTestUtils.setField(handler, "redirectUriWhitelist", List.of(FRONTEND_BASE_URL));
+        ReflectionTestUtils.setField(handler, "frontendBaseUrl", FRONTEND_BASE_URL);
+
+        when(uniqueUserInfoGenerator.getUniqueEmailLocalPart("new-member@example.com"))
+                .thenReturn("new-member");
+        when(uniqueUserInfoGenerator.getUniqueNickname("new member"))
+                .thenReturn("new-member");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"/", "/blog", "/blog/post/41?from=home"})
+    void 미가입_사용자는_로그인_시작_경로와_무관하게_회원가입_페이지로_이동한다(String path) throws Exception {
+        MockHttpServletRequest request = requestWithRedirectUrl(FRONTEND_BASE_URL + path);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationSuccess(request, response, authentication(NEW_MEMBER_ATTRIBUTES, null));
+
+        assertThat(response.getRedirectedUrl())
+                .isEqualTo(FRONTEND_BASE_URL + "/signup?email=new-member&name=new-member");
+    }
+
+    @Test
+    void 기존_회원의_리다이렉트_동작은_유지한다() throws Exception {
+        String redirectUrl = FRONTEND_BASE_URL + "/blog";
+        MockHttpServletRequest request = requestWithRedirectUrl(redirectUrl);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        handler.onAuthenticationSuccess(request, response, authentication(Map.of("sub", "oauth-user"), mock(Member.class)));
+
+        assertThat(response.getRedirectedUrl()).isEqualTo(redirectUrl + "/");
+    }
+
+    private MockHttpServletRequest requestWithRedirectUrl(String redirectUrl) {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.getSession().setAttribute("redirectUrl", redirectUrl);
+        return request;
+    }
+
+    private OAuth2AuthenticationToken authentication(Map<String, Object> attributes, Member member) {
+        CustomOAuth2User user = new CustomOAuth2User(
+                attributes,
+                member,
+                null,
+                null
+        );
+        return new OAuth2AuthenticationToken(user, List.of(), "google");
+    }
+}


### PR DESCRIPTION
## 📌 What
- OAuth 로그인 시작 경로와 무관하게 미가입 사용자를 /signup으로 이동하도록 수정했습니다.
- 루트, 블로그, 상세 경로와 기존 회원 리다이렉트에 대한 회귀 테스트를 추가했습니다.
- Jira: https://bom-bom.atlassian.net/browse/BOM-1213

## ❓ Why
- 기존에는 세션의 redirectUrl 전체 경로를 기준으로 /signup을 덧붙였습니다.
- 블로그 등 루트가 아닌 경로에서 로그인을 시작하면 /blog/signup과 같은 존재하지 않는 경로로 이동해 404가 발생했습니다.

## 🔧 How
- 기존 회원은 기존과 동일하게 세션의 redirectUrl을 사용합니다.
- 미가입 사용자는 로그인 시작 경로를 사용하지 않고 frontendBaseUrl의 /signup으로 이동합니다.
- 기존 email, name 회원가입 쿼리 파라미터 생성 로직은 유지했습니다.
- OAuth2LoginSuccessHandlerTest로 루트, 블로그, 상세 경로 및 기존 회원 동작을 검증했습니다.

## 👀 Review Point (Optional)
- 미가입 사용자 분기만 frontendBaseUrl을 사용하고 기존 회원 리다이렉트 동작은 유지되는지 확인 부탁드립니다.