### PR TITLE
feat: FAQ 카테고리별 필터링 기능 추가

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqController.java
@@ -2,7 +2,7 @@ package me.bombom.api.v1.faq.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.faq.dto.FaqResponse;
-import me.bombom.api.v1.faq.dto.GetFaqsRequest;
+import me.bombom.api.v1.faq.dto.GetFaqsOptionsRequest;
 import me.bombom.api.v1.faq.service.FaqService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,7 +22,7 @@ public class FaqController implements FaqControllerApi {
     @Override
     @GetMapping
     public Page<FaqResponse> getFaqs(
-            @ModelAttribute GetFaqsRequest request,
+            @ModelAttribute GetFaqsOptionsRequest request,
             @PageableDefault(size = 20) Pageable pageable
     ) {
         return faqService.getFaqs(request, pageable);

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqController.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.faq.controller;
 
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.faq.dto.FaqResponse;
+import me.bombom.api.v1.faq.dto.GetFaqsRequest;
 import me.bombom.api.v1.faq.service.FaqService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +10,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.SortDefault;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,12 +24,13 @@ public class FaqController implements FaqControllerApi {
     @Override
     @GetMapping
     public Page<FaqResponse> getFaqs(
+            @ModelAttribute GetFaqsRequest request,
             @PageableDefault(size = 20)
             @SortDefault.SortDefaults({
                     @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC),
                     @SortDefault(sort = "id", direction = Sort.Direction.ASC)
             }) Pageable pageable
     ) {
-        return faqService.getFaqs(pageable);
+        return faqService.getFaqs(request, pageable);
     }
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqController.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqController.java
@@ -6,8 +6,6 @@ import me.bombom.api.v1.faq.dto.GetFaqsRequest;
 import me.bombom.api.v1.faq.service.FaqService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.SortDefault;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -25,11 +23,7 @@ public class FaqController implements FaqControllerApi {
     @GetMapping
     public Page<FaqResponse> getFaqs(
             @ModelAttribute GetFaqsRequest request,
-            @PageableDefault(size = 20)
-            @SortDefault.SortDefaults({
-                    @SortDefault(sort = "createdAt", direction = Sort.Direction.DESC),
-                    @SortDefault(sort = "id", direction = Sort.Direction.ASC)
-            }) Pageable pageable
+            @PageableDefault(size = 20) Pageable pageable
     ) {
         return faqService.getFaqs(request, pageable);
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqControllerApi.java
@@ -5,6 +5,8 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import me.bombom.api.v1.faq.dto.FaqResponse;
+import me.bombom.api.v1.faq.dto.GetFaqsRequest;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -13,10 +15,10 @@ public interface FaqControllerApi {
 
     @Operation(
             summary = "FAQ 목록 조회",
-            description = "FAQ 목록을 조회합니다."
+            description = "FAQ 목록을 조회합니다. (카테고리 필터링 지원)"
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "FAQ 목록 조회 성공")
     })
-    Page<FaqResponse> getFaqs(Pageable pageable);
+    Page<FaqResponse> getFaqs(@ParameterObject GetFaqsRequest request, @ParameterObject Pageable pageable);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqControllerApi.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/controller/FaqControllerApi.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import me.bombom.api.v1.faq.dto.FaqResponse;
-import me.bombom.api.v1.faq.dto.GetFaqsRequest;
+import me.bombom.api.v1.faq.dto.GetFaqsOptionsRequest;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -20,5 +20,5 @@ public interface FaqControllerApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "FAQ 목록 조회 성공")
     })
-    Page<FaqResponse> getFaqs(@ParameterObject GetFaqsRequest request, @ParameterObject Pageable pageable);
+    Page<FaqResponse> getFaqs(@ParameterObject GetFaqsOptionsRequest request, @ParameterObject Pageable pageable);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/dto/GetFaqsOptionsRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/dto/GetFaqsOptionsRequest.java
@@ -2,7 +2,7 @@ package me.bombom.api.v1.faq.dto;
 
 import me.bombom.api.v1.faq.domain.FaqCategory;
 
