### PR TITLE
[BOM-1230] refactor: 연속 읽기 랭킹의 배지 조회 범위 축소

### DIFF
--- a/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingSnapshotRepository.java
+++ b/backend/bom-bom-server/src/main/java/me/bombom/api/v1/reading/repository/ContinueReadingSnapshotRepository.java
@@ -36,9 +36,9 @@ public interface ContinueReadingSnapshotRepository extends JpaRepository<Continu
 
     @Query(value = """
             SELECT
-                m.nickname AS nickname,
-                rs.rank_order AS `rank`,
-                rs.day_count AS dayCount,
+                ranked.nickname AS nickname,
+                ranked.rank_order AS `rank`,
+                ranked.day_count AS dayCount,
                 rb.badge_grade AS rankingBadgeGrade,
                 rb.period_year AS rankingBadgeYear,
                 rb.period_month AS rankingBadgeMonth,
@@ -46,30 +46,39 @@ public interface ContinueReadingSnapshotRepository extends JpaRepository<Continu
                 cb_latest.challenge_name AS challengeBadgeName,
                 cb_latest.challenge_generation AS challengeBadgeGeneration,
                 sb_latest.streak_day_count AS streakDayCount
-            FROM continue_reading_snapshot rs
-            JOIN member m ON rs.member_id = m.id
-            LEFT JOIN badge rb ON rb.member_id = rs.member_id
+            FROM (
+                SELECT
+                    rs.member_id,
+                    m.nickname,
+                    rs.rank_order,
+                    rs.day_count
+                FROM continue_reading_snapshot rs
+                JOIN member m ON rs.member_id = m.id
+                ORDER BY rs.rank_order, m.nickname
+                LIMIT :limit
+            ) ranked
+            LEFT JOIN badge rb ON rb.member_id = ranked.member_id
                 AND rb.badge_category = 'RANKING'
                 AND rb.period_year = :lastMonthYear
                 AND rb.period_month = :lastMonthValue
             LEFT JOIN LATERAL (
-                SELECT cb.*
+                SELECT cb.badge_grade, cb.challenge_name, cb.challenge_generation
                 FROM badge cb
-                WHERE cb.member_id = rs.member_id
+                WHERE cb.member_id = ranked.member_id
                     AND cb.badge_category = 'CHALLENGE'
                 ORDER BY cb.created_at DESC
                 LIMIT 1
             ) cb_latest ON true
             LEFT JOIN LATERAL (
-                SELECT sb.*
+                SELECT sb.streak_day_count
                 FROM badge sb
-                WHERE sb.member_id = rs.member_id
+                WHERE sb.member_id = ranked.member_id
                     AND sb.badge_category = 'STREAK'
                 ORDER BY sb.streak_day_count DESC,
                 sb.created_at DESC
                 LIMIT 1
             ) sb_latest ON true
-            ORDER BY rs.rank_order, m.nickname
+            ORDER BY ranked.rank_order, ranked.nickname
             LIMIT :limit
             """, nativeQuery = true)
     List<ContinueReadingRankFlat> findContinueReadingRanking(

--- a/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/controller/ContinueReadingRankingControllerTest.java
+++ b/backend/bom-bom-server/src/test/java/me/bombom/api/v1/reading/controller/ContinueReadingRankingControllerTest.java
@@ -1,0 +1,116 @@
+package me.bombom.api.v1.reading.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import me.bombom.support.acceptance.AcceptanceTest;
+import me.bombom.support.acceptance.AcceptanceDataSetLoader;
+import me.bombom.support.acceptance.AdditionalAcceptanceDataSet;
+import me.bombom.support.acceptance.ResetsAcceptanceData;
+import me.bombom.support.time.MutableClock;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@AcceptanceTest({
+        "acceptance/common/member.json",
+        "acceptance/reading/reading.json",
+        "acceptance/reading/streak-ranking.json"
+})
+class ContinueReadingRankingControllerTest {
+
+    @Autowired
+    private MutableClock clock;
+
+    @Autowired
+    private AcceptanceDataSetLoader dataSetLoader;
+
+    @BeforeEach
+    void 날짜를_고정한다() {
+        clock.setDate(LocalDate.of(2026, 9, 6));
+    }
+
+    @Test
+    void 공동_순위는_닉네임_순으로_limit만큼_조회하고_선정된_회원의_배지를_반환한다() {
+        List<Map<String, Object>> ranking = getRanking(2);
+
+        assertThat(ranking).extracting(row -> row.get("nickname"))
+                .containsExactly("Alpha", "Zeta");
+        Map<String, Object> first = ranking.getFirst();
+        Map<String, Object> badges = nested(first, "badges");
+        assertSoftly(softly -> {
+            softly.assertThat(first.get("rank")).isEqualTo(1);
+            softly.assertThat(first.get("dayCount")).isEqualTo(10);
+            softly.assertThat(nested(badges, "monthlyRanking"))
+                    .containsEntry("grade", "GOLD")
+                    .containsEntry("year", 2026)
+                    .containsEntry("month", 8);
+            softly.assertThat(nested(badges, "challenge"))
+                    .containsEntry("grade", "SILVER")
+                    .containsEntry("name", "최근 챌린지")
+                    .containsEntry("generation", 2);
+            softly.assertThat(nested(badges, "streak")).containsEntry("tier", "THIRTY");
+            softly.assertThat(ranking.get(1).get("badges")).isNull();
+        });
+    }
+
+    @Test
+    void limit이_전체_인원보다_크면_모든_회원을_순위와_닉네임_순으로_반환한다() {
+        List<Map<String, Object>> ranking = getRanking(10);
+
+        assertSoftly(softly -> {
+            softly.assertThat(ranking).extracting(row -> row.get("nickname"))
+                    .containsExactly("Alpha", "Zeta", "인수테스트회원", "Lower");
+            softly.assertThat(ranking).extracting(row -> row.get("rank"))
+                    .containsExactly(1, 1, 1, 4);
+        });
+    }
+
+    @Test
+    @AdditionalAcceptanceDataSet("acceptance/reading/streak-ranking-duplicate-badge.json")
+    void 같은_회원의_월간_배지가_중복되어도_응답은_limit을_넘지_않는다() {
+        assertThat(getRanking(2)).hasSize(2);
+    }
+
+    @Test
+    @ResetsAcceptanceData
+    void 랭킹_대상이_없으면_빈_목록을_반환한다() {
+        dataSetLoader.load("acceptance/reading/streak-ranking-empty.json");
+
+        assertThat(getRanking(2)).isEmpty();
+    }
+
+    @Test
+    void limit이_0이면_잘못된_요청으로_응답한다() {
+        RestAssured.given()
+                .queryParam("limit", 0)
+                .when()
+                .get("/api/v1/members/me/reading/streak/rank")
+                .then()
+                .statusCode(400);
+    }
+
+    private static List<Map<String, Object>> getRanking(int limit) {
+        return RestAssured.given()
+                .accept(ContentType.JSON)
+                .queryParam("limit", limit)
+                .when()
+                .get("/api/v1/members/me/reading/streak/rank")
+                .then()
+                .statusCode(200)
+                .contentType(ContentType.JSON)
+                .extract()
+                .jsonPath()
+                .getList("data");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> nested(Map<String, Object> source, String key) {
+        return (Map<String, Object>) source.get(key);
+    }
+}

--- a/backend/bom-bom-server/src/test/resources/acceptance/reading/streak-ranking-duplicate-badge.json
+++ b/backend/bom-bom-server/src/test/resources/acceptance/reading/streak-ranking-duplicate-badge.json
@@ -1,0 +1,5 @@
+{
+  "badge": [
+    { "id": 8, "member_id": 3, "badge_category": "RANKING", "badge_grade": "SILVER", "period_year": 2026, "period_month": 8 }
+  ]
+}

--- a/backend/bom-bom-server/src/test/resources/acceptance/reading/streak-ranking-empty.json
+++ b/backend/bom-bom-server/src/test/resources/acceptance/reading/streak-ranking-empty.json
@@ -1,0 +1,3 @@
+{
+  "continue_reading_snapshot": []
+}

--- a/backend/bom-bom-server/src/test/resources/acceptance/reading/streak-ranking.json
+++ b/backend/bom-bom-server/src/test/resources/acceptance/reading/streak-ranking.json
@@ -1,0 +1,21 @@
+{
+  "member": [
+    { "id": 2, "provider": "provider", "provider_id": "streak-zeta", "email": "zeta@example.com", "nickname": "Zeta", "gender": "FEMALE", "role_id": 1 },
+    { "id": 3, "provider": "provider", "provider_id": "streak-alpha", "email": "alpha@example.com", "nickname": "Alpha", "gender": "FEMALE", "role_id": 1 },
+    { "id": 4, "provider": "provider", "provider_id": "streak-lower", "email": "lower@example.com", "nickname": "Lower", "gender": "FEMALE", "role_id": 1 }
+  ],
+  "continue_reading_snapshot": [
+    { "id": 2, "member_id": 2, "day_count": 10, "rank_order": 1 },
+    { "id": 3, "member_id": 3, "day_count": 10, "rank_order": 1 },
+    { "id": 4, "member_id": 4, "day_count": 1, "rank_order": 4 }
+  ],
+  "badge": [
+    { "id": 1, "member_id": 3, "badge_category": "RANKING", "badge_grade": "BRONZE", "period_year": 2026, "period_month": 7 },
+    { "id": 2, "member_id": 3, "badge_category": "RANKING", "badge_grade": "GOLD", "period_year": 2026, "period_month": 8 },
+    { "id": 3, "member_id": 3, "badge_category": "CHALLENGE", "badge_grade": "GOLD", "challenge_name": "이전 챌린지", "challenge_generation": 1, "created_at": "2026-07-01T00:00:00" },
+    { "id": 4, "member_id": 3, "badge_category": "CHALLENGE", "badge_grade": "SILVER", "challenge_name": "최근 챌린지", "challenge_generation": 2, "created_at": "2026-08-01T00:00:00" },
+    { "id": 5, "member_id": 3, "badge_category": "STREAK", "streak_day_count": 30, "created_at": "2026-07-01T00:00:00" },
+    { "id": 6, "member_id": 3, "badge_category": "STREAK", "streak_day_count": 7, "created_at": "2026-08-01T00:00:00" },
+    { "id": 7, "member_id": 4, "badge_category": "STREAK", "streak_day_count": 100, "created_at": "2026-08-01T00:00:00" }
+  ]
+}


### PR DESCRIPTION
## 📌 What

연속 읽기 랭킹 API(`/api/v1/members/me/reading/streak/rank`)에서 상위 N명을 먼저 선정한 뒤 해당 회원의 배지만 조회하도록 개선합니다.

- Jira: [BOM-1230](https://bom-bom.atlassian.net/browse/BOM-1230)

## ❓ Why

저번 랭킹 조회 문제가 스트릭 랭킹에도 동일하게 존재하고 있었습니다.

약 1초가 걸린다는 응답 지연 제보가 있었습니다. 기존 쿼리는 전체 랭킹 후보의 배지를 조인한 뒤 마지막에 `LIMIT`을 적용해, 응답에 포함되지 않는 회원의 배지까지 반복 조회합니다.

로컬 MySQL 8.4.5에서 합성 회원 2,000명·배지 1,000개, 배지 보조 인덱스 없음, `limit=20` 조건으로 비교했습니다.

| 항목 | 수정 전 | 수정 후 |
| --- | ---: | ---: |
| 배지 종류별 조회 반복 | 2,000회 | 20회 |
| EXPLAIN ANALYZE 전체 시간 | 약 1,723ms | 약 19ms |

반환 결과는 동일했습니다. 수치는 단일 로컬 실행 계획 측정이며 운영 성능 수치는 아닙니다. 운영 DB는 직접 연결 타임아웃으로 실행 계획을 확인하지 못했습니다.

## 🔧 How

- `member` 조인 및 순위·닉네임 정렬을 포함한 파생 테이블에서 상위 N명을 선정합니다.
- 해당 회원의 지난달 랭킹 배지, 최신 챌린지 배지, 최고 스트릭 배지만 조회하고 필요한 컬럼만 선택합니다.
- 월간 배지 중복 시에도 응답이 N행을 넘지 않도록 최종 `LIMIT`을 유지합니다.
- 공동 순위 정렬, limit, 배지 선택·부재, 중복 배지, 빈 랭킹, 잘못된 limit에 대한 인수 테스트 5개를 추가합니다.
- API 응답 형식과 DB 스키마 변경은 없습니다.



## 👀 Review Point (Optional)

상위 N명 선정 전후의 정렬과 배지 선택 규칙이 유지되는지 확인해 주세요. 배포 후 해당 API의 응답 시간과 실제 배지 조회 반복 횟수를 확인해야 합니다.