-public record GetFaqsRequest(
+public record GetFaqsOptionsRequest(
         FaqCategory faqCategory
 ) {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/dto/GetFaqsRequest.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/dto/GetFaqsRequest.java
@@ -1,0 +1,8 @@
+package me.bombom.api.v1.faq.dto;
+
+import me.bombom.api.v1.faq.domain.FaqCategory;
+
+public record GetFaqsRequest(
+        FaqCategory faqCategory
+) {
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/CustomFaqRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/CustomFaqRepository.java
@@ -1,0 +1,11 @@
+package me.bombom.api.v1.faq.repository;
+
+import me.bombom.api.v1.faq.domain.Faq;
+import me.bombom.api.v1.faq.dto.GetFaqsRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomFaqRepository {
+
+    Page<Faq> findFaqs(GetFaqsRequest request, Pageable pageable);
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/CustomFaqRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/CustomFaqRepository.java
@@ -1,11 +1,11 @@
 package me.bombom.api.v1.faq.repository;
 
 import me.bombom.api.v1.faq.domain.Faq;
-import me.bombom.api.v1.faq.dto.GetFaqsRequest;
+import me.bombom.api.v1.faq.dto.GetFaqsOptionsRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomFaqRepository {
 
-    Page<Faq> findFaqs(GetFaqsRequest request, Pageable pageable);
+    Page<Faq> findFaqs(GetFaqsOptionsRequest request, Pageable pageable);
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/FaqRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/FaqRepository.java
@@ -3,5 +3,5 @@ package me.bombom.api.v1.faq.repository;
 import me.bombom.api.v1.faq.domain.Faq;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FaqRepository extends JpaRepository<Faq, Long> {
+public interface FaqRepository extends JpaRepository<Faq, Long>, CustomFaqRepository {
 }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/FaqRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/FaqRepositoryImpl.java
@@ -9,7 +9,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.faq.domain.Faq;
 import me.bombom.api.v1.faq.domain.FaqCategory;
-import me.bombom.api.v1.faq.dto.GetFaqsRequest;
+import me.bombom.api.v1.faq.dto.GetFaqsOptionsRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -20,7 +20,7 @@ public class FaqRepositoryImpl implements CustomFaqRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     @Override
-    public Page<Faq> findFaqs(GetFaqsRequest request, Pageable pageable) {
+    public Page<Faq> findFaqs(GetFaqsOptionsRequest request, Pageable pageable) {
         List<Faq> content = jpaQueryFactory
                 .selectFrom(faq)
                 .where(categoryEq(request.faqCategory()))

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/FaqRepositoryImpl.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/repository/FaqRepositoryImpl.java
@@ -1,0 +1,46 @@
+package me.bombom.api.v1.faq.repository;
+
+import static me.bombom.api.v1.faq.domain.QFaq.faq;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import me.bombom.api.v1.faq.domain.Faq;
+import me.bombom.api.v1.faq.domain.FaqCategory;
+import me.bombom.api.v1.faq.dto.GetFaqsRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+@RequiredArgsConstructor
+public class FaqRepositoryImpl implements CustomFaqRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<Faq> findFaqs(GetFaqsRequest request, Pageable pageable) {
+        List<Faq> content = jpaQueryFactory
+                .selectFrom(faq)
+                .where(categoryEq(request.faqCategory()))
+                .orderBy(faq.createdAt.desc(), faq.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = jpaQueryFactory
+                .select(faq.count())
+                .from(faq)
+                .where(categoryEq(request.faqCategory()));
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    private BooleanExpression categoryEq(FaqCategory category) {
+        if (category == null) {
+            return null;
+        }
+        return faq.faqCategory.eq(category);
+    }
+}

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/service/FaqService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/service/FaqService.java
@@ -2,7 +2,7 @@ package me.bombom.api.v1.faq.service;
 
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.faq.dto.FaqResponse;
-import me.bombom.api.v1.faq.dto.GetFaqsRequest;
+import me.bombom.api.v1.faq.dto.GetFaqsOptionsRequest;
 import me.bombom.api.v1.faq.repository.FaqRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,7 +16,7 @@ public class FaqService {
 
     private final FaqRepository faqRepository;
 
-    public Page<FaqResponse> getFaqs(GetFaqsRequest request, Pageable pageable) {
+    public Page<FaqResponse> getFaqs(GetFaqsOptionsRequest request, Pageable pageable) {
         return faqRepository.findFaqs(request, pageable)
                 .map(FaqResponse::from);
     }

--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/service/FaqService.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/faq/service/FaqService.java
@@ -2,6 +2,7 @@ package me.bombom.api.v1.faq.service;
 
 import lombok.RequiredArgsConstructor;
 import me.bombom.api.v1.faq.dto.FaqResponse;
+import me.bombom.api.v1.faq.dto.GetFaqsRequest;
 import me.bombom.api.v1.faq.repository.FaqRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -15,8 +16,8 @@ public class FaqService {
 
     private final FaqRepository faqRepository;
 
-    public Page<FaqResponse> getFaqs(Pageable pageable) {
-        return faqRepository.findAll(pageable)
+    public Page<FaqResponse> getFaqs(GetFaqsRequest request, Pageable pageable) {
+        return faqRepository.findFaqs(request, pageable)
                 .map(FaqResponse::from);
     }
 }

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/faq/controller/FaqControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/faq/controller/FaqControllerTest.java
@@ -35,6 +35,27 @@ class FaqControllerTest {
         });
     }
 
+    @Test
+    void FAQ_목록을_카테고리로_필터링하여_조회한다() {
+        Map<String, Object> result = RestAssured.given()
+                .accept(ContentType.JSON)
+                .queryParam("faqCategory", "NEWSLETTER")
+                .when()
+                .get("/api/v1/faqs")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .extract()
+                .jsonPath()
+                .getMap("$");
+
+        assertSoftly(softly -> {
+            softly.assertThat(content(result)).hasSize(1);
+            softly.assertThat(content(result).get(0).get("question")).isEqualTo("질문2");
+            softly.assertThat(result.get("totalElements")).isEqualTo(1);
+        });
+    }
+
     @SuppressWarnings("unchecked")
     private static List<Map<String, Object>> content(Map<String, Object> page) {
         return (List<Map<String, Object>>) page.get("content");

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/faq/controller/FaqControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/faq/controller/FaqControllerTest.java
@@ -31,7 +31,6 @@ class FaqControllerTest {
             softly.assertThat(content(result).get(2).get("question")).isEqualTo("질문1");
             softly.assertThat(result.get("totalElements")).isEqualTo(3);
             softly.assertThat(result.get("size")).isEqualTo(20);
-            softly.assertThat(sort(result).get("sorted")).isEqualTo(true);
         });
     }
 
@@ -59,10 +58,5 @@ class FaqControllerTest {
     @SuppressWarnings("unchecked")
     private static List<Map<String, Object>> content(Map<String, Object> page) {
         return (List<Map<String, Object>>) page.get("content");
-    }
-
-    @SuppressWarnings("unchecked")
-    private static Map<String, Object> sort(Map<String, Object> page) {
-        return (Map<String, Object>) page.get("sort");
     }
 }


### PR DESCRIPTION
## 📌 What
<!-- 해결하고자 한 문제를 간결하고 명확하게 서술해주세요. -->
<!-- ex) 로그인 실패 시 에러 메시지가 출력되지 않던 문제 -->
- FAQ를 카테고리별로 필터링 할 수 있도록 설정합니다.

## ❓ Why
<!-- 이 문제를 왜 해결해야 했는지, 어떤 맥락에서 발생했는지 작성해주세요. -->
<!-- ex) 사용자 피드백으로 오류 발생 시 원인 파악이 어렵다는 의견이 있었음 -->
- 기존 기획에서는, 카테고리 필터링 없이 모든 FAQ를 노출하려고 했습니다.
- 뷰를 구현하는 와중, 카테고리별 FAQ 필터링 기능을 지원하지 않으면 원하는 항목을 찾기 어려울 것 같다는 생각이 들었습니다. (각 카테고리별 FAQ가 5개라고 가정하면 총 25개)

## 🔧 How
<!-- 어떤 방식으로 해결했는지 기술적 접근 방법을 설명해주세요. -->
<!-- 주요 변경 사항, 선택한 로직이나 방법에 대한 이유가 있으면 함께 작성해주세요. -->
- 기존 FAQ 조회 API에서, FaqCategory 기반 필터링이 가능하도록 수정합니다.
- 카테고리 필터 유무를 서비스 단에서 분기하지 않고 안전하게 처리하기 위해, 그리고 FAQ 키워드 검색 등 확장 가능성을 고려해 QueryDSL을 사용했습니다.

## 👀 Review Point (Optional)
<!-- 리뷰어에게 중점적으로 봐주었으면 하는 부분을 작성해주세요. -->
<!-- ex) 예외 처리 방식이 적절한지 확인 부탁드립니다. -->
- 프로젝트의 컨벤션에 어긋나는 부분이 있는지 봐주시면 감사하겠습니다!